### PR TITLE
🚀 Release: 홈·sitemap force-dynamic 반영

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -8,10 +8,15 @@ import { getCurrentUser } from '@/lib/utils/server-utils'
 import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 
+export const dynamic = 'force-dynamic'
+
 const getMovieList = async (): Promise<Movie[]> => {
-  const repo = new MovieRepository()
-  const result = await repo.getMovie()
-  return result
+  try {
+    const repo = new MovieRepository()
+    return await repo.getMovie()
+  } catch {
+    return []
+  }
 }
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -50,8 +55,8 @@ const Page: FunctionComponent<PageProps> = async ({}) => {
   const user = await getCurrentUser()
   const isAuthenticated = !!user
 
-  console.log(data)
-  if (!data) return <AppSkeleton className="container min-h-[364px] p-6" />
+  if (!data || data.length === 0)
+    return <AppSkeleton className="container min-h-[364px] p-6" />
 
   return (
     <main>

--- a/src/app/(root)/(routes)/sitemap.xml/route.ts
+++ b/src/app/(root)/(routes)/sitemap.xml/route.ts
@@ -4,18 +4,18 @@ import { MatchRepository } from '@/modules/match/match-repository'
 import { ISitemapField } from 'next-sitemap'
 import { getServerSideSitemap } from 'next-sitemap'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(): Promise<ReturnType<typeof getServerSideSitemap>> {
-  // 영화 데이터
-  const movieRepo = new MovieRepository()
-  const movies = await movieRepo.getMovie()
+  const movies = await new MovieRepository().getMovie().catch(() => [])
 
-  // 게시글 데이터 (최대 50개만, 필요시 pageSize 조정)
-  const articleRepo = new ArticleRepository()
-  const { articles } = await articleRepo.listArticles(1, 50)
+  const { articles } = await new ArticleRepository()
+    .listArticles(1, 50)
+    .catch(() => ({ articles: [], hasNext: false }))
 
-  // 매치 데이터 (최대 50개만)
-  const matchRepo = new MatchRepository()
-  const { matchPosts: matches } = await matchRepo.getMatchPosts(1, 50)
+  const { matchPosts: matches } = await new MatchRepository()
+    .getMatchPosts(1, 50)
+    .catch(() => ({ matchPosts: [], hasNext: false }))
 
   const fields: ISitemapField[] = []
 


### PR DESCRIPTION
## Summary
이전 릴리스(#202) 이후 `pnpm run build` 중 정적 prerender 단계에서 백엔드 API 호출로 실패하던 문제 해결 릴리스.

- `/`와 `/sitemap.xml`에 `export const dynamic = 'force-dynamic'` 추가 (#203)
- 런타임 API 장애 대비 try/catch 폴백 추가

## Test plan
- [ ] `build-and-push` job 성공 (pnpm build 통과)
- [ ] `deploy` job 성공
- [ ] 배포된 프론트 정상 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)