### PR TITLE
✨ 매치 작성·내 매칭·채팅 Cinéma Noir 적용 (Phase 9)

### DIFF
--- a/src/app/(root)/(routes)/chat/page.tsx
+++ b/src/app/(root)/(routes)/chat/page.tsx
@@ -1,0 +1,21 @@
+import { FunctionComponent } from 'react'
+
+const Page: FunctionComponent = () => {
+  return (
+    <div className="flex min-h-page flex-col items-center justify-center bg-dm-bg">
+      <div className="mb-3 font-dm-display text-[32px] italic text-dm-text">
+        Chat.
+      </div>
+      <div className="mb-1 font-dm-mono text-[11px] uppercase tracking-[2px] text-dm-amber">
+        Coming Soon
+      </div>
+      <div className="font-dm-mono text-[11px] text-dm-text-faint">
+        매칭 후 채팅은{' '}
+        <span className="text-dm-text">매칭 상세 페이지</span>에서 이용할 수
+        있어요.
+      </div>
+    </div>
+  )
+}
+
+export default Page

--- a/src/app/(root)/(routes)/match/my-matches/components/my-applied-matches.tsx
+++ b/src/app/(root)/(routes)/match/my-matches/components/my-applied-matches.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { MatchApplication } from '@/lib/type'
+import { useRouter } from 'next/navigation'
+import { FunctionComponent } from 'react'
+
+const statusBadge: Record<string, { text: string; cls: string }> = {
+  pending: { text: '대기', cls: 'text-dm-amber border-dm-amber/50' },
+  accepted: { text: '승인', cls: 'text-green-400 border-green-400/50' },
+  rejected: { text: '거절', cls: 'text-dm-red border-dm-red/50' },
+}
+
+interface MyAppliedMatchesProps {
+  applications: MatchApplication[]
+  onCancel: (id: string) => void
+}
+
+const MyAppliedMatches: FunctionComponent<MyAppliedMatchesProps> = ({
+  applications,
+  onCancel,
+}) => {
+  const router = useRouter()
+
+  if (applications.length === 0)
+    return (
+      <div className="py-12 text-center font-dm-mono text-[12px] text-dm-text-faint">
+        신청한 매칭이 없습니다.
+      </div>
+    )
+
+  return (
+    <div>
+      {applications.map((app) => {
+        const badge = statusBadge[app.status] ?? statusBadge.pending
+        return (
+          <div key={app.id} className="border-b border-dm-line px-5 py-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => router.push(`/match/${app.matchPostId}`)}
+                    className="text-[14px] font-semibold text-dm-text hover:text-dm-amber"
+                  >
+                    매칭 상세보기 →
+                  </button>
+                  <span
+                    className={`border px-1.5 py-0.5 font-dm-mono text-[9px] uppercase tracking-[0.5px] ${badge.cls}`}
+                  >
+                    {badge.text}
+                  </span>
+                </div>
+                {app.message && (
+                  <p className="mt-1 text-[13px] text-dm-text-muted">
+                    {app.message}
+                  </p>
+                )}
+                <div className="mt-1 font-dm-mono text-[10px] text-dm-text-faint">
+                  {new Date(app.createdAt).toLocaleDateString('ko-KR')}
+                </div>
+              </div>
+              {app.status === 'pending' && (
+                <button
+                  onClick={() => onCancel(app.id)}
+                  className="shrink-0 border border-dm-line px-2.5 py-1 font-dm-mono text-[11px] text-dm-text-faint hover:border-dm-red hover:text-dm-red"
+                >
+                  취소
+                </button>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export { MyAppliedMatches }

--- a/src/app/(root)/(routes)/match/my-matches/components/my-created-matches.tsx
+++ b/src/app/(root)/(routes)/match/my-matches/components/my-created-matches.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { MatchPost } from '@/lib/type'
+import { useRouter } from 'next/navigation'
+import { FunctionComponent } from 'react'
+
+interface MyCreatedMatchesProps {
+  matches: MatchPost[]
+}
+
+const MyCreatedMatches: FunctionComponent<MyCreatedMatchesProps> = ({
+  matches,
+}) => {
+  const router = useRouter()
+
+  if (matches.length === 0)
+    return (
+      <div className="py-12 text-center font-dm-mono text-[12px] text-dm-text-faint">
+        작성한 매칭이 없습니다.
+      </div>
+    )
+
+  return (
+    <div>
+      {matches.map((match) => (
+        <div key={match.id} className="border-b border-dm-line px-5 py-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <button
+                onClick={() => router.push(`/match/${match.id}`)}
+                className="text-left text-[14px] font-semibold text-dm-text hover:text-dm-amber"
+              >
+                {match.title}
+              </button>
+              <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 font-dm-mono text-[11px] text-dm-text-faint">
+                <span>{match.movieTitle}</span>
+                <span>{match.theaterName}</span>
+                <span>
+                  {match.currentParticipants}/{match.maxParticipants}명
+                </span>
+              </div>
+              <div className="mt-1 font-dm-mono text-[10px] text-dm-text-faint">
+                {new Date(match.createdAt).toLocaleDateString('ko-KR')}
+              </div>
+            </div>
+            <button
+              onClick={() => router.push(`/match/${match.id}`)}
+              className="shrink-0 border border-dm-line px-2.5 py-1 font-dm-mono text-[11px] text-dm-text-faint hover:border-dm-amber hover:text-dm-amber"
+            >
+              관리
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export { MyCreatedMatches }

--- a/src/app/(root)/(routes)/match/my-matches/components/my-matches-container.tsx
+++ b/src/app/(root)/(routes)/match/my-matches/components/my-matches-container.tsx
@@ -1,261 +1,85 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
+import { useAppToast } from '@/hooks/use-app-toast'
 import { useSession } from 'next-auth/react'
-import { Button } from '@/components/ui/button'
-import Box from '@/components/ui/box'
-import { useToast } from '@/hooks/use-toast'
-import {
-  useMyApplications,
-  useMyPosts,
-  useCancelApplication,
-} from '../../hooks'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import { useCancelApplication, useMyApplications, useMyPosts } from '../../hooks'
+import { MyAppliedMatches } from './my-applied-matches'
+import { MyCreatedMatches } from './my-created-matches'
+
+type Tab = 'applied' | 'created'
 
 const MyMatchesContainer = () => {
-  const { data: _session, status } = useSession()
+  const { status } = useSession()
   const router = useRouter()
-  const { toast } = useToast()
-  const [activeTab, setActiveTab] = useState<'applied' | 'created'>('applied')
+  const searchParams = useSearchParams()
+  const { showToast } = useAppToast()
 
-  // SWR hooks
-  const {
-    applications: appliedMatches,
-    isLoading: loadingApplications,
-    refetch: refetchApplications,
-  } = useMyApplications()
-  const { matches: createdMatches, isLoading: loadingPosts } = useMyPosts()
+  const initialTab = (searchParams?.get('tab') as Tab) ?? 'applied'
+  const [activeTab, setActiveTab] = useState<Tab>(initialTab)
+
+  const { applications, isLoading: loadingApplied, refetch } = useMyApplications()
+  const { matches, isLoading: loadingCreated } = useMyPosts()
   const { cancelApplication } = useCancelApplication()
 
-  const isLoading = activeTab === 'applied' ? loadingApplications : loadingPosts
-
-  // 로그인 체크
   useEffect(() => {
-    if (status === 'loading') return
-    if (status === 'unauthenticated') {
-      router.push('/login')
-    }
+    if (status === 'unauthenticated') router.push('/login')
   }, [status, router])
 
-  // 신청 취소
-  const handleCancelApplication = useCallback(
-    async (applicationId: string) => {
+  const handleCancel = useCallback(
+    async (id: string) => {
       if (!window.confirm('정말로 신청을 취소하시겠습니까?')) return
-
       try {
-        await cancelApplication(applicationId)
-        toast({
-          title: '성공',
-          description: '신청이 취소되었습니다.',
-        })
-        refetchApplications()
-      } catch (error) {
-        toast({
-          title: '오류',
-          description: '신청 취소에 실패했습니다.',
-          variant: 'destructive',
-        })
+        await cancelApplication(id)
+        showToast('신청이 취소되었습니다.')
+        refetch()
+      } catch {
+        showToast('신청 취소에 실패했습니다.')
       }
     },
-    [cancelApplication, toast, refetchApplications],
+    [cancelApplication, showToast, refetch],
   )
 
-  // 로딩 상태
-  if (status === 'loading') {
+  if (status === 'loading')
     return (
-      <main className="container mx-auto px-4 py-8">
-        <div className="py-8 text-center">
-          <p>로딩 중...</p>
-        </div>
-      </main>
+      <div className="flex h-[40vh] items-center justify-center font-dm-mono text-[12px] text-dm-text-faint">
+        loading...
+      </div>
     )
-  }
 
-  // 로그인되지 않은 경우
-  if (status === 'unauthenticated') {
-    return null
-  }
+  if (status === 'unauthenticated') return null
 
-  // 상태 텍스트 및 색상
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'pending':
-        return '대기 중'
-      case 'accepted':
-        return '승인됨'
-      case 'rejected':
-        return '거절됨'
-      default:
-        return status
-    }
-  }
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'pending':
-        return 'bg-yellow-100 text-yellow-800'
-      case 'accepted':
-        return 'bg-green-100 text-green-800'
-      case 'rejected':
-        return 'bg-red-100 text-red-800'
-      default:
-        return 'bg-gray-100 text-gray-800'
-    }
-  }
+  const isLoading = activeTab === 'applied' ? loadingApplied : loadingCreated
 
   return (
-    <main className="container mx-auto px-4 py-8">
-      <div className="mb-6">
-        <h1 className="mb-2 text-3xl font-bold">내 매칭 관리</h1>
-        <p className="text-gray-600">
-          신청한 매칭과 내가 만든 매칭을 관리하세요.
-        </p>
+    <div>
+      <div className="flex border-b border-dm-line">
+        {(['applied', 'created'] as Tab[]).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`flex-1 py-3 font-dm-mono text-[11px] uppercase tracking-[1px] transition ${
+              activeTab === tab
+                ? 'border-b-2 border-dm-amber text-dm-amber'
+                : 'text-dm-text-faint hover:text-dm-text'
+            }`}
+          >
+            {tab === 'applied' ? '신청한 매칭' : '내가 만든 매칭'}
+          </button>
+        ))}
       </div>
 
-      {/* 탭 메뉴 */}
-      <div className="mb-6 flex space-x-1 rounded-lg bg-gray-100 p-1">
-        <button
-          onClick={() => setActiveTab('applied')}
-          className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-            activeTab === 'applied'
-              ? 'bg-white text-blue-600 shadow-sm'
-              : 'text-gray-600 hover:text-gray-900'
-          }`}
-        >
-          신청한 매칭
-        </button>
-        <button
-          onClick={() => setActiveTab('created')}
-          className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-            activeTab === 'created'
-              ? 'bg-white text-blue-600 shadow-sm'
-              : 'text-gray-600 hover:text-gray-900'
-          }`}
-        >
-          내가 만든 매칭
-        </button>
-      </div>
-
-      {/* 콘텐츠 */}
       {isLoading ? (
-        <div className="py-8 text-center">
-          <p>데이터를 불러오는 중...</p>
+        <div className="flex h-[30vh] items-center justify-center font-dm-mono text-[12px] text-dm-text-faint">
+          loading...
         </div>
       ) : activeTab === 'applied' ? (
-        <div className="space-y-4">
-          {appliedMatches.length === 0 ? (
-            <Box className="py-8 text-center">
-              <p className="text-gray-500">신청한 매칭이 없습니다.</p>
-              <Button onClick={() => router.push('/match')} className="mt-4">
-                매칭 찾아보기
-              </Button>
-            </Box>
-          ) : (
-            appliedMatches.map((application) => (
-              <Box key={application.id} className="p-6">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
-                    <div className="mb-2 flex items-center gap-3">
-                      <h3
-                        className="cursor-pointer text-lg font-semibold hover:text-blue-600"
-                        onClick={() =>
-                          router.push(`/match/${application.matchPostId}`)
-                        }
-                      >
-                        매칭 상세보기
-                      </h3>
-                      <span
-                        className={`rounded px-2 py-1 text-xs ${getStatusColor(
-                          application.status,
-                        )}`}
-                      >
-                        {getStatusText(application.status)}
-                      </span>
-                    </div>
-                    <p className="mb-3 text-gray-600">{application.message}</p>
-                    <div className="text-sm text-gray-500">
-                      신청일:{' '}
-                      {new Date(application.createdAt).toLocaleString('ko-KR')}
-                    </div>
-                  </div>
-                  <div className="ml-4 flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() =>
-                        router.push(`/match/${application.matchPostId}`)
-                      }
-                    >
-                      상세보기
-                    </Button>
-                    {application.status === 'pending' && (
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => handleCancelApplication(application.id)}
-                      >
-                        신청 취소
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              </Box>
-            ))
-          )}
-        </div>
+        <MyAppliedMatches applications={applications} onCancel={handleCancel} />
       ) : (
-        <div className="space-y-4">
-          {createdMatches.length === 0 ? (
-            <Box className="py-8 text-center">
-              <p className="text-gray-500">작성한 매칭이 없습니다.</p>
-              <Button onClick={() => router.push('/match')} className="mt-4">
-                매칭 작성하기
-              </Button>
-            </Box>
-          ) : (
-            createdMatches.map((match) => (
-              <Box key={match.id} className="p-6">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
-                    <h3
-                      className="mb-2 cursor-pointer text-lg font-semibold hover:text-blue-600"
-                      onClick={() => router.push(`/match/${match.id}`)}
-                    >
-                      {match.title}
-                    </h3>
-                    <div className="mb-3 grid gap-2 text-sm text-gray-600 md:grid-cols-2">
-                      <div>영화: {match.movieTitle}</div>
-                      <div>상영관: {match.theaterName}</div>
-                      <div>
-                        상영시간:{' '}
-                        {new Date(match.showTime).toLocaleString('ko-KR')}
-                      </div>
-                      <div>
-                        모집인원: {match.currentParticipants}/
-                        {match.maxParticipants}명
-                      </div>
-                    </div>
-                    <div className="text-sm text-gray-500">
-                      작성일:{' '}
-                      {new Date(match.createdAt).toLocaleString('ko-KR')}
-                    </div>
-                  </div>
-                  <div className="ml-4 flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => router.push(`/match/${match.id}`)}
-                    >
-                      관리하기
-                    </Button>
-                  </div>
-                </div>
-              </Box>
-            ))
-          )}
-        </div>
+        <MyCreatedMatches matches={matches} />
       )}
-    </main>
+    </div>
   )
 }
 

--- a/src/app/(root)/(routes)/match/my-matches/page.tsx
+++ b/src/app/(root)/(routes)/match/my-matches/page.tsx
@@ -1,11 +1,17 @@
 import { FunctionComponent } from 'react'
 import { MyMatchesContainer } from './components/my-matches-container'
 
-interface PageProps {}
-
-const Page: FunctionComponent<PageProps> = () => {
-  // return <MyMatchesContainer />
-  return <div>준비중</div>
+const Page: FunctionComponent = () => {
+  return (
+    <div className="min-h-page bg-dm-bg pb-[100px] text-dm-text">
+      <div className="flex items-center border-b border-dm-line px-4 py-3.5">
+        <h1 className="font-dm-display text-[20px] italic font-bold text-dm-text">
+          내 매칭
+        </h1>
+      </div>
+      <MyMatchesContainer />
+    </div>
+  )
 }
 
 export default Page

--- a/src/app/(root)/(routes)/match/new/page.tsx
+++ b/src/app/(root)/(routes)/match/new/page.tsx
@@ -1,18 +1,18 @@
 import { FunctionComponent } from 'react'
 import { NewMatchContainer } from './components/new-match-container'
 
-interface PageProps {}
-
-const Page: FunctionComponent<PageProps> = () => {
+const Page: FunctionComponent = () => {
   return (
-    <main className="container mx-auto px-4 py-8">
-      <div className="mb-6">
-        <h1 className="mb-2 text-3xl font-bold">영화 메이트 모집하기</h1>
-        <p className="text-gray-600">함께 영화를 볼 메이트를 모집해보세요!</p>
+    <div className="min-h-page bg-dm-bg text-dm-text">
+      <div className="flex items-center border-b border-dm-line px-4 py-3.5">
+        <h1 className="font-dm-display text-[20px] italic font-bold text-dm-text">
+          매치 만들기
+        </h1>
       </div>
-
-      <NewMatchContainer />
-    </main>
+      <div className="px-5 py-5">
+        <NewMatchContainer />
+      </div>
+    </div>
   )
 }
 

--- a/src/components/form/match/fields/content-input-field.tsx
+++ b/src/components/form/match/fields/content-input-field.tsx
@@ -1,32 +1,21 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { Textarea } from '@/components/ui/textarea'
-import { FunctionComponent, HTMLAttributes } from 'react'
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { FunctionComponent } from 'react'
 import { useMatchPostFormContext } from '../hooks/match-post-form-context'
 
-interface ContentInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+const cls = 'w-full resize-none border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-1.5 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const ContentInputField: FunctionComponent<ContentInputFieldProps> = () => {
+const ContentInputField: FunctionComponent = () => {
   const { form } = useMatchPostFormContext()
-
   return (
     <FormField
       control={form.control}
       name="content"
       render={({ field }) => (
         <FormItem>
-          <FormLabel>내용</FormLabel>
+          <label className={labelCls}>내용</label>
           <FormControl>
-            <Textarea
-              {...field}
-              placeholder="모집 내용을 입력하세요"
-              rows={4}
-            />
+            <textarea {...field} className={cls} rows={4} placeholder="모집 내용을 입력하세요" />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/src/components/form/match/fields/location-input-field.tsx
+++ b/src/components/form/match/fields/location-input-field.tsx
@@ -1,28 +1,21 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
-import { FunctionComponent, HTMLAttributes } from 'react'
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { FunctionComponent } from 'react'
 import { useMatchPostFormContext } from '../hooks/match-post-form-context'
 
-interface LocationInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+const cls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-1.5 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const LocationInputField: FunctionComponent<LocationInputFieldProps> = () => {
+const LocationInputField: FunctionComponent = () => {
   const { form } = useMatchPostFormContext()
-
   return (
     <FormField
       control={form.control}
       name="location"
       render={({ field }) => (
         <FormItem>
-          <FormLabel>위치</FormLabel>
+          <label className={labelCls}>위치</label>
           <FormControl>
-            <Input {...field} placeholder="영화관 위치 (예: 강남구, 홍대 등)" />
+            <input {...field} className={cls} placeholder="영화관 위치 (예: 강남구, 홍대 등)" />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/src/components/form/match/fields/max-participants-input-field.tsx
+++ b/src/components/form/match/fields/max-participants-input-field.tsx
@@ -1,35 +1,26 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
-import { FunctionComponent, HTMLAttributes } from 'react'
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { FunctionComponent } from 'react'
 import { useMatchPostFormContext } from '../hooks/match-post-form-context'
 
-interface MaxParticipantsInputFieldProps
-  extends HTMLAttributes<HTMLDivElement> {}
+const cls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-1.5 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const MaxParticipantsInputField: FunctionComponent<
-  MaxParticipantsInputFieldProps
-> = () => {
+const MaxParticipantsInputField: FunctionComponent = () => {
   const { form } = useMatchPostFormContext()
-
   return (
     <FormField
       control={form.control}
       name="maxParticipants"
       render={({ field }) => (
         <FormItem>
-          <FormLabel>최대 인원</FormLabel>
+          <label className={labelCls}>최대 인원</label>
           <FormControl>
-            <Input
+            <input
               {...field}
               type="number"
               min="1"
               max="10"
+              className={cls}
               onChange={(e) => field.onChange(parseInt(e.target.value) || 1)}
             />
           </FormControl>

--- a/src/components/form/match/fields/movie-title-input-field.tsx
+++ b/src/components/form/match/fields/movie-title-input-field.tsx
@@ -1,30 +1,21 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
-import { FunctionComponent, HTMLAttributes } from 'react'
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { FunctionComponent } from 'react'
 import { useMatchPostFormContext } from '../hooks/match-post-form-context'
 
-interface MovieTitleInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+const cls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-1.5 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const MovieTitleInputField: FunctionComponent<
-  MovieTitleInputFieldProps
-> = () => {
+const MovieTitleInputField: FunctionComponent = () => {
   const { form } = useMatchPostFormContext()
-
   return (
     <FormField
       control={form.control}
       name="movieTitle"
       render={({ field }) => (
         <FormItem>
-          <FormLabel>영화 제목</FormLabel>
+          <label className={labelCls}>영화 제목</label>
           <FormControl>
-            <Input {...field} placeholder="영화 제목" />
+            <input {...field} className={cls} placeholder="영화 제목" />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/src/components/form/match/fields/show-time-input-field.tsx
+++ b/src/components/form/match/fields/show-time-input-field.tsx
@@ -1,52 +1,30 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { AppDatePicker } from '@/components/app/app-date-picker'
-import { FunctionComponent, HTMLAttributes } from 'react'
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { FunctionComponent } from 'react'
 import { useMatchPostFormContext } from '../hooks/match-post-form-context'
 
-interface ShowTimeInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+const cls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text focus:border-dm-amber focus:outline-none [color-scheme:dark]'
+const labelCls = 'mb-1.5 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const ShowTimeInputField: FunctionComponent<ShowTimeInputFieldProps> = () => {
+const ShowTimeInputField: FunctionComponent = () => {
   const { form } = useMatchPostFormContext()
-
   return (
     <FormField
       control={form.control}
       name="showTime"
-      render={({ field }) => {
-        const currentValue = field.value ? new Date(field.value) : undefined
-
-        const handleDateChange = (date?: Date) => {
-          if (date) {
-            // YYYY-MM-DD 형식으로 변환
-            const year = date.getFullYear()
-            const month = String(date.getMonth() + 1).padStart(2, '0')
-            const day = String(date.getDate()).padStart(2, '0')
-            field.onChange(`${year}-${month}-${day}`)
-          } else {
-            field.onChange(undefined)
-          }
-        }
-
-        return (
-          <FormItem>
-            <FormLabel>상영 시간</FormLabel>
-            <FormControl>
-              <AppDatePicker
-                value={currentValue}
-                onChange={handleDateChange}
-                placeholder="날짜를 선택하세요"
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )
-      }}
+      render={({ field }) => (
+        <FormItem>
+          <label className={labelCls}>상영 시간</label>
+          <FormControl>
+            <input
+              type="date"
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value || undefined)}
+              className={cls}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
     />
   )
 }

--- a/src/components/form/match/fields/theater-name-input-field.tsx
+++ b/src/components/form/match/fields/theater-name-input-field.tsx
@@ -1,30 +1,21 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
-import { FunctionComponent, HTMLAttributes } from 'react'
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { FunctionComponent } from 'react'
 import { useMatchPostFormContext } from '../hooks/match-post-form-context'
 
-interface TheaterNameInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+const cls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-1.5 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const TheaterNameInputField: FunctionComponent<
-  TheaterNameInputFieldProps
-> = () => {
+const TheaterNameInputField: FunctionComponent = () => {
   const { form } = useMatchPostFormContext()
-
   return (
     <FormField
       control={form.control}
       name="theaterName"
       render={({ field }) => (
         <FormItem>
-          <FormLabel>영화관</FormLabel>
+          <label className={labelCls}>영화관</label>
           <FormControl>
-            <Input {...field} placeholder="영화관 이름" />
+            <input {...field} className={cls} placeholder="영화관 이름" />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/src/components/form/match/fields/title-input-field.tsx
+++ b/src/components/form/match/fields/title-input-field.tsx
@@ -1,28 +1,21 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
-import { FunctionComponent, HTMLAttributes } from 'react'
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { FunctionComponent } from 'react'
 import { useMatchPostFormContext } from '../hooks/match-post-form-context'
 
-interface TitleInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+const inputCls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-1.5 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const TitleInputField: FunctionComponent<TitleInputFieldProps> = () => {
+const TitleInputField: FunctionComponent = () => {
   const { form } = useMatchPostFormContext()
-
   return (
     <FormField
       control={form.control}
       name="title"
       render={({ field }) => (
         <FormItem>
-          <FormLabel>제목</FormLabel>
+          <label className={labelCls}>제목</label>
           <FormControl>
-            <Input {...field} placeholder="모집 글 제목을 입력하세요" />
+            <input {...field} className={inputCls} placeholder="모집 글 제목을 입력하세요" />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/src/components/form/match/match-post-form.tsx
+++ b/src/components/form/match/match-post-form.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
 import { Form } from '@/components/ui/form'
 import { FunctionComponent, useState } from 'react'
 import { useMatchPostFormContext } from './hooks/match-post-form-context'
@@ -11,7 +10,6 @@ import { TheaterNameInputField } from './fields/theater-name-input-field'
 import { ShowTimeInputField } from './fields/show-time-input-field'
 import { MaxParticipantsInputField } from './fields/max-participants-input-field'
 import { LocationInputField } from './fields/location-input-field'
-import Box from '@/components/ui/box'
 import { CreateMatchPostRequest } from '@/lib/type'
 
 interface MatchPostFormProps {
@@ -47,36 +45,38 @@ const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
   })
 
   return (
-    <Box className="rounded-lg border p-6">
-      <h2 className="mb-6 text-xl font-semibold">영화 메이트 모집</h2>
+    <Form {...form}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TitleInputField />
+        <ContentInputField />
 
-      <Form {...form}>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <TitleInputField />
-          <ContentInputField />
+        <div className="grid grid-cols-2 gap-3">
+          <MovieTitleInputField />
+          <TheaterNameInputField />
+        </div>
 
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <MovieTitleInputField />
-            <TheaterNameInputField />
-          </div>
+        <ShowTimeInputField />
+        <MaxParticipantsInputField />
+        <LocationInputField />
 
-          <ShowTimeInputField />
-
-          <MaxParticipantsInputField />
-
-          <LocationInputField />
-
-          <div className="flex justify-end gap-2 pt-4">
-            <Button type="button" variant="outline" onClick={onCancel}>
-              취소
-            </Button>
-            <Button type="submit" disabled={isLoading}>
-              {isLoading ? '등록 중...' : '등록하기'}
-            </Button>
-          </div>
-        </form>
-      </Form>
-    </Box>
+        <div className="flex gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 border border-dm-line py-3 font-dm-mono text-[13px] text-dm-text-muted hover:border-dm-amber hover:text-dm-amber"
+          >
+            취소
+          </button>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="flex-1 bg-dm-red py-3 font-dm-mono text-[13px] text-white disabled:bg-dm-surface-2 disabled:text-dm-text-faint"
+          >
+            {isLoading ? '등록 중...' : '등록하기 →'}
+          </button>
+        </div>
+      </form>
+    </Form>
   )
 }
 


### PR DESCRIPTION
## Summary
- `/chat` 플레이스홀더 추가 — BottomNav 탭에서 404 대신 Coming Soon dm 화면
- `/match/new` 전체 dm 스타일 적용 — 폼 필드 네이티브 input 교체, dm 버튼
- `/match/my-matches` 활성화 — 기존 "준비중" 텍스트 제거, dm 테마 전면 적용
- `my-matches-container` 262줄 → 86줄 + `my-applied-matches` 77줄 + `my-created-matches` 59줄 분리

## 변경
- `match-post-form.tsx` Box/Button 의존성 제거
- 매치 폼 7개 필드 Input/Textarea/AppDatePicker → 네이티브 dm 스타일 교체
- `show-time-input-field` `AppDatePicker` → `input[type=date]` 교체

## Test plan
- [ ] /chat 접속 시 Coming Soon 화면 표시 확인
- [ ] /match/new 폼 입력·제출 동작 확인
- [ ] /match/my-matches 신청한 매칭 목록·취소 동작 확인
- [ ] /match/my-matches 내가 만든 매칭 목록·관리 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)