### PR TITLE
♻️ docker-compose 서비스별 분리 (frontend 전용)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,11 +75,11 @@ jobs:
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
             echo "▶ 최신 이미지 Pull"
-            cd /app/movie
-            docker compose -f docker-compose.yml pull frontend
+            cd /app/movie/movie-review-front
+            docker compose pull frontend
 
             echo "▶ 프론트엔드 재시작"
-            docker compose -f docker-compose.yml up -d frontend
+            docker compose up -d frontend
 
             echo "▶ 미사용 이미지 정리"
             docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ next-env.d.ts
 
 # env
 .env
+.env.production
+.env.development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  frontend:
+    image: ghcr.io/sihun0105/movie-review-front:latest
+    container_name: frontend
+    env_file:
+      - ./.env.production
+    environment:
+      - NODE_ENV=production
+    networks:
+      - app-network
+    restart: unless-stopped
+
+networks:
+  app-network:
+    name: app-network
+    external: true


### PR DESCRIPTION
## Summary
모놀리식한 `/app/movie/docker-compose.yml` 대신 서비스가 자기 폴더에 compose를 소유하는 구조로 전환.

- `docker-compose.yml` 신규 (frontend 전용)
- `.github/workflows/deploy.yml`: `cd /app/movie/movie-review-front` 로 경로 변경
- `.gitignore`: 런타임 env 파일(`.env.production`, `.env.development`) 추가

## 서버 측 요구사항
PR 머지 전/후로 서버에서 아래 준비 필요:
- `/app/movie/movie-review-front/docker-compose.yml` 배치 (이 PR의 compose를 scp 또는 git pull)
- `/app/movie/movie-review-front/.env.production` 생성 (실제 시크릿)
- `app-network` Docker 네트워크가 사전 생성돼 있어야 함 (루트 compose 또는 `docker network create app-network`)

## Test plan
- [ ] 머지 후 develop→master 릴리스 PR 생성
- [ ] 배포 액션 통과 (Deploy SSH 단계까지)
- [ ] 서버에서 `docker compose ps` 로 frontend 컨테이너 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)