### PR TITLE
🐳 Dockerfile 빌드 타임 env placeholder 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,19 @@ ARG NEXT_PUBLIC_CHAT_SERVER_API
 ENV NEXT_PUBLIC_SERVER_API=${NEXT_PUBLIC_SERVER_API} \
     NEXT_PUBLIC_CHAT_SERVER_API=${NEXT_PUBLIC_CHAT_SERVER_API}
 
+# 빌드 타임 page data 수집 시 assertValue 통과용 placeholder.
+# 실제 값은 런타임에 docker-compose env_file로 주입됨 (이미지에 시크릿 박히지 않음).
+ARG COOKIE_TOKEN_KEY=build-placeholder
+ARG NEXTAUTH_URL=http://localhost:3000
+ARG NEXTAUTH_SECRET=build-placeholder
+ARG GOOGLE_CLIENT_ID=build-placeholder
+ARG GOOGLE_CLIENT_SECRET=build-placeholder
+ENV COOKIE_TOKEN_KEY=${COOKIE_TOKEN_KEY} \
+    NEXTAUTH_URL=${NEXTAUTH_URL} \
+    NEXTAUTH_SECRET=${NEXTAUTH_SECRET} \
+    GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID} \
+    GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+
 RUN pnpm run build
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Next.js 빌드 중 page data 수집 시 `src/config/app-env.ts`의 top-level `assertValue`가 평가되며 `COOKIE_TOKEN_KEY` 등 서버 env 부재로 빌드 실패
- Dockerfile 빌드 스테이지에 ARG + ENV로 placeholder 값 설정 (assertValue null/undefined 체크만 통과)
- 런타임 스테이지는 별도 FROM이라 placeholder가 실행 환경에 섞이지 않음 — 실제 시크릿은 docker-compose env_file로 주입

## Test plan
- [ ] develop 머지 후 develop→master 릴리스 PR로 배포 액션 재검증
- [ ] `pnpm run build` 단계 통과
- [ ] 런타임에서 AppEnv가 실제 env_file 값 참조하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)