### PR TITLE
🚀 Release: Dockerfile build env placeholder 반영

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,19 @@ ARG NEXT_PUBLIC_CHAT_SERVER_API
 ENV NEXT_PUBLIC_SERVER_API=${NEXT_PUBLIC_SERVER_API} \
     NEXT_PUBLIC_CHAT_SERVER_API=${NEXT_PUBLIC_CHAT_SERVER_API}
 
+# 빌드 타임 page data 수집 시 assertValue 통과용 placeholder.
+# 실제 값은 런타임에 docker-compose env_file로 주입됨 (이미지에 시크릿 박히지 않음).
+ARG COOKIE_TOKEN_KEY=build-placeholder
+ARG NEXTAUTH_URL=http://localhost:3000
+ARG NEXTAUTH_SECRET=build-placeholder
+ARG GOOGLE_CLIENT_ID=build-placeholder
+ARG GOOGLE_CLIENT_SECRET=build-placeholder
+ENV COOKIE_TOKEN_KEY=${COOKIE_TOKEN_KEY} \
+    NEXTAUTH_URL=${NEXTAUTH_URL} \
+    NEXTAUTH_SECRET=${NEXTAUTH_SECRET} \
+    GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID} \
+    GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+
 RUN pnpm run build
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
이전 릴리스(#200) 이후 배포 액션이 `pnpm run build`에서 실패한 문제를 수정한 후속 릴리스.

- Dockerfile 빌드 스테이지에 서버 env placeholder ARG 추가 (#201)
- `assertValue` 빌드 타임 검증 통과하도록 더미값 기본 주입, 런타임은 env_file로 실제 시크릿 주입

## Test plan
- [ ] `build-and-push` job 성공 (pnpm build 통과 확인)
- [ ] `deploy` job 성공
- [ ] drunkenmovie.shop 프론트엔드 정상 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)