### PR TITLE
🐛 홈·sitemap.xml force-dynamic 전환

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -8,10 +8,15 @@ import { getCurrentUser } from '@/lib/utils/server-utils'
 import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 
+export const dynamic = 'force-dynamic'
+
 const getMovieList = async (): Promise<Movie[]> => {
-  const repo = new MovieRepository()
-  const result = await repo.getMovie()
-  return result
+  try {
+    const repo = new MovieRepository()
+    return await repo.getMovie()
+  } catch {
+    return []
+  }
 }
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -50,8 +55,8 @@ const Page: FunctionComponent<PageProps> = async ({}) => {
   const user = await getCurrentUser()
   const isAuthenticated = !!user
 
-  console.log(data)
-  if (!data) return <AppSkeleton className="container min-h-[364px] p-6" />
+  if (!data || data.length === 0)
+    return <AppSkeleton className="container min-h-[364px] p-6" />
 
   return (
     <main>

--- a/src/app/(root)/(routes)/sitemap.xml/route.ts
+++ b/src/app/(root)/(routes)/sitemap.xml/route.ts
@@ -4,18 +4,18 @@ import { MatchRepository } from '@/modules/match/match-repository'
 import { ISitemapField } from 'next-sitemap'
 import { getServerSideSitemap } from 'next-sitemap'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(): Promise<ReturnType<typeof getServerSideSitemap>> {
-  // 영화 데이터
-  const movieRepo = new MovieRepository()
-  const movies = await movieRepo.getMovie()
+  const movies = await new MovieRepository().getMovie().catch(() => [])
 
-  // 게시글 데이터 (최대 50개만, 필요시 pageSize 조정)
-  const articleRepo = new ArticleRepository()
-  const { articles } = await articleRepo.listArticles(1, 50)
+  const { articles } = await new ArticleRepository()
+    .listArticles(1, 50)
+    .catch(() => ({ articles: [], hasNext: false }))
 
-  // 매치 데이터 (최대 50개만)
-  const matchRepo = new MatchRepository()
-  const { matchPosts: matches } = await matchRepo.getMatchPosts(1, 50)
+  const { matchPosts: matches } = await new MatchRepository()
+    .getMatchPosts(1, 50)
+    .catch(() => ({ matchPosts: [], hasNext: false }))
 
   const fields: ISitemapField[] = []
 


### PR DESCRIPTION
## Summary
Next.js App Router가 `/`와 `/sitemap.xml`을 정적 페이지로 간주해 빌드 타임에 백엔드 API를 호출하다 실패하던 문제 수정.

- `export const dynamic = 'force-dynamic'`으로 빌드 타임 prerender 스킵
- 런타임 API 장애에 대비해 try/catch 폴백 추가 (home: 빈 배열 → 스켈레톤, sitemap: 해당 섹션만 빈 리스트)
- 홈 디버그 `console.log(data)` 제거

## Test plan
- [x] `pnpm run build` 로컬 통과 (`/`, `/sitemap.xml` 모두 λ로 표시)
- [ ] develop 머지 후 develop→master 릴리스 PR로 배포 액션 재검증
- [ ] 런타임에서 홈 영화 목록 정상 렌더링
- [ ] sitemap.xml 엔드포인트 정상 응답

## Notes
- 정적 최적화는 포기함 — 도메인·백엔드 네트워크 정상화 후 ISR(`revalidate`)로 복구하는 단계가 별도로 필요
- `sitemap.xml/route.ts`의 `https://drunkenmovie.shop/...` 하드코딩 URL은 도메인 재구매 시 env화 필요 (이번 PR 범위 밖)

🤖 Generated with [Claude Code](https://claude.com/claude-code)