### PR TITLE
✨ Cinéma Noir 디자인 토큰 도입 (Phase 1)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,9 +8,11 @@ import { MessageModalContextProvider } from '@/hooks/use-message-modal-context'
 import { cn } from '@/lib/utils'
 import { SessionProvider } from '@/providers/session-provider'
 import '@/styles/globals.css'
-import type { Metadata } from 'next'
-import { Roboto } from 'next/font/google'
+import { Bebas_Neue, IBM_Plex_Mono, Playfair_Display, Roboto } from 'next/font/google'
 import Script from 'next/script'
+import { siteMetadata, siteJsonLd } from './site-metadata'
+
+export const metadata = siteMetadata
 
 const roboto = Roboto({
   weight: ['400', '700'],
@@ -19,96 +21,33 @@ const roboto = Roboto({
   display: 'swap',
 })
 
-export const metadata: Metadata = {
-  metadataBase: new URL('https://drunkenmovie.shop'),
-  title: '영화 뭐함 - 영화뭐함 | 최신 영화 리뷰와 추천',
-  description:
-    '영화 뭐함? 영화뭐함에서 최신 영화 리뷰, 평점, 추천을 확인하세요! 어떤 영화를 볼지 고민될 때 영화 뭐함 사이트에서 완벽한 답을 찾으세요.',
-  keywords: [
-    '영화 뭐함',
-    '영화뭐함',
-    '영화 추천',
-    '영화 리뷰',
-    '영화 평점',
-    '최신 영화',
-    '영화 순위',
-    '영화 정보',
-    '영화 커뮤니티',
-    '영화 고민',
-    '무슨 영화',
-    '어떤 영화',
-    '영화 선택',
-    '영화 찾기',
-    '볼만한 영화',
-    'DrunkenMovie',
-    'drunkenmovie',
-  ],
-  authors: [{ name: '영화뭐함 - DrunkenMovie' }],
-  openGraph: {
-    type: 'website',
-    locale: 'ko_KR',
-    url: 'https://drunkenmovie.shop',
-    siteName: '영화 뭐함 - 영화뭐함',
-    title: '영화 뭐함? 영화뭐함에서 찾는 완벽한 영화 추천',
-    description:
-      '영화 뭐함? 영화뭐함에서 최신 영화 리뷰, 평점, 추천을 확인하세요! 어떤 영화를 볼지 고민될 때 완벽한 답을 찾으세요.',
-    images: [
-      {
-        url: '/images/og-image.png',
-        width: 1200,
-        height: 630,
-        alt: '영화 뭐함 - 영화뭐함 OG 이미지',
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: '영화 뭐함? 영화뭐함에서 찾는 완벽한 영화 추천',
-    description:
-      '영화 뭐함? 영화뭐함에서 최신 영화 리뷰, 평점, 추천을 확인하세요!',
-    images: ['/images/og-image.png'],
-  },
-  viewport: {
-    width: 'device-width',
-    initialScale: 1,
-    maximumScale: 1,
-  },
-  alternates: {
-    canonical: 'https://drunkenmovie.shop',
-  },
-}
+const dmDisplay = Playfair_Display({
+  weight: ['400', '700'],
+  style: ['normal', 'italic'],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--dm-font-display',
+})
+
+const dmMono = IBM_Plex_Mono({
+  weight: ['400', '500'],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--dm-font-mono',
+})
+
+const dmRank = Bebas_Neue({
+  weight: ['400'],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--dm-font-rank',
+})
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    name: '영화 뭐함 - 영화뭐함',
-    alternateName: ['영화뭐함', '영화 뭐함', 'DrunkenMovie'],
-    url: 'https://drunkenmovie.shop',
-    description:
-      '영화 뭐함? 영화뭐함에서 최신 영화 리뷰, 평점, 추천을 확인하세요!',
-    potentialAction: {
-      '@type': 'SearchAction',
-      target: {
-        '@type': 'EntryPoint',
-        urlTemplate: 'https://drunkenmovie.shop/search?q={search_term_string}',
-      },
-      'query-input': 'required name=search_term_string',
-    },
-    mainEntity: {
-      '@type': 'Organization',
-      name: '영화뭐함',
-      sameAs: ['https://drunkenmovie.shop'],
-      logo: {
-        '@type': 'ImageObject',
-        url: 'https://drunkenmovie.shop/images/og-image.png',
-      },
-    },
-  }
   return (
     <html lang="ko">
       <head>
@@ -132,7 +71,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(siteJsonLd) }}
         />
         <link rel="icon" href="/favicon/favicon.ico" />
         <link
@@ -182,6 +121,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         className={cn(
           'flex min-h-screen flex-col items-center',
           roboto.className,
+          dmDisplay.variable,
+          dmMono.variable,
+          dmRank.variable,
         )}
       >
         {/* Google Tag Manager (noscript) */}

--- a/src/app/site-metadata.ts
+++ b/src/app/site-metadata.ts
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next'
+
+export const siteMetadata: Metadata = {
+  metadataBase: new URL('https://drunkenmovie.shop'),
+  title: '영화 뭐함 - 영화뭐함 | 최신 영화 리뷰와 추천',
+  description:
+    '영화 뭐함? 영화뭐함에서 최신 영화 리뷰, 평점, 추천을 확인하세요! 어떤 영화를 볼지 고민될 때 영화 뭐함 사이트에서 완벽한 답을 찾으세요.',
+  keywords: [
+    '영화 뭐함',
+    '영화뭐함',
+    '영화 추천',
+    '영화 리뷰',
+    '영화 평점',
+    '최신 영화',
+    '영화 순위',
+    '영화 정보',
+    '영화 커뮤니티',
+    '영화 고민',
+    '무슨 영화',
+    '어떤 영화',
+    '영화 선택',
+    '영화 찾기',
+    '볼만한 영화',
+    'DrunkenMovie',
+    'drunkenmovie',
+  ],
+  authors: [{ name: '영화뭐함 - DrunkenMovie' }],
+  openGraph: {
+    type: 'website',
+    locale: 'ko_KR',
+    url: 'https://drunkenmovie.shop',
+    siteName: '영화 뭐함 - 영화뭐함',
+    title: '영화 뭐함? 영화뭐함에서 찾는 완벽한 영화 추천',
+    description:
+      '영화 뭐함? 영화뭐함에서 최신 영화 리뷰, 평점, 추천을 확인하세요! 어떤 영화를 볼지 고민될 때 완벽한 답을 찾으세요.',
+    images: [
+      {
+        url: '/images/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: '영화 뭐함 - 영화뭐함 OG 이미지',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '영화 뭐함? 영화뭐함에서 찾는 완벽한 영화 추천',
+    description:
+      '영화 뭐함? 영화뭐함에서 최신 영화 리뷰, 평점, 추천을 확인하세요!',
+    images: ['/images/og-image.png'],
+  },
+  viewport: {
+    width: 'device-width',
+    initialScale: 1,
+    maximumScale: 1,
+  },
+  alternates: {
+    canonical: 'https://drunkenmovie.shop',
+  },
+}
+
+export const siteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: '영화 뭐함 - 영화뭐함',
+  alternateName: ['영화뭐함', '영화 뭐함', 'DrunkenMovie'],
+  url: 'https://drunkenmovie.shop',
+  description:
+    '영화 뭐함? 영화뭐함에서 최신 영화 리뷰, 평점, 추천을 확인하세요!',
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: 'https://drunkenmovie.shop/search?q={search_term_string}',
+    },
+    'query-input': 'required name=search_term_string',
+  },
+  mainEntity: {
+    '@type': 'Organization',
+    name: '영화뭐함',
+    sameAs: ['https://drunkenmovie.shop'],
+    logo: {
+      '@type': 'ImageObject',
+      url: 'https://drunkenmovie.shop/images/og-image.png',
+    },
+  },
+}

--- a/src/styles/dm/tokens.css
+++ b/src/styles/dm/tokens.css
@@ -1,0 +1,34 @@
+/*
+ * Cinéma Noir 디자인 토큰
+ * Phase 1 — 신규 dm.* 네임스페이스, 기존 토큰과 분리.
+ * 사용 방법: Tailwind className `text-dm-text`, `bg-dm-red`, `font-dm-display` 등.
+ */
+
+@layer base {
+  :root {
+    /* surfaces */
+    --dm-bg: #0a0a0c;
+    --dm-bg-deep: #050506;
+    --dm-surface: #15151a;
+    --dm-surface-2: #1e1e24;
+    --dm-line: #2a2a30;
+    --dm-line-2: #3a3a42;
+
+    /* text */
+    --dm-text: #f2ece1;
+    --dm-text-muted: #9a948a;
+    --dm-text-faint: #5c5853;
+
+    /* accents */
+    --dm-red: #c0302a;
+    --dm-red-deep: #8f1f1a;
+    --dm-amber: #d99520;
+    --dm-amber-light: #ecb85a;
+
+    /* poster default oklch palette (per-movie override 가능) */
+    --dm-poster-h: 18;
+    --dm-poster-c: 0.11;
+    --dm-poster-l-top: 0.32;
+    --dm-poster-l-bot: 0.09;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,6 @@
+@import './themes/dark.css';
+@import './dm/tokens.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -93,99 +96,6 @@
     --chart-5: 27 87% 67%;
   }
 
-  [data-theme='dark'] {
-    --background: 0 0% 10%;
-    --foreground: 222.2 84% 96.1%;
-
-    --muted: 210 40% 4.9%;
-    --muted-foreground: 215.4 16.3% 86.9%;
-
-    --popover: 0 0% 10%;
-    --popover-foreground: 222.2 84% 96.1%;
-
-    --card: 0 0% 10%;
-    --card-foreground: 222.2 84% 96.1%;
-
-    --border: 214.3 31.8% 8.6%;
-    --input: var(--gray-006);
-
-    --primary: var(--blue-002);
-    --primary-foreground: 0 0% 98%;
-
-    --secondary: 210 40% 4.9%;
-    --secondary-foreground: 222.2 47.4% 96.1%;
-
-    --accent: 210 40% 4.9%;
-    --accent-foreground: 222.2 47.4% 96.1%;
-
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 4.9%;
-
-    --ring: 215 20.2% 34.9%;
-
-    --gray-001: #000000;
-    --gray-002: #0a0a0a;
-    --gray-003: #141414;
-    --gray-004: #1e1e1e;
-    --gray-005: #282828;
-    --gray-006: #333333;
-    --gray-007: #4d4d4d;
-    --gray-010: #ffffff;
-
-    /* Button variants - Dark mode */
-    --button-primary: var(--blue-002);
-    --button-primary-hover: var(--blue-001);
-    --button-primary-text: #ffffff;
-    --button-outline-border: #374151;
-    --button-outline-border-hover: #6b7280;
-    --button-outline-bg: transparent;
-    --button-outline-bg-hover: #1f2937;
-    --button-outline-text: #d1d5db;
-    --button-link: var(--blue-001);
-    --button-link-hover: var(--blue-002);
-    --button-disabled: #4b5563;
-    --button-disabled-text: #9ca3af;
-  }
-  .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: var(--blue-002);
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-
-    /* Button variants - Dark mode (.dark class) */
-    --button-primary: var(--blue-002);
-    --button-primary-hover: var(--blue-001);
-    --button-primary-text: #ffffff;
-    --button-outline-border: #374151;
-    --button-outline-border-hover: #6b7280;
-    --button-outline-bg: transparent;
-    --button-outline-bg-hover: #1f2937;
-    --button-outline-text: #d1d5db;
-    --button-link: var(--blue-001);
-    --button-link-hover: var(--blue-002);
-    --button-disabled: #4b5563;
-    --button-disabled-text: #9ca3af;
-  }
 }
 
 @layer base {

--- a/src/styles/themes/dark.css
+++ b/src/styles/themes/dark.css
@@ -1,0 +1,101 @@
+/*
+ * 다크 테마 토큰 — `[data-theme='dark']` (AppThemeProvider 토글) + `.dark` (next-themes 호환).
+ * 라이트 토큰은 globals.css 의 `:root` 블록.
+ */
+
+@layer base {
+  [data-theme='dark'] {
+    --background: 0 0% 10%;
+    --foreground: 222.2 84% 96.1%;
+
+    --muted: 210 40% 4.9%;
+    --muted-foreground: 215.4 16.3% 86.9%;
+
+    --popover: 0 0% 10%;
+    --popover-foreground: 222.2 84% 96.1%;
+
+    --card: 0 0% 10%;
+    --card-foreground: 222.2 84% 96.1%;
+
+    --border: 214.3 31.8% 8.6%;
+    --input: var(--gray-006);
+
+    --primary: var(--blue-002);
+    --primary-foreground: 0 0% 98%;
+
+    --secondary: 210 40% 4.9%;
+    --secondary-foreground: 222.2 47.4% 96.1%;
+
+    --accent: 210 40% 4.9%;
+    --accent-foreground: 222.2 47.4% 96.1%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 4.9%;
+
+    --ring: 215 20.2% 34.9%;
+
+    --gray-001: #000000;
+    --gray-002: #0a0a0a;
+    --gray-003: #141414;
+    --gray-004: #1e1e1e;
+    --gray-005: #282828;
+    --gray-006: #333333;
+    --gray-007: #4d4d4d;
+    --gray-010: #ffffff;
+
+    /* Button variants - Dark mode */
+    --button-primary: var(--blue-002);
+    --button-primary-hover: var(--blue-001);
+    --button-primary-text: #ffffff;
+    --button-outline-border: #374151;
+    --button-outline-border-hover: #6b7280;
+    --button-outline-bg: transparent;
+    --button-outline-bg-hover: #1f2937;
+    --button-outline-text: #d1d5db;
+    --button-link: var(--blue-001);
+    --button-link-hover: var(--blue-002);
+    --button-disabled: #4b5563;
+    --button-disabled-text: #9ca3af;
+  }
+
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: var(--blue-002);
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
+
+    /* Button variants - Dark mode (.dark class) */
+    --button-primary: var(--blue-002);
+    --button-primary-hover: var(--blue-001);
+    --button-primary-text: #ffffff;
+    --button-outline-border: #374151;
+    --button-outline-border-hover: #6b7280;
+    --button-outline-bg: transparent;
+    --button-outline-bg-hover: #1f2937;
+    --button-outline-text: #d1d5db;
+    --button-link: var(--blue-001);
+    --button-link-hover: var(--blue-002);
+    --button-disabled: #4b5563;
+    --button-disabled-text: #9ca3af;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,8 +23,26 @@ module.exports = {
       },
       fontFamily: {
         sans: ['var(--app-font)', 'sans-serif'],
+        'dm-display': ['var(--dm-font-display)', 'serif'],
+        'dm-mono': ['var(--dm-font-mono)', 'monospace'],
+        'dm-rank': ['var(--dm-font-rank)', 'sans-serif'],
       },
       colors: {
+        dm: {
+          bg: 'var(--dm-bg)',
+          'bg-deep': 'var(--dm-bg-deep)',
+          surface: 'var(--dm-surface)',
+          'surface-2': 'var(--dm-surface-2)',
+          line: 'var(--dm-line)',
+          'line-2': 'var(--dm-line-2)',
+          text: 'var(--dm-text)',
+          'text-muted': 'var(--dm-text-muted)',
+          'text-faint': 'var(--dm-text-faint)',
+          red: 'var(--dm-red)',
+          'red-deep': 'var(--dm-red-deep)',
+          amber: 'var(--dm-amber)',
+          'amber-light': 'var(--dm-amber-light)',
+        },
         'app-purple': {
           '001': 'var(--purple-001)',
           '002': 'var(--purple-002)',


### PR DESCRIPTION
## Summary
디자인 핸드오프 (\`drunkenmovie_app.html\`) 의 Cinéma Noir 컨셉을 적용하기 위한 **Phase 1: 디자인 토큰** PR. 기존 코드엔 영향 없음, 후속 Phase 에서 사용할 토큰 인프라만 추가.

## 원인
사용자 디자인 핸드오프 번들 \`drunkenmovie_app.html\` 의 컨셉을 단계별로 적용하기로 합의:
- Phase 1 — 디자인 토큰 (이 PR)
- Phase 2 — \`src/components/dm/\` 공유 컴포넌트 (BottomNav, AppHeader, Poster, Pill, Stars 등)
- Phase 3~8 — 화면별 적용

새 코드는 \`dm.*\` 네임스페이스에 격리, 완성 시 기존 컴포넌트와 점진 교체.

## 변경
### 디자인 토큰
- **\`src/styles/dm/tokens.css\`** 신규 — 잉크 블랙·시네마 레드(#c0302a)·앰버(#d99520) 팔레트, 포스터용 oklch 기본값
- **\`tailwind.config.ts\`** — \`dm.*\` 컬러 (\`dm-bg\`, \`dm-text\`, \`dm-red\`, \`dm-amber\` 등) + \`font-dm-display/mono/rank\` 토큰 등록
- **\`src/app/layout.tsx\`** — Playfair Display(serif·헤드라인) / IBM Plex Mono(메타) / Bebas Neue(랭크) Google Font 추가, CSS 변수로만 노출 (body 기본 폰트는 Roboto 유지)

### 200줄 룰 준수 부수 작업
- \`layout.tsx\` 217 → 159: \`metadata\`·JSON-LD 를 \`src/app/site-metadata.ts\` 로 분리
- \`globals.css\` 215 → 125: 다크 테마 토큰을 \`src/styles/themes/dark.css\` 로 분리

## 사용 방법 (Phase 2 부터)
\`\`\`tsx
<div className=\"bg-dm-bg text-dm-text font-dm-display\">…</div>
<span className=\"font-dm-mono text-dm-amber\">DM-MT001-0426</span>
\`\`\`

## Test plan
- [x] \`pnpm exec tsc --noEmit\` 통과
- [x] 모든 변경 파일 200줄 이하
- [ ] dev 서버에서 기존 페이지 회귀 없음 확인 (런타임)
- [ ] 머지 후 develop → master 릴리스 PR 에 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)