### PR TITLE
♻️ movie/[id]/page.tsx 분리 (406 → 58줄, 200줄 룰 준수)

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/data.ts
+++ b/src/app/(root)/(routes)/movie/[id]/data.ts
@@ -1,0 +1,40 @@
+import { Reply } from '@/lib/type'
+import { CommentRepository } from '@/modules/comment/comment-repository'
+import { AverageMovieScore, Movie } from '@/modules/movie/movie.entity'
+import { MovieRepository } from '@/modules/movie/movie-repository'
+
+export const getMovieDetail = async (id: string): Promise<Movie> => {
+  const repo = new MovieRepository()
+  return repo.getMovieDetail(id)
+}
+
+export const getReviews = async (id: string): Promise<Reply[]> => {
+  const repo = new CommentRepository()
+  const result = await repo.getCommentList(id, 1)
+  return result.comments
+}
+
+export const getScore = async (
+  id: string,
+): Promise<AverageMovieScore | null> => {
+  try {
+    const repo = new MovieRepository()
+    return repo.getAverageScore(id)
+  } catch (error) {
+    console.error('Failed to get average score:', error)
+    return null
+  }
+}
+
+export function hasValidScore(
+  score: AverageMovieScore | null,
+): score is AverageMovieScore & { averageScore: number; scoreCount: number } {
+  return !!(
+    score &&
+    typeof score.averageScore === 'number' &&
+    !isNaN(score.averageScore) &&
+    score.averageScore > 0 &&
+    score.averageScore <= 5 &&
+    score.scoreCount > 0
+  )
+}

--- a/src/app/(root)/(routes)/movie/[id]/json-ld.ts
+++ b/src/app/(root)/(routes)/movie/[id]/json-ld.ts
@@ -1,0 +1,139 @@
+import { Reply } from '@/lib/type'
+import { AverageMovieScore, Movie } from '@/modules/movie/movie.entity'
+import { hasValidScore } from './data'
+
+const BASE = 'https://drunkenmovie.shop'
+
+export function buildMovieJsonLd(
+  id: string,
+  movie: Movie,
+  reviews: Reply[],
+  score: AverageMovieScore | null,
+) {
+  const validReviews = reviews.filter(
+    (r) =>
+      r && r.content && r.content.trim() && r.nickname && r.nickname.trim(),
+  )
+  const validScore = hasValidScore(score)
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Movie',
+    '@id': `${BASE}/movie/${id}`,
+    name: movie.title,
+    description: movie.plot,
+    image: [
+      {
+        '@type': 'ImageObject',
+        url: movie.poster,
+        caption: `${movie.title} 포스터`,
+        width: 400,
+        height: 600,
+      },
+    ],
+    url: `${BASE}/movie/${id}`,
+    sameAs: `${BASE}/movie/${id}`,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${BASE}/movie/${id}`,
+      url: `${BASE}/movie/${id}`,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'DrunkenMovie',
+      url: BASE,
+    },
+  }
+
+  if (movie.genre) {
+    const genres = Array.isArray(movie.genre) ? movie.genre : [movie.genre]
+    jsonLd.genre = genres.filter((g) => g && g.trim())
+  }
+
+  if (movie.openedAt) {
+    const released = new Date(movie.openedAt)
+    if (!isNaN(released.getTime())) {
+      const date = released.toISOString().split('T')[0]
+      jsonLd.datePublished = date
+      jsonLd.releaseDate = date
+    }
+  }
+
+  if (movie.director?.trim()) {
+    jsonLd.director = { '@type': 'Person', name: movie.director.trim() }
+  }
+  if (movie.ratting?.trim()) jsonLd.contentRating = movie.ratting.trim()
+
+  if (validReviews.length > 0) {
+    jsonLd.review = validReviews.slice(0, 10).map((r, index) => {
+      const review: Record<string, unknown> = {
+        '@type': 'Review',
+        '@id': `${BASE}/movie/${id}#review${index + 1}`,
+        author: { '@type': 'Person', name: r.nickname.trim() },
+        reviewBody: r.content.trim(),
+        inLanguage: 'ko',
+        itemReviewed: {
+          '@type': 'Movie',
+          '@id': `${BASE}/movie/${id}`,
+          name: movie.title,
+        },
+      }
+      if (r.createdAt) {
+        const created = new Date(r.createdAt)
+        if (!isNaN(created.getTime())) {
+          review.datePublished = created.toISOString()
+        }
+      }
+      return review
+    })
+  }
+
+  if (validScore) {
+    jsonLd.aggregateRating = {
+      '@type': 'AggregateRating',
+      '@id': `${BASE}/movie/${id}#aggregateRating`,
+      ratingValue: Number(score.averageScore.toFixed(1)),
+      ratingCount: score.scoreCount,
+      reviewCount: validReviews.length,
+      bestRating: 5,
+      worstRating: 1,
+      itemReviewed: {
+        '@type': 'Movie',
+        '@id': `${BASE}/movie/${id}`,
+        name: movie.title,
+      },
+    }
+  }
+
+  jsonLd.potentialAction = {
+    '@type': 'WatchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: `${BASE}/movie/${id}`,
+      actionPlatform: [
+        'https://schema.org/DesktopWebPlatform',
+        'https://schema.org/IOSPlatform',
+        'https://schema.org/AndroidPlatform',
+      ],
+    },
+  }
+
+  return jsonLd
+}
+
+export function buildBreadcrumbJsonLd(id: string, title: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: '홈', item: BASE },
+      { '@type': 'ListItem', position: 2, name: '영화', item: BASE },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: title,
+        item: `${BASE}/movie/${id}`,
+      },
+    ],
+  }
+}

--- a/src/app/(root)/(routes)/movie/[id]/metadata.ts
+++ b/src/app/(root)/(routes)/movie/[id]/metadata.ts
@@ -1,0 +1,143 @@
+import { Metadata } from 'next'
+import { getMovieDetail, getReviews, getScore, hasValidScore } from './data'
+
+const FALLBACK: Metadata = {
+  title: '영화 상세 - DrunkenMovie',
+  description: 'DrunkenMovie에서 다양한 영화 정보와 리뷰를 확인하세요.',
+  metadataBase: new URL('https://drunkenmovie.shop'),
+}
+
+function genreList(genre: unknown): string[] {
+  return (Array.isArray(genre) ? genre : [genre])
+    .filter((g): g is string => Boolean(g))
+}
+
+export async function generateMovieMetadata(id: string): Promise<Metadata> {
+  try {
+    const movie = await getMovieDetail(id)
+    const score = await getScore(id)
+    const validScore = hasValidScore(score)
+
+    const keywords = [
+      movie.title,
+      `${movie.title} 리뷰`,
+      `${movie.title} 평점`,
+      `${movie.title} 영화`,
+      ...genreList(movie.genre).map((g) => `${g} 영화`),
+      movie.director && `${movie.director} 감독`,
+      '영화 리뷰',
+      '영화 평점',
+      'DrunkenMovie',
+      '영화뭐함',
+      '한국 영화 리뷰',
+      validScore && `평점 ${score.averageScore.toFixed(1)}점`,
+    ]
+      .filter(Boolean)
+      .join(', ')
+
+    let description = movie.plot
+
+    const reviews = await getReviews(id)
+    const validReviewCount = reviews.filter(
+      (r) =>
+        r && r.content && r.content.trim() && r.nickname && r.nickname.trim(),
+    ).length
+
+    if (validScore) {
+      const ratingText = `⭐ ${score.averageScore.toFixed(1)}/5.0 (${score.scoreCount.toLocaleString()}명 평가${
+        validReviewCount > 0 ? `, ${validReviewCount}개 리뷰` : ''
+      })`
+      description = `${description} | ${ratingText}`
+    } else if (validReviewCount > 0) {
+      description = `${description} | ${validReviewCount}개의 사용자 리뷰`
+    }
+
+    const genreText = genreList(movie.genre).join(', ')
+    if (genreText) description = `[${genreText}] ${description}`
+    if (movie.director) description = `${description} | 감독: ${movie.director}`
+
+    if (movie.openedAt) {
+      const year = new Date(movie.openedAt).getFullYear()
+      if (!isNaN(year)) description = `${description} | ${year}년 개봉`
+    }
+
+    const title = `${movie.title} - DrunkenMovie`
+    const currentDate = new Date().toISOString().slice(0, 10)
+
+    return {
+      title,
+      description: description.slice(0, 160),
+      keywords,
+      authors: [{ name: 'DrunkenMovie' }],
+      publisher: 'DrunkenMovie',
+      robots: {
+        index: true,
+        follow: true,
+        nocache: false,
+        googleBot: {
+          index: true,
+          follow: true,
+          'max-video-preview': -1,
+          'max-image-preview': 'large',
+          'max-snippet': -1,
+        },
+      },
+      openGraph: {
+        title,
+        description,
+        type: 'video.movie',
+        url: `https://drunkenmovie.shop/movie/${id}`,
+        siteName: 'DrunkenMovie',
+        locale: 'ko_KR',
+        images: [
+          {
+            url: movie.poster,
+            alt: `${movie.title} 포스터`,
+            width: 400,
+            height: 600,
+          },
+        ],
+        videos:
+          movie.vods?.length > 0
+            ? movie.vods.map((vod) => ({
+                url: vod.vodUrl,
+                type: 'video/mp4',
+              }))
+            : undefined,
+      },
+      twitter: {
+        card: 'summary_large_image',
+        site: '@DrunkenMovie',
+        title,
+        description,
+        images: [movie.poster],
+      },
+      alternates: { canonical: `https://drunkenmovie.shop/movie/${id}` },
+      metadataBase: new URL('https://drunkenmovie.shop'),
+      other: {
+        'movie:title': movie.title,
+        'movie:director': movie.director || '',
+        'movie:genre': genreText || '',
+        'movie:rating': validScore ? score.averageScore.toString() : '',
+        'movie:rating_count': validScore ? score.scoreCount.toString() : '',
+        'movie:review_count': validReviewCount.toString(),
+        'article:published_time': movie.openedAt
+          ? new Date(movie.openedAt).toISOString().slice(0, 10)
+          : currentDate,
+        'article:modified_time': currentDate,
+        'article:section': 'Movies',
+        'article:tag': genreText || '',
+        ...(validScore && {
+          rating: score.averageScore.toString(),
+          ratingCount: score.scoreCount.toString(),
+        }),
+        ...(validReviewCount > 0 && {
+          reviewCount: validReviewCount.toString(),
+        }),
+      },
+    }
+  } catch (error) {
+    console.error('Failed to generate metadata:', error)
+    return FALLBACK
+  }
+}

--- a/src/app/(root)/(routes)/movie/[id]/page.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/page.tsx
@@ -1,391 +1,43 @@
-import { Reply } from '@/lib/type'
-import { CommentRepository } from '@/modules/comment/comment-repository'
-import { AverageMovieScore, Movie } from '@/modules/movie/movie.entity'
-import { MovieRepository } from '@/modules/movie/movie-repository'
 import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
+import { getMovieDetail, getReviews, getScore } from './data'
 import { ModifyCommentModalContextProvider } from './hooks/use-modify-comment-context'
 import { VodModalContextProvider } from './hooks/use-vod-modal-context'
+import { buildBreadcrumbJsonLd, buildMovieJsonLd } from './json-ld'
+import { generateMovieMetadata } from './metadata'
 import ActiveSection from './sections/active-section'
 import CommentSection from './sections/comment-section'
 import DescriptionSection from './sections/description-section'
 
 interface PageProps {
-  params: {
-    id: string
-  }
-}
-
-const getMovieList = async (id: string): Promise<Movie> => {
-  const repo = new MovieRepository()
-  return repo.getMovieDetail(id)
-}
-
-const getReviews = async (id: string): Promise<Reply[]> => {
-  const repo = new CommentRepository()
-  const result = await repo.getCommentList(id, 1)
-  return result.comments
-}
-
-const getScore = async (id: string): Promise<AverageMovieScore | null> => {
-  try {
-    const repo = new MovieRepository()
-    return repo.getAverageScore(id)
-  } catch (error) {
-    console.error('Failed to get average score:', error)
-    // 기본값 반환
-    return null
-  }
+  params: { id: string }
 }
 
 export async function generateMetadata({
   params: { id },
-}: {
-  params: { id: string }
-}): Promise<Metadata> {
-  try {
-    const movie = await getMovieList(id)
-    const score = await getScore(id)
-
-    // 유효한 평점 확인
-    const hasValidScore =
-      score &&
-      typeof score.averageScore === 'number' &&
-      !isNaN(score.averageScore) &&
-      score.averageScore > 0 &&
-      score.averageScore <= 5 &&
-      score.scoreCount > 0
-
-    // 동적 키워드 생성 (더 구체적으로)
-    const keywords = [
-      movie.title,
-      `${movie.title} 리뷰`,
-      `${movie.title} 평점`,
-      `${movie.title} 영화`,
-      ...(Array.isArray(movie.genre) ? movie.genre : [movie.genre])
-        .filter(Boolean)
-        .map((g) => `${g} 영화`),
-      movie.director && `${movie.director} 감독`,
-      '영화 리뷰',
-      '영화 평점',
-      'DrunkenMovie',
-      '영화뭐함',
-      '한국 영화 리뷰',
-      hasValidScore && `평점 ${score.averageScore.toFixed(1)}점`,
-    ]
-      .filter(Boolean)
-      .join(', ')
-
-    // 더 상세한 설명 생성
-    let description = movie.plot
-
-    // 리뷰 개수 가져오기
-    const reviews = await getReviews(id)
-    const validReviewCount = reviews.filter(
-      (r) =>
-        r && r.content && r.content.trim() && r.nickname && r.nickname.trim(),
-    ).length
-
-    // 평점 정보가 있을 때 추가
-    if (hasValidScore) {
-      const ratingText = `⭐ ${score.averageScore.toFixed(1)}/5.0 (${score.scoreCount.toLocaleString()}명 평가${validReviewCount > 0 ? `, ${validReviewCount}개 리뷰` : ''})`
-      description = `${description} | ${ratingText}`
-    } else if (validReviewCount > 0) {
-      description = `${description} | ${validReviewCount}개의 사용자 리뷰`
-    }
-
-    // 장르 정보 추가
-    const genreText = Array.isArray(movie.genre)
-      ? movie.genre.join(', ')
-      : movie.genre
-    if (genreText) {
-      description = `[${genreText}] ${description}`
-    }
-
-    // 감독 정보 추가
-    if (movie.director) {
-      description = `${description} | 감독: ${movie.director}`
-    }
-
-    // 개봉년도 정보 추가
-    if (movie.openedAt) {
-      const year = new Date(movie.openedAt).getFullYear()
-      if (!isNaN(year)) {
-        description = `${description} | ${year}년 개봉`
-      }
-    }
-
-    const title = `${movie.title} - DrunkenMovie`
-
-    const currentDate = new Date().toISOString().slice(0, 10)
-
-    return {
-      title,
-      description: description.slice(0, 160), // Google 권장 길이로 제한
-      keywords,
-      authors: [{ name: 'DrunkenMovie' }],
-      publisher: 'DrunkenMovie',
-      robots: {
-        index: true,
-        follow: true,
-        nocache: false,
-        googleBot: {
-          index: true,
-          follow: true,
-          'max-video-preview': -1,
-          'max-image-preview': 'large',
-          'max-snippet': -1,
-        },
-      },
-      openGraph: {
-        title,
-        description,
-        type: 'video.movie',
-        url: `https://drunkenmovie.shop/movie/${id}`,
-        siteName: 'DrunkenMovie',
-        locale: 'ko_KR',
-        images: [
-          {
-            url: movie.poster,
-            alt: `${movie.title} 포스터`,
-            width: 400,
-            height: 600,
-          },
-        ],
-        videos:
-          movie.vods?.length > 0
-            ? movie.vods.map((vod) => ({
-                url: vod.vodUrl,
-                type: 'video/mp4',
-              }))
-            : undefined,
-      },
-      twitter: {
-        card: 'summary_large_image',
-        site: '@DrunkenMovie',
-        title,
-        description,
-        images: [movie.poster],
-      },
-      alternates: {
-        canonical: `https://drunkenmovie.shop/movie/${id}`,
-      },
-      metadataBase: new URL('https://drunkenmovie.shop'),
-      // 구조화 데이터 힌트를 위한 추가 메타데이터
-      other: {
-        'movie:title': movie.title,
-        'movie:director': movie.director || '',
-        'movie:genre': genreText || '',
-        'movie:rating': hasValidScore ? score.averageScore.toString() : '',
-        'movie:rating_count': hasValidScore ? score.scoreCount.toString() : '',
-        'movie:review_count': validReviewCount.toString(),
-        // 추가 SEO 메타태그
-        'article:published_time': movie.openedAt
-          ? new Date(movie.openedAt).toISOString().slice(0, 10)
-          : currentDate,
-        'article:modified_time': currentDate,
-        'article:section': 'Movies',
-        'article:tag': genreText || '',
-        // Rich snippet 관련 (undefined 제거)
-        ...(hasValidScore && {
-          rating: score.averageScore.toString(),
-          ratingCount: score.scoreCount.toString(),
-        }),
-        ...(validReviewCount > 0 && {
-          reviewCount: validReviewCount.toString(),
-        }),
-      },
-    }
-  } catch (error) {
-    console.error('Failed to generate metadata:', error)
-    // 기본 메타데이터 반환
-    return {
-      title: '영화 상세 - DrunkenMovie',
-      description: 'DrunkenMovie에서 다양한 영화 정보와 리뷰를 확인하세요.',
-      metadataBase: new URL('https://drunkenmovie.shop'),
-    }
-  }
+}: PageProps): Promise<Metadata> {
+  return generateMovieMetadata(id)
 }
 
 const Page: FunctionComponent<PageProps> = async ({ params: { id } }) => {
-  const movieData = await getMovieList(id)
+  const movie = await getMovieDetail(id)
   const reviews = await getReviews(id)
   const score = await getScore(id)
 
-  // 유효한 평점 데이터 확인
-  const hasValidRating =
-    score &&
-    typeof score.averageScore === 'number' &&
-    !isNaN(score.averageScore) &&
-    score.averageScore > 0 &&
-    score.averageScore <= 5 &&
-    score.scoreCount > 0
-
-  // 구조화 데이터 생성 (Google Movie schema 최적화)
-  const jsonLd: any = {
-    '@context': 'https://schema.org',
-    '@type': 'Movie',
-    '@id': `https://drunkenmovie.shop/movie/${id}`,
-    name: movieData.title,
-    description: movieData.plot,
-    image: [
-      {
-        '@type': 'ImageObject',
-        url: movieData.poster,
-        caption: `${movieData.title} 포스터`,
-        width: 400,
-        height: 600,
-      },
-    ],
-    url: `https://drunkenmovie.shop/movie/${id}`,
-    sameAs: `https://drunkenmovie.shop/movie/${id}`,
-    mainEntityOfPage: {
-      '@type': 'WebPage',
-      '@id': `https://drunkenmovie.shop/movie/${id}`,
-      url: `https://drunkenmovie.shop/movie/${id}`,
-    },
-    publisher: {
-      '@type': 'Organization',
-      name: 'DrunkenMovie',
-      url: 'https://drunkenmovie.shop',
-    },
-  }
-
-  // 장르 정보 추가 (문자열 배열로 정규화)
-  if (movieData.genre) {
-    const genres = Array.isArray(movieData.genre)
-      ? movieData.genre
-      : [movieData.genre]
-    jsonLd.genre = genres.filter((g) => g && g.trim())
-  }
-
-  // 개봉일이 있을 때만 추가
-  if (movieData.openedAt) {
-    const releaseDate = new Date(movieData.openedAt)
-    if (!isNaN(releaseDate.getTime())) {
-      jsonLd.datePublished = releaseDate.toISOString().split('T')[0]
-      jsonLd.releaseDate = releaseDate.toISOString().split('T')[0]
-    }
-  }
-
-  // 감독 정보가 있을 때만 추가
-  if (movieData.director && movieData.director.trim()) {
-    jsonLd.director = {
-      '@type': 'Person',
-      name: movieData.director.trim(),
-    }
-  }
-
-  // 평점 등급 정보 추가
-  if (movieData.ratting && movieData.ratting.trim()) {
-    jsonLd.contentRating = movieData.ratting.trim()
-  }
-
-  // 유효한 리뷰가 있을 때만 추가
-  const validReviews = reviews.filter(
-    (r) =>
-      r && r.content && r.content.trim() && r.nickname && r.nickname.trim(),
-  )
-
-  if (validReviews.length > 0) {
-    jsonLd.review = validReviews.slice(0, 10).map((r, index) => {
-      // 최대 10개 리뷰만 포함
-      const review: any = {
-        '@type': 'Review',
-        '@id': `https://drunkenmovie.shop/movie/${id}#review${index + 1}`,
-        author: {
-          '@type': 'Person',
-          name: r.nickname.trim(),
-        },
-        reviewBody: r.content.trim(),
-        inLanguage: 'ko',
-        itemReviewed: {
-          '@type': 'Movie',
-          '@id': `https://drunkenmovie.shop/movie/${id}`,
-          name: movieData.title,
-        },
-      }
-
-      if (r.createdAt) {
-        const createdDate = new Date(r.createdAt)
-        if (!isNaN(createdDate.getTime())) {
-          review.datePublished = createdDate.toISOString()
-        }
-      }
-
-      return review
-    })
-  }
-
-  // 유효한 평점이 있을 때만 aggregateRating 추가 (Google 권장 형식)
-  if (hasValidRating) {
-    jsonLd.aggregateRating = {
-      '@type': 'AggregateRating',
-      '@id': `https://drunkenmovie.shop/movie/${id}#aggregateRating`,
-      ratingValue: Number(score.averageScore.toFixed(1)), // 소수점 1자리로 변경
-      ratingCount: score.scoreCount,
-      reviewCount: validReviews.length,
-      bestRating: 5,
-      worstRating: 1,
-    }
-
-    // 평점이 있을 때 Movie 객체에 추가 정보 제공
-    jsonLd.aggregateRating.itemReviewed = {
-      '@type': 'Movie',
-      '@id': `https://drunkenmovie.shop/movie/${id}`,
-      name: movieData.title,
-    }
-  }
-
-  // 추가 SEO 향상을 위한 속성
-  jsonLd.potentialAction = {
-    '@type': 'WatchAction',
-    target: {
-      '@type': 'EntryPoint',
-      urlTemplate: `https://drunkenmovie.shop/movie/${id}`,
-      actionPlatform: [
-        'https://schema.org/DesktopWebPlatform',
-        'https://schema.org/IOSPlatform',
-        'https://schema.org/AndroidPlatform',
-      ],
-    },
-  }
-
-  // BreadcrumbList 구조화 데이터 추가
-  const breadcrumbJsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: [
-      {
-        '@type': 'ListItem',
-        position: 1,
-        name: '홈',
-        item: 'https://drunkenmovie.shop',
-      },
-      {
-        '@type': 'ListItem',
-        position: 2,
-        name: '영화',
-        item: 'https://drunkenmovie.shop',
-      },
-      {
-        '@type': 'ListItem',
-        position: 3,
-        name: movieData.title,
-        item: `https://drunkenmovie.shop/movie/${id}`,
-      },
-    ],
-  }
+  const movieJsonLd = buildMovieJsonLd(id, movie, reviews, score)
+  const breadcrumbJsonLd = buildBreadcrumbJsonLd(id, movie.title)
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(movieJsonLd) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(breadcrumbJsonLd),
+        }}
       />
       <div
         id="movie-detail-page"


### PR DESCRIPTION
## Summary
영화 상세 페이지 라우트를 책임별 4개 파일로 분리. 200줄 룰 위반 해소 + 가독성 개선. 동작 변화 없음.

## 변경
| 파일 | 줄수 | 역할 |
|------|------|------|
| \`data.ts\` | 40 | \`getMovieDetail\`, \`getReviews\`, \`getScore\` + \`hasValidScore\` 가드 |
| \`metadata.ts\` | 143 | \`generateMovieMetadata\` — Next Metadata 객체 (키워드·description·OpenGraph·Twitter·other) |
| \`json-ld.ts\` | 139 | \`buildMovieJsonLd\` (Movie schema·Review·AggregateRating·WatchAction), \`buildBreadcrumbJsonLd\` |
| \`page.tsx\` | 58 | fetch → JSON-LD 빌더 호출 → JSX 만 |

## 부수 정리
- 중복 \`hasValidScore\` 인라인 체크 → \`data.ts\` 의 type guard 로 일원화
- 중복 \`'https://drunkenmovie.shop'\` 리터럴 → \`json-ld.ts\` 의 \`BASE\` 상수
- 코드량 26줄 감소

## 200줄 룰 결과
모든 신규/수정 파일 200줄 미만. 기존 page.tsx 406 → page.tsx 58.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` 통과
- [x] \`pnpm build\` 통과
- [ ] dev 서버에서 \`/movie/{id}\` 메타 태그·JSON-LD 정상 출력 확인
- [ ] 머지 후 develop → master 릴리스 PR 에 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)