### PR TITLE
🔥 모듈 레이어의 debug log·노이즈 제거

### DIFF
--- a/src/modules/article/article-repository.ts
+++ b/src/modules/article/article-repository.ts
@@ -1,7 +1,6 @@
 import { Article, LikeState, Reply } from '@/lib/type'
 import { ArticleDatasource } from './article-datasource'
 import { assertArticle, assertArticleComment } from './article.entity'
-import console from 'console'
 
 export class ArticleRepository {
   private datasource: ArticleDatasource
@@ -17,11 +16,8 @@ export class ArticleRepository {
     page = 1,
     pageSize = 10,
   ): Promise<{ articles: Article[]; hasNext: boolean }> {
-    console.log('listArticles called with page:', page, 'pageSize:', pageSize)
-
     const data = await this.datasource.listArticles(page, pageSize)
     if (!data.articles) {
-      console.log('data.articles is undefined')
       return { articles: [], hasNext: false }
     }
 
@@ -108,7 +104,6 @@ export class ArticleRepository {
     dislikes: number
   }> {
     const data = await this.datasource.updateArticleLike(id, state)
-    console.log('updateArticleLike data:', data)
     return {
       likes: data.likes,
       dislikes: data.dislikes,
@@ -149,10 +144,7 @@ export class ArticleRepository {
     return data
   }
   async modifyComment(id: string, comment: string): Promise<Reply> {
-    console.log('modifyComment called with id:', id, 'comment:', comment)
-    console.log('modifyComment id:', id, 'comment:', comment)
     const data = await this.datasource.modifyComment(id, comment)
-    console.log('modifyComment data:', data)
     return data
   }
 }

--- a/src/modules/auth/auth-repository.ts
+++ b/src/modules/auth/auth-repository.ts
@@ -14,7 +14,6 @@ export class AuthRepository {
   }
 
   async validateEmail(email: string): Promise<ValidationResponse> {
-    console.log('Validating email:', email)
     if (!email || !email.includes('@')) {
       return {
         isAvailable: false,
@@ -22,9 +21,7 @@ export class AuthRepository {
       }
     }
 
-    const result = await this.dataSource.validateEmail(email)
-    console.log('Email validation result:', result)
-    return result
+    return await this.dataSource.validateEmail(email)
   }
 
   async validateNickname(nickname: string): Promise<ValidationResponse> {
@@ -46,8 +43,6 @@ export class AuthRepository {
   }
 
   async register(data: RegisterRequest): Promise<AuthResponse> {
-    // 클라이언트 사이드 validation
-    console.log('Registering user:', data)
     if (!data.userId || !data.password || !data.nickname) {
       return {
         success: false,

--- a/src/modules/chat/chat-repository.ts
+++ b/src/modules/chat/chat-repository.ts
@@ -87,7 +87,6 @@ export class ChatRepository {
   ): Promise<ChatRoomsResponseEntity> {
     try {
       const result = await this.datasource.getChatRooms(params)
-      console.log('Chat rooms result:', result)
 
       // 각 채팅방 API 응답을 엔티티로 변환하고 검증
       const convertedChatRooms = result.chatRooms.map((room) => {
@@ -113,7 +112,6 @@ export class ChatRepository {
   ): Promise<MessagesResponseEntity> {
     try {
       const result = await this.datasource.getMessages(params)
-      console.log('Messages result:', result)
 
       // 메시지가 없는 경우 빈 배열로 초기화
       if (!result.messages || !Array.isArray(result.messages)) {
@@ -157,7 +155,6 @@ export class ChatRepository {
       const chatRoomsResponse = await this.getChatRooms({
         userId: currentUserId,
       })
-      console.log('Chat rooms response:', chatRoomsResponse)
       // direct 타입 채팅방 중에서 상대방과의 채팅방이 있는지 확인
       const existingRoom = chatRoomsResponse.chatRooms.find(
         (room) =>
@@ -205,7 +202,6 @@ export class ChatRepository {
   async sendMessage(request: SendMessageRequest): Promise<any> {
     try {
       const result = await this.datasource.sendMessage(request)
-      console.log('Send message result:', result)
       return result
     } catch (error) {
       console.error(`메시지 전송 실패 (채팅방: ${request.chatRoomId}):`, error)

--- a/src/modules/comment/comment-repository.ts
+++ b/src/modules/comment/comment-repository.ts
@@ -18,7 +18,6 @@ export class CommentRepository {
     const data = await this.datasource.getCommentList(id, page ?? 0)
 
     if (!data.replies) {
-      console.log('data.replies is undefined')
       return { comments: [], hasNext: false }
     }
     const comments = data.replies.map((item: any) =>

--- a/src/modules/comment/comment.entity.ts
+++ b/src/modules/comment/comment.entity.ts
@@ -14,7 +14,6 @@ export function isComment(arg: any): arg is Reply {
 }
 
 export function assertComment(arg: any): asserts arg is Reply {
-  console.log('assertComment arg:', arg)
   if (!isComment(arg)) {
     throw new Error('Invalid Comment')
   }

--- a/src/modules/match/match-datasource.ts
+++ b/src/modules/match/match-datasource.ts
@@ -39,9 +39,7 @@ export class MatchDataSource {
         throw new Error('Failed to fetch match posts')
       }
 
-      const data = await response.json()
-      console.log('Match posts data:', data)
-      return data
+      return await response.json()
     } catch (error) {
       console.error('Match posts fetch error:', error)
       throw new Error('매치 게시글을 불러오는데 실패했습니다.')
@@ -73,7 +71,6 @@ export class MatchDataSource {
 
   // 매치 게시글 작성
   async createMatchPost(data: CreateMatchPostRequest): Promise<MatchPost> {
-    console.log('Creating match post with data:', data)
     try {
       const response = await fetch(AppBackEndApiEndpoint.createMatchPost(), {
         method: 'POST',
@@ -175,9 +172,7 @@ export class MatchDataSource {
         throw new Error('Failed to fetch match applications')
       }
 
-      const data = await response.json()
-      console.log('Match applications data:', data)
-      return data
+      return await response.json()
     } catch (error) {
       console.error('Match applications fetch error:', error)
       throw new Error('매치 신청 목록을 불러오는데 실패했습니다.')

--- a/src/modules/match/match-repository.ts
+++ b/src/modules/match/match-repository.ts
@@ -38,14 +38,11 @@ export class MatchRepository {
       throw new Error('매치 ID가 필요합니다.')
     }
 
-    const result = await this.dataSource.getMatchPost(matchId)
-    console.log('Fetched match post:', result)
-    return result
+    return await this.dataSource.getMatchPost(matchId)
   }
 
   // 매치 게시글 작성
   async createMatchPost(data: CreateMatchPostRequest): Promise<MatchPost> {
-    console.log('Creating match post with data:', data)
     // 클라이언트 사이드 validation
     if (!data.title || data.title.trim() === '') {
       throw new Error('제목을 입력해주세요.')

--- a/src/modules/users/users-repository.ts
+++ b/src/modules/users/users-repository.ts
@@ -9,17 +9,12 @@ export class UsersRepository {
   ) {
     this.datasource = datasource ?? new UsersDatasource(token)
   }
+
   async login({ userId, password }: { userId: string; password: string }) {
-    try {
-      const result = await this.datasource.login({
-        userId: userId,
-        password: password,
-      })
-      return this.convertToUserEntity(result)
-    } catch (err) {
-      throw new Error('UsersRepository-signIn 에러')
-    }
+    const result = await this.datasource.login({ userId, password })
+    return this.convertToUserEntity(result)
   }
+
   async signUp({
     userId,
     password,
@@ -31,41 +26,20 @@ export class UsersRepository {
     nickname: string
     gender: string
   }) {
-    try {
-      const result = await this.datasource.signUp({
-        userId: userId,
-        password: password,
-        nickname: nickname,
-        gender: gender,
-      })
-      return result
-    } catch (err) {
-      throw new Error('UsersRepository-signUp 에러')
-    }
+    return await this.datasource.signUp({ userId, password, nickname, gender })
   }
 
   async signInWithProvider(params: { id: string }) {
-    try {
-      const result = await this.datasource.signInWithProvider({
-        id: params.id,
-      })
-      return this.convertToUserEntity(result)
-    } catch (error) {
-      console.log(error)
-      throw new Error('UsersRepository-signInWithProvider 에러')
-    }
+    const result = await this.datasource.signInWithProvider({ id: params.id })
+    return this.convertToUserEntity(result)
   }
+
   async signUpWithProvider(params: {
     email: string
     platform: string
     nickname: string
   }) {
-    try {
-      const result = await this.datasource.signUpWithProvider(params)
-      return result
-    } catch (error) {
-      throw new Error('UsersRepository-signUpWithProvider 에러')
-    }
+    return await this.datasource.signUpWithProvider(params)
   }
 
   convertToUserEntity(arg: any) {
@@ -81,24 +55,12 @@ export class UsersRepository {
     assertUserEntity(result)
     return result
   }
+
   async updateProfile({ nickname }: { nickname: string }) {
-    try {
-      const result = await this.datasource.updateProfile({
-        nickname: nickname,
-      })
-      return result
-    } catch (error) {
-      throw new Error('UsersRepository-updateProfile 에러')
-    }
+    return await this.datasource.updateProfile({ nickname })
   }
+
   async updateImage({ file }: { file: File }) {
-    try {
-      const result = await this.datasource.updateImage({
-        file: file,
-      })
-      return result
-    } catch (error) {
-      throw new Error('UsersRepository-updateProfile 에러')
-    }
+    return await this.datasource.updateImage({ file })
   }
 }

--- a/src/modules/users/users.entity.ts
+++ b/src/modules/users/users.entity.ts
@@ -13,7 +13,6 @@ export function isUserEntity(arg: any): arg is UserEntity {
 }
 
 export function assertUserEntity(arg: any): asserts arg is UserEntity {
-  console.log(arg)
   if (!isUserEntity(arg)) {
     throw new Error('Invalid user')
   }


### PR DESCRIPTION
## Summary
- entity·repository·datasource 에 흩어진 debug `console.log` 일괄 제거
- `import console from 'console'` (Node 전용) 제거
- 원인 정보를 버리던 try/catch 래퍼 제거 (users-repository)

## 원인
`.claude/rules/frontend-module-pattern.md` 의 다음 규칙들 위반 정리:
- "entity 의 assertXxx / isXxx 함수 안에 console.log" 금지
- "import console from 'console'" 금지 (Node 전용, 브라우저 번들 위험)
- "try { ... } catch (e) { throw new Error('generic') }" 금지 (cause 소실)

## 변경
- `article-repository.ts`: `import console`, listArticles·updateArticleLike·modifyComment 의 디버그 log 6개 제거
- `auth-repository.ts`: validateEmail·register 의 디버그 log 3개 제거
- `chat-repository.ts`: getChatRooms·getMessages·findOrCreateDirectChatRoom·sendMessage 의 디버그 log 4개 제거
- `comment-repository.ts`, `comment.entity.ts`: assertComment 내부 log + 'data.replies is undefined' log 제거
- `match-datasource.ts`, `match-repository.ts`: getMatchPosts·createMatchPost·getMatchApplications·getMatchPost 의 디버그 log 5개 제거
- `users-repository.ts`: 모든 메서드의 try/catch 래퍼 제거 (cause 보존), signInWithProvider 의 `console.log(error)` 제거
- `users.entity.ts`: assertUserEntity 내부 `console.log(arg)` 제거

`console.error` 는 datasource catch 블록의 실제 에러 로깅이라 보존.

## 부수 효과 (200줄 룰)
- `chat/chat-repository.ts`: 215 → 211 (여전히 초과 — 다음 PR 에서 분할)
- `match/match-datasource.ts`: 292 → 287 (여전히 초과)
- `match/match-repository.ts`: 224 → 221 (여전히 초과)

## Test plan
- [x] \`pnpm exec tsc --noEmit\` 통과
- [ ] 머지 후 develop → master 릴리스 PR 에 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)