### PR TITLE
♻️ datasource·repository 의 타입 선언을 entity 로 이관

### DIFF
--- a/src/modules/chat/chat-datasource.ts
+++ b/src/modules/chat/chat-datasource.ts
@@ -4,37 +4,12 @@ import type {
   ChatRoomEntity,
   ChatRoomsResponseEntity,
   MessagesResponseEntity,
+  CreateChatRoomRequest,
+  GetChatRoomParams,
+  GetChatRoomsParams,
+  GetMessagesParams,
+  SendMessageRequest,
 } from './chat.entity'
-
-export interface CreateChatRoomRequest {
-  memberIds: number[]
-  roomName: string
-  type: 'direct' | 'group'
-}
-
-export interface GetChatRoomParams {
-  chatRoomId: string
-  userId: number
-}
-
-export interface GetChatRoomsParams {
-  userId: number
-  page?: number
-  pageSize?: number
-}
-
-export interface GetMessagesParams {
-  chatRoomId: string
-  userId: number
-  page?: number
-  pageSize?: number
-}
-
-export interface SendMessageRequest {
-  chatRoomId: string
-  senderId: number
-  content: string
-}
 
 export class ChatDatasource {
   private token?: string

--- a/src/modules/chat/chat-repository.ts
+++ b/src/modules/chat/chat-repository.ts
@@ -1,16 +1,14 @@
-import {
-  ChatDatasource,
-  CreateChatRoomRequest,
-  GetChatRoomParams,
-  GetChatRoomsParams,
-  GetMessagesParams,
-  SendMessageRequest,
-} from './chat-datasource'
+import { ChatDatasource } from './chat-datasource'
 import {
   ChatRoomEntity,
   ChatRoomsResponseEntity,
   MessagesResponseEntity,
   ChatMessageEntity,
+  CreateChatRoomRequest,
+  GetChatRoomParams,
+  GetChatRoomsParams,
+  GetMessagesParams,
+  SendMessageRequest,
   assertChatRoomEntity,
   assertChatMessageEntity,
 } from './chat.entity'

--- a/src/modules/chat/chat.entity.ts
+++ b/src/modules/chat/chat.entity.ts
@@ -77,3 +77,34 @@ export function assertChatMessageEntity(
     throw new Error('Invalid ChatMessageEntity')
   }
 }
+
+// 요청·파라미터 타입
+export interface CreateChatRoomRequest {
+  memberIds: number[]
+  roomName: string
+  type: 'direct' | 'group'
+}
+
+export interface GetChatRoomParams {
+  chatRoomId: string
+  userId: number
+}
+
+export interface GetChatRoomsParams {
+  userId: number
+  page?: number
+  pageSize?: number
+}
+
+export interface GetMessagesParams {
+  chatRoomId: string
+  userId: number
+  page?: number
+  pageSize?: number
+}
+
+export interface SendMessageRequest {
+  chatRoomId: string
+  senderId: number
+  content: string
+}

--- a/src/modules/chat/index.ts
+++ b/src/modules/chat/index.ts
@@ -1,10 +1,3 @@
 export * from './chat.entity'
 export { ChatDatasource } from './chat-datasource'
-export type {
-  CreateChatRoomRequest,
-  GetChatRoomParams,
-  GetChatRoomsParams,
-  GetMessagesParams,
-  SendMessageRequest,
-} from './chat-datasource'
 export { ChatRepository } from './chat-repository'

--- a/src/modules/movie/movie-repository.ts
+++ b/src/modules/movie/movie-repository.ts
@@ -1,6 +1,7 @@
 import { MovieDatasource } from './movie-datasource'
 import {
   AverageMovieScore,
+  CGVTheaterList,
   Movie,
   Score,
   assertAverageMovieScore,
@@ -8,21 +9,6 @@ import {
   assertScore,
 } from './movie.entity'
 
-export interface CGVTheaterList {
-  theaters: CGVTheater[]
-}
-export interface CGVTheater {
-  id: number
-  name: string
-  region: string
-  address: string
-  phone: string
-  website: string
-  latitude: number
-  longitude: number
-  createdAt: string
-  updatedAt: string
-}
 export class MovieRepository {
   private datasource: MovieDatasource
   constructor(

--- a/src/modules/movie/movie.entity.ts
+++ b/src/modules/movie/movie.entity.ts
@@ -91,3 +91,20 @@ export function assertAverageMovieScore(
     throw new Error('Invalid AverageMovieScore')
   }
 }
+
+export interface CGVTheater {
+  id: number
+  name: string
+  region: string
+  address: string
+  phone: string
+  website: string
+  latitude: number
+  longitude: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CGVTheaterList {
+  theaters: CGVTheater[]
+}


### PR DESCRIPTION
## Summary
- `chat-datasource` 의 Request/Params 타입 5개를 `chat.entity` 로 이동
- `movie-repository` 의 `CGVTheater`·`CGVTheaterList` 인터페이스를 `movie.entity` 로 이동

## 원인
`.claude/rules/frontend-module-pattern.md` 의 **"datasource 에서 Request/Params 타입 export 금지 (entity 가 단일 출처)"** 및 **"repository 파일 안에 타입 선언 금지"** 규칙 위반이 두 모듈에서 확인됨. 타입 출처를 entity 로 일원화.

## 변경
- `chat.entity.ts` 끝에 요청·파라미터 타입 5개 추가
- `chat-datasource.ts` 는 해당 타입을 `./chat.entity` 에서 import 만
- `chat-repository.ts` 의 import 경로 `./chat-datasource` → `./chat.entity`
- `chat/index.ts`: 타입 re-export 는 `export * from './chat.entity'` 로 커버되므로 개별 명시 제거
- `movie.entity.ts` 에 `CGVTheater`·`CGVTheaterList` 추가
- `movie-repository.ts` 는 entity 에서 import

## 부수 효과 (200줄 룰)
- `chat/chat-datasource.ts`: 201 → 176 (스멜 해소)
- `movie/movie-repository.ts`: 157 → 143
- `chat/chat-repository.ts`: 217 → 215 (본 PR 대상 아님 — 후속 분할 PR 예정)
- `match/match-datasource.ts` 292, `match/match-repository.ts` 224 (후속 PR)

## Test plan
- [x] \`pnpm exec tsc --noEmit\` 통과
- [ ] 머지 후 develop → master 릴리스 PR 에 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)