### PR TITLE
💄 회원가입 Cinéma Noir 적용 — 4단계 다크 플로우

### DIFF
--- a/src/components/form/auth/register/fields/id-input-field.tsx
+++ b/src/components/form/auth/register/fields/id-input-field.tsx
@@ -1,79 +1,50 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { FunctionComponent, HTMLAttributes, useState, useEffect } from 'react'
-import { cn } from '@/lib/utils'
-import { Input } from '@/components/ui/input'
-import { useRegisterFormContext } from '../hook/register-form-context'
-import { validateEmail } from '@/lib/utils/validation-api'
+'use client'
+
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
 import { useDebounce } from '@/hooks/use-debounce'
+import { validateEmail } from '@/lib/utils/validation-api'
+import { FunctionComponent, useEffect, useState } from 'react'
+import { useRegisterFormContext } from '../hook/register-form-context'
 
-interface IdInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+const inputCls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-2 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const IdInputField: FunctionComponent<IdInputFieldProps> = ({
-  className,
-  ...props
-}) => {
+const IdInputField: FunctionComponent = () => {
   const { form, setEmailValidationState } = useRegisterFormContext()
   const [isValidating, setIsValidating] = useState(false)
   const [validationMessage, setValidationMessage] = useState('')
-  const [isEmailValid, setIsEmailValid] = useState(false)
-
   const emailValue = form.watch('userId')
   const debouncedEmail = useDebounce(emailValue, 500)
 
   useEffect(() => {
-    const validateEmailAsync = async () => {
-      // 이메일이 변경되면 기존 검증 상태 초기화
-      setIsEmailValid(false)
+    const run = async () => {
+      setValidationMessage('')
       setEmailValidationState({ isValidating: false, isValid: false })
-
-      if (!debouncedEmail || !debouncedEmail.includes('@')) {
-        setValidationMessage('')
+      if (!debouncedEmail?.includes('@')) {
         setIsValidating(false)
         form.clearErrors('userId')
         return
       }
-
       setIsValidating(true)
       setEmailValidationState({ isValidating: true, isValid: false })
-
       try {
         const result = await validateEmail(debouncedEmail)
-
         if (!result.isAvailable) {
-          form.setError('userId', {
-            type: 'manual',
-            message: result.message || '이미 사용 중인 이메일입니다.',
-          })
-          setValidationMessage('이미 사용 중인 이메일입니다.')
-          setIsEmailValid(false)
+          form.setError('userId', { type: 'manual', message: result.message || '이미 사용 중인 이메일입니다.' })
           setEmailValidationState({ isValidating: false, isValid: false })
         } else {
           form.clearErrors('userId')
           setValidationMessage('사용 가능한 이메일입니다.')
-          setIsEmailValid(true)
           setEmailValidationState({ isValidating: false, isValid: true })
         }
-      } catch (error) {
-        console.error('Email validation error:', error)
-        form.setError('userId', {
-          type: 'manual',
-          message: '이메일 검증 중 오류가 발생했습니다.',
-        })
-        setValidationMessage('이메일 검증 중 오류가 발생했습니다.')
-        setIsEmailValid(false)
+      } catch {
+        form.setError('userId', { type: 'manual', message: '이메일 검증 중 오류가 발생했습니다.' })
         setEmailValidationState({ isValidating: false, isValid: false })
       } finally {
         setIsValidating(false)
       }
     }
-
-    validateEmailAsync()
+    run()
   }, [debouncedEmail, form, setEmailValidationState])
 
   return (
@@ -82,28 +53,21 @@ const IdInputField: FunctionComponent<IdInputFieldProps> = ({
       name="userId"
       render={({ field }) => (
         <FormItem>
-          <FormLabel className={cn('text-black')}>아이디</FormLabel>
+          <label className={labelCls}>이메일</label>
           <FormControl>
             <div className="relative">
-              <Input
-                {...field}
-                className={cn('w-full')}
-                placeholder="이메일 주소"
-                type="email"
-              />
+              <input {...field} type="email" placeholder="you@email.com" className={inputCls} />
               {isValidating && (
-                <div className="absolute right-3 top-1/2 -translate-y-1/2 transform">
-                  <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-blue-600"></div>
+                <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-dm-amber border-t-transparent" />
                 </div>
               )}
             </div>
           </FormControl>
-          <div className="h-10">
-            <FormMessage />
-            {validationMessage && !form.formState.errors.userId && (
-              <p className="mt-1 text-sm text-green-600">{validationMessage}</p>
-            )}
-          </div>
+          <FormMessage className="font-dm-mono text-[11px] text-dm-red" />
+          {validationMessage && !form.formState.errors.userId && (
+            <p className="font-dm-mono text-[11px] text-green-400">{validationMessage}</p>
+          )}
         </FormItem>
       )}
     />

--- a/src/components/form/auth/register/fields/nickname-input-field.tsx
+++ b/src/components/form/auth/register/fields/nickname-input-field.tsx
@@ -1,73 +1,47 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { FunctionComponent, HTMLAttributes, useState, useEffect } from 'react'
-import { cn } from '@/lib/utils'
-import { Input } from '@/components/ui/input'
-import { useRegisterFormContext } from '../hook/register-form-context'
-import { validateNickname } from '@/lib/utils/validation-api'
-import { useDebounce } from '@/hooks/use-debounce'
-interface NicknameInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+'use client'
 
-const NicknameInputField: FunctionComponent<NicknameInputFieldProps> = ({
-  className,
-  ...props
-}) => {
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { useDebounce } from '@/hooks/use-debounce'
+import { validateNickname } from '@/lib/utils/validation-api'
+import { FunctionComponent, useEffect, useState } from 'react'
+import { useRegisterFormContext } from '../hook/register-form-context'
+
+const inputCls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-2 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
+
+const NicknameInputField: FunctionComponent = () => {
   const { form, setNicknameValidationState } = useRegisterFormContext()
   const [isValidating, setIsValidating] = useState(false)
   const [validationMessage, setValidationMessage] = useState('')
-
   const nicknameValue = form.watch('nickname')
-  const debouncedNickname = useDebounce(nicknameValue, 500)
+  const debounced = useDebounce(nicknameValue, 500)
 
   useEffect(() => {
-    const validateNicknameAsync = async () => {
+    const run = async () => {
+      setValidationMessage('')
       setNicknameValidationState({ isValidating: false, isValid: false })
-
-      if (!debouncedNickname || debouncedNickname.length < 2) {
-        setValidationMessage('')
-        setIsValidating(false)
-        form.clearErrors('nickname')
-        return
-      }
-
+      if (!debounced || debounced.length < 2) { setIsValidating(false); form.clearErrors('nickname'); return }
       setIsValidating(true)
       setNicknameValidationState({ isValidating: true, isValid: false })
-
       try {
-        const result = await validateNickname(debouncedNickname)
-
+        const result = await validateNickname(debounced)
         if (!result.isAvailable) {
-          form.setError('nickname', {
-            type: 'manual',
-            message: result.message || '이미 사용 중인 닉네임입니다.',
-          })
-          setValidationMessage('이미 사용 중인 닉네임입니다.')
+          form.setError('nickname', { type: 'manual', message: result.message || '이미 사용 중인 닉네임입니다.' })
           setNicknameValidationState({ isValidating: false, isValid: false })
         } else {
           form.clearErrors('nickname')
           setValidationMessage('사용 가능한 닉네임입니다.')
           setNicknameValidationState({ isValidating: false, isValid: true })
         }
-      } catch (error) {
-        console.error('Nickname validation error:', error)
-        form.setError('nickname', {
-          type: 'manual',
-          message: '닉네임 검증 중 오류가 발생했습니다.',
-        })
-        setValidationMessage('닉네임 검증 중 오류가 발생했습니다.')
+      } catch {
+        form.setError('nickname', { type: 'manual', message: '닉네임 검증 중 오류가 발생했습니다.' })
         setNicknameValidationState({ isValidating: false, isValid: false })
       } finally {
         setIsValidating(false)
       }
     }
-
-    validateNicknameAsync()
-  }, [debouncedNickname, form, setNicknameValidationState])
+    run()
+  }, [debounced, form, setNicknameValidationState])
 
   return (
     <FormField
@@ -75,23 +49,24 @@ const NicknameInputField: FunctionComponent<NicknameInputFieldProps> = ({
       name="nickname"
       render={({ field }) => (
         <FormItem>
-          <FormLabel className={cn('text-black')}>닉네임</FormLabel>
+          <label className={labelCls}>
+            닉네임
+          </label>
           <FormControl>
             <div className="relative">
-              <Input {...field} className={cn('w-full')} placeholder="닉네임" />
+              <input {...field} placeholder="@my_handle" className={inputCls} />
               {isValidating && (
-                <div className="absolute right-3 top-1/2 -translate-y-1/2 transform">
-                  <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-blue-600"></div>
+                <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-dm-amber border-t-transparent" />
                 </div>
               )}
             </div>
           </FormControl>
-          <div className="h-10">
-            <FormMessage />
-            {validationMessage && !form.formState.errors.nickname && (
-              <p className="mt-1 text-sm text-green-600">{validationMessage}</p>
-            )}
-          </div>
+          <p className="mt-1 font-dm-mono text-[10px] text-dm-text-faint">한글, 영문, 숫자, _ 사용 가능</p>
+          <FormMessage className="font-dm-mono text-[11px] text-dm-red" />
+          {validationMessage && !form.formState.errors.nickname && (
+            <p className="font-dm-mono text-[11px] text-green-400">{validationMessage}</p>
+          )}
         </FormItem>
       )}
     />

--- a/src/components/form/auth/register/fields/password-input-field.tsx
+++ b/src/components/form/auth/register/fields/password-input-field.tsx
@@ -1,68 +1,28 @@
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form'
-import { FunctionComponent, HTMLAttributes, useState, useEffect } from 'react'
-import { cn } from '@/lib/utils'
-import { Input } from '@/components/ui/input'
+'use client'
+
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { FunctionComponent, useEffect, useState } from 'react'
 import { useRegisterFormContext } from '../hook/register-form-context'
-import { Check, X } from 'lucide-react'
 
-interface PasswordInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
+const inputCls = 'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
+const labelCls = 'mb-2 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
 
-const PasswordInputField: FunctionComponent<PasswordInputFieldProps> = ({
-  className,
-  ...props
-}) => {
+const rules = [
+  { key: 'length', label: '8자 이상', test: (v: string) => v.length >= 8 },
+  { key: 'letter', label: '영문 포함', test: (v: string) => /[a-zA-Z]/.test(v) },
+  { key: 'number', label: '숫자 포함', test: (v: string) => /\d/.test(v) },
+  { key: 'special', label: '특수문자 포함 (@$!%*?&)', test: (v: string) => /[@$!%*?&]/.test(v) },
+]
+
+const PasswordInputField: FunctionComponent = () => {
   const { form } = useRegisterFormContext()
-  const [validationChecks, setValidationChecks] = useState({
-    length: false,
-    hasLetter: false,
-    hasNumber: false,
-    hasSpecial: false,
-  })
-
-  const passwordValue = form.watch('password')
+  const [checks, setChecks] = useState({ length: false, letter: false, number: false, special: false })
+  const pw = form.watch('password')
 
   useEffect(() => {
-    if (!passwordValue) {
-      setValidationChecks({
-        length: false,
-        hasLetter: false,
-        hasNumber: false,
-        hasSpecial: false,
-      })
-      return
-    }
-
-    setValidationChecks({
-      length: passwordValue.length >= 8,
-      hasLetter: /[a-zA-Z]/.test(passwordValue),
-      hasNumber: /\d/.test(passwordValue),
-      hasSpecial: /[@$!%*?&]/.test(passwordValue),
-    })
-  }, [passwordValue])
-
-  const ValidationCheck = ({
-    isValid,
-    text,
-  }: {
-    isValid: boolean
-    text: string
-  }) => (
-    <div
-      className={cn(
-        'flex items-center gap-2 text-sm',
-        isValid ? 'text-green-600' : 'text-gray-400',
-      )}
-    >
-      {isValid ? <Check className="h-4 w-4" /> : <X className="h-4 w-4" />}
-      <span>{text}</span>
-    </div>
-  )
+    if (!pw) { setChecks({ length: false, letter: false, number: false, special: false }); return }
+    setChecks({ length: pw.length >= 8, letter: /[a-zA-Z]/.test(pw), number: /\d/.test(pw), special: /[@$!%*?&]/.test(pw) })
+  }, [pw])
 
   return (
     <FormField
@@ -70,41 +30,23 @@ const PasswordInputField: FunctionComponent<PasswordInputFieldProps> = ({
       name="password"
       render={({ field }) => (
         <FormItem>
-          <FormLabel className={cn('text-black')}>비밀번호</FormLabel>
+          <label className={labelCls}>비밀번호</label>
           <FormControl>
-            <Input
-              {...field}
-              className={cn('w-full')}
-              placeholder="비밀번호"
-              type="password"
-            />
+            <input {...field} type="password" placeholder="••••••••" className={inputCls} />
           </FormControl>
-          <div className="space-y-2">
-            <FormMessage />
-            {passwordValue && (
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-gray-700">
-                  비밀번호 요구사항:
-                </p>
-                <ValidationCheck
-                  isValid={validationChecks.length}
-                  text="최소 8자 이상"
-                />
-                <ValidationCheck
-                  isValid={validationChecks.hasLetter}
-                  text="영문 포함"
-                />
-                <ValidationCheck
-                  isValid={validationChecks.hasNumber}
-                  text="숫자 포함"
-                />
-                <ValidationCheck
-                  isValid={validationChecks.hasSpecial}
-                  text="특수문자 포함 (@$!%*?&)"
-                />
-              </div>
-            )}
-          </div>
+          <FormMessage className="font-dm-mono text-[11px] text-dm-red" />
+          {pw && (
+            <div className="mt-2 space-y-1.5">
+              {rules.map((r) => {
+                const ok = checks[r.key as keyof typeof checks]
+                return (
+                  <div key={r.key} className={`flex items-center gap-2 font-dm-mono text-[11px] ${ok ? 'text-green-400' : 'text-dm-text-faint'}`}>
+                    <span>{ok ? '✓' : '○'}</span>{r.label}
+                  </div>
+                )
+              })}
+            </div>
+          )}
         </FormItem>
       )}
     />

--- a/src/components/form/auth/register/fields/profile-step.tsx
+++ b/src/components/form/auth/register/fields/profile-step.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { FormControl, FormField, FormMessage } from '@/components/ui/form'
+import { FunctionComponent } from 'react'
+import { useRegisterFormContext } from '../hook/register-form-context'
+
+const labelCls = 'mb-2 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
+
+const ProfileStep: FunctionComponent = () => {
+  const { form } = useRegisterFormContext()
+  const genderValue = form.watch('gender')
+  const termsValue = form.watch('termsAgreed')
+
+  const genders: [string, string, string][] = [
+    ['female', '여성', '#e67a9a'],
+    ['male', '남성', '#7aa8e6'],
+  ]
+
+  return (
+    <div className="space-y-6">
+      <FormField
+        control={form.control}
+        name="gender"
+        render={({ field }) => (
+          <div>
+            <div className={labelCls}>
+              성별{' '}
+              <span className="text-dm-amber normal-case tracking-normal">
+                · 매칭에 사용
+              </span>
+            </div>
+            <FormControl>
+              <div className="flex gap-2">
+                {genders.map(([val, label, color]) => (
+                  <button
+                    key={val}
+                    type="button"
+                    onClick={() => field.onChange(val)}
+                    style={{
+                      flex: 1,
+                      padding: 14,
+                      background:
+                        genderValue === val ? color + '22' : 'transparent',
+                      border: `1px solid ${genderValue === val ? color : 'var(--dm-line-2)'}`,
+                      color: genderValue === val ? color : 'var(--dm-text-muted)',
+                      fontFamily: 'inherit',
+                      fontSize: 13,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </FormControl>
+            <FormMessage className="mt-1 font-dm-mono text-[11px] text-dm-red" />
+          </div>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="termsAgreed"
+        render={({ field }) => (
+          <div>
+            <label className="flex cursor-pointer items-start gap-2.5">
+              <input
+                type="checkbox"
+                checked={field.value ?? false}
+                onChange={(e) => field.onChange(e.target.checked)}
+                style={{ accentColor: 'var(--dm-red)', marginTop: 2 }}
+              />
+              <div className="text-[12px] leading-relaxed text-dm-text-muted">
+                <span className="text-dm-text">이용약관</span> 및{' '}
+                <span className="text-dm-text">개인정보 처리방침</span>에
+                동의해요.
+                <br />
+                <span className="font-dm-mono text-[10px] text-dm-text-faint">
+                  (만 14세 이상만 가입 가능합니다)
+                </span>
+              </div>
+            </label>
+            {!termsValue && form.formState.isSubmitted && (
+              <p className="mt-1 font-dm-mono text-[11px] text-dm-red">
+                약관에 동의해주세요.
+              </p>
+            )}
+          </div>
+        )}
+      />
+    </div>
+  )
+}
+
+export { ProfileStep }

--- a/src/components/form/auth/register/multi-step-register-form.tsx
+++ b/src/components/form/auth/register/multi-step-register-form.tsx
@@ -1,403 +1,160 @@
 'use client'
 
 import { Form } from '@/components/ui/form'
-import {
-  FunctionComponent,
-  HTMLAttributes,
-  useState,
-  useMemo,
-  useCallback,
-} from 'react'
-import { Button } from '@/components/ui/button'
-import { IdInputField } from './fields/id-input-field'
-import { PasswordInputField } from './fields/password-input-field'
-import { useRegisterFormContext } from './hook/register-form-context'
-import { NicknameInputField } from './fields/nickname-input-field'
-import { GenderSelectField } from './fields/gender-select-field'
-import { useRegister } from './hook/use-register'
-import { useRouter } from 'next/navigation'
-import { ChevronLeft, Check } from 'lucide-react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { TermsAgreement } from './fields/terms-agreement'
 import { useAppToast } from '@/hooks/use-app-toast'
+import { useRouter } from 'next/navigation'
+import { FunctionComponent, useMemo, useState } from 'react'
+import { useRegister } from './hook/use-register'
+import { useRegisterFormContext } from './hook/register-form-context'
+import { IdInputField } from './fields/id-input-field'
+import { NicknameInputField } from './fields/nickname-input-field'
+import { PasswordInputField } from './fields/password-input-field'
+import { ProfileStep } from './fields/profile-step'
 
-interface MultiStepRegisterFormProps extends HTMLAttributes<HTMLDivElement> {}
+const TOTAL = 4
 
-const MultiStepRegisterForm: FunctionComponent<MultiStepRegisterFormProps> = ({
-  className: _className,
-  ..._props
-}) => {
+const stepTitle: Record<number, string> = {
+  1: '이메일을 알려주세요',
+  2: '비밀번호를\n설정해주세요',
+  3: '닉네임을\n정해주세요',
+  4: '프로필을 만들어요',
+}
+
+const StepDots = ({ step }: { step: number }) => (
+  <div className="flex items-center gap-1.5">
+    {[1, 2, 3, 4].map((n) => (
+      <div
+        key={n}
+        className="h-1 transition-all duration-200"
+        style={{
+          width: n === step ? 18 : 6,
+          background: n <= step ? 'var(--dm-red)' : 'var(--dm-line-2)',
+        }}
+      />
+    ))}
+    <span className="ml-1 font-dm-mono text-[9px] tracking-[1px] text-dm-text-faint">
+      STEP {step}/{TOTAL}
+    </span>
+  </div>
+)
+
+const MultiStepRegisterForm: FunctionComponent = () => {
   const { showToast } = useAppToast()
   const { form, onSubmit, emailValidationState, nicknameValidationState } =
     useRegisterFormContext()
-  const { register: _register, isRegisting } = useRegister()
+  const { isRegisting } = useRegister()
   const router = useRouter()
-  const [currentStep, setCurrentStep] = useState(1)
-  const totalSteps = 5
+  const [step, setStep] = useState(1)
 
-  const handleNext = async () => {
-    let isValid = false
-    let hasValidationError = false
+  const watched = form.watch()
 
-    switch (currentStep) {
-      case 1: {
-        isValid = await form.trigger('termsAgreed')
-        // 약관 동의 확인
-        const termsErrors = form.formState.errors.termsAgreed
-        if (termsErrors || !form.getValues('termsAgreed')) {
-          hasValidationError = true
-        }
-        break
-      }
-      case 2: {
-        isValid = await form.trigger('userId')
-        // 이메일 검증 중이거나 검증 실패한 경우 진행 차단
-        const emailErrors = form.formState.errors.userId
-        const isEmailValidating = emailValidationState.isValidating
-        const isEmailValid = emailValidationState.isValid
-
-        if (
-          emailErrors ||
-          !form.getValues('userId') ||
-          isEmailValidating ||
-          !isEmailValid
-        ) {
-          hasValidationError = true
-        }
-        break
-      }
-      case 3: {
-        isValid = await form.trigger('password')
-        // 비밀번호 검증 실패한 경우 진행 차단
-        const passwordErrors = form.formState.errors.password
-        if (passwordErrors || !form.getValues('password')) {
-          hasValidationError = true
-        }
-        break
-      }
-      case 4: {
-        isValid = await form.trigger('nickname')
-        // 닉네임 검증 중이거나 검증 실패한 경우 진행 차단
-        const nicknameErrors = form.formState.errors.nickname
-        const isNicknameValidating = nicknameValidationState.isValidating
-        const isNicknameValid = nicknameValidationState.isValid
-
-        if (
-          nicknameErrors ||
-          !form.getValues('nickname') ||
-          isNicknameValidating ||
-          !isNicknameValid
-        ) {
-          hasValidationError = true
-        }
-        break
-      }
-      case 5: {
-        isValid = await form.trigger('gender')
-        // 성별 선택 검증
-        const genderErrors = form.formState.errors.gender
-        if (genderErrors || !form.getValues('gender')) {
-          hasValidationError = true
-        }
-        break
-      }
-    }
-
-    if (isValid && !hasValidationError && currentStep < totalSteps) {
-      setCurrentStep(currentStep + 1)
-    }
-  }
-
-  const handleBack = () => {
-    if (currentStep > 1) {
-      setCurrentStep(currentStep - 1)
-    }
-  }
-
-  const handleSubmitClick = async () => {
-    // 먼저 수동으로 validation 실행
-    const isValid = await form.trigger()
-
-    if (isValid) {
-      const data = form.getValues()
-      await onSubmit(
-        data,
-        () => {
-          showToast(
-            '회원가입이 완료되었습니다! 로그인 페이지로 이동합니다.',
-            3000,
-          )
-          form.reset()
-          setTimeout(() => {
-            router.push('/login')
-          }, 1500)
-        },
-        (error: string) => {
-          showToast(error, 3000)
-        },
-      )
-    }
-  }
-
-  const getStepTitle = () => {
-    switch (currentStep) {
+  const isStepValid = useMemo(() => {
+    switch (step) {
       case 1:
-        return '약관에 동의해주세요'
-      case 2:
-        return '이메일을 입력해주세요'
-      case 3:
-        return '비밀번호를 입력해주세요'
-      case 4:
-        return '닉네임을 입력해주세요'
-      case 5:
-        return '성별을 선택해주세요'
-      default:
-        return ''
-    }
-  }
-
-  const getStepSubtitle = () => {
-    switch (currentStep) {
-      case 1:
-        return '서비스 이용을 위해 약관에 동의해주세요.'
-      case 2:
-        return '로그인할 때 사용할 이메일 주소를 입력해주세요.'
-      case 3:
-        return '안전한 비밀번호를 설정해주세요.'
-      case 4:
-        return '다른 사용자들에게 보여질 닉네임을 입력해주세요.'
-      case 5:
-        return '프로필 설정을 위해 성별을 선택해주세요.'
-      default:
-        return ''
-    }
-  }
-
-  // form 값들을 실시간으로 감지
-  const watchedValues = form.watch()
-  const formErrors = form.formState.errors
-
-  const isCurrentStepValid = useMemo(() => {
-    switch (currentStep) {
-      case 1: {
-        const termsAgreed = watchedValues.termsAgreed
-        const hasError = formErrors.termsAgreed
-        return termsAgreed && !hasError
-      }
-      case 2: {
-        const emailValue = watchedValues.userId
-        const hasError = formErrors.userId
-
-        // 이메일이 있고, 에러가 없고, 검증이 완료되었고, 유효한 상태여야 함
-        const isValidEmail =
-          emailValue &&
-          emailValue.includes('@') &&
-          !hasError &&
+        return !!(
+          watched.userId?.includes('@') &&
+          !form.formState.errors.userId &&
           !emailValidationState.isValidating &&
           emailValidationState.isValid
-
-        return isValidEmail
-      }
-      case 3: {
-        const passwordValue = watchedValues.password
-        const hasError = formErrors.password
-
-        // 비밀번호가 있고 에러가 없어야 함
-        const isValidPassword =
-          passwordValue && passwordValue.length >= 8 && !hasError
-
-        return isValidPassword
-      }
-      case 4: {
-        const nicknameValue = watchedValues.nickname
-        const hasError = formErrors.nickname
-
-        // 닉네임이 있고, 에러가 없고, 검증이 완료되었고, 유효한 상태여야 함
-        const isValidNickname =
-          nicknameValue &&
-          nicknameValue.length >= 2 &&
-          !hasError &&
+        )
+      case 2:
+        return !!(
+          watched.password &&
+          watched.password.length >= 8 &&
+          /[a-zA-Z]/.test(watched.password) &&
+          /\d/.test(watched.password) &&
+          /[@$!%*?&]/.test(watched.password) &&
+          !form.formState.errors.password
+        )
+      case 3:
+        return !!(
+          watched.nickname &&
+          watched.nickname.length >= 2 &&
+          !form.formState.errors.nickname &&
           !nicknameValidationState.isValidating &&
           nicknameValidationState.isValid
-
-        return isValidNickname
-      }
-      case 5: {
-        const genderValue = watchedValues.gender
-        const hasError = formErrors.gender
-
-        // 성별이 선택되었고 에러가 없어야 함
-        const isValidGender = genderValue && !hasError
-
-        return isValidGender
-      }
+        )
+      case 4:
+        return !!(watched.gender && watched.termsAgreed)
       default:
         return false
     }
-  }, [
-    currentStep,
-    watchedValues,
-    formErrors,
-    emailValidationState.isValidating,
-    emailValidationState.isValid,
-    nicknameValidationState.isValidating,
-    nicknameValidationState.isValid,
-  ])
+  }, [step, watched, form.formState.errors, emailValidationState, nicknameValidationState])
 
-  // 약관 동의 변경 핸들러를 메모이제이션
-  const handleAgreementChange = useCallback(
-    (isAgreed: boolean) => {
-      const currentValue = form.getValues('termsAgreed')
-      if (currentValue !== isAgreed) {
-        form.setValue('termsAgreed', isAgreed)
-        if (isAgreed) {
-          form.clearErrors('termsAgreed')
-        }
-      }
-    },
-    [form],
-  )
+  const handleNext = () => {
+    if (step < TOTAL) { setStep(step + 1); return }
+    handleSubmit()
+  }
+
+  const handleSubmit = async () => {
+    const isValid = await form.trigger()
+    if (!isValid) return
+    const data = form.getValues()
+    await onSubmit(
+      data,
+      () => {
+        showToast('회원가입이 완료되었습니다!', 3000)
+        form.reset()
+        setTimeout(() => router.push('/login'), 1200)
+      },
+      (err: string) => showToast(err, 3000),
+    )
+  }
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-blue-50 via-white to-indigo-50">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-gray-100 bg-white/80 p-4 backdrop-blur-sm">
+    <div className="flex min-h-page flex-col bg-dm-bg text-dm-text">
+      <div className="flex items-center border-b border-dm-line px-4 py-3.5">
         <button
-          onClick={currentStep > 1 ? handleBack : () => router.back()}
-          className="rounded-full p-2 transition-colors hover:bg-gray-100"
+          onClick={() => (step > 1 ? setStep(step - 1) : router.back())}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full"
+          style={{ background: 'rgba(255,255,255,0.06)' }}
         >
-          <ChevronLeft className="h-6 w-6" />
+          <svg width="8" height="14" viewBox="0 0 8 14">
+            <path d="M7 1L1 7l6 6" stroke="currentColor" strokeWidth="1.8" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
         </button>
-        <div className="text-sm font-medium text-gray-500">
-          {currentStep} / {totalSteps}
+        <div className="ml-3.5 flex-1">
+          <StepDots step={step} />
         </div>
       </div>
 
-      {/* Progress Bar */}
-      <div className="bg-white/80 px-4 py-2 backdrop-blur-sm">
-        <div className="h-1 w-full rounded-full bg-gray-200">
-          <motion.div
-            className="h-1 rounded-full bg-blue-500"
-            initial={{ width: '25%' }}
-            animate={{ width: `${(currentStep / totalSteps) * 100}%` }}
-            transition={{ duration: 0.3 }}
-          />
+      <div className="flex-1 px-6 pb-[120px] pt-6">
+        <div className="font-dm-mono text-[10px] tracking-[2px] text-dm-amber">SIGN UP</div>
+        <div className="mt-1.5 whitespace-pre-line font-dm-display text-[26px] italic leading-tight text-dm-text">
+          {stepTitle[step]}
         </div>
-      </div>
 
-      {/* Main Content */}
-      <div className="flex flex-1 flex-col justify-center px-6 py-8">
-        <motion.div
-          key={currentStep}
-          initial={{ opacity: 0, x: 20 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -20 }}
-          transition={{ duration: 0.3 }}
-          className="space-y-6"
-        >
-          <div className="space-y-2 text-center">
-            <h1 className="text-2xl font-bold text-gray-900">
-              {getStepTitle()}
-            </h1>
-            <p className="leading-relaxed text-gray-600">{getStepSubtitle()}</p>
+        <Form {...form}>
+          <div className="mt-7">
+            {step === 1 && <IdInputField />}
+            {step === 2 && <PasswordInputField />}
+            {step === 3 && <NicknameInputField />}
+            {step === 4 && <ProfileStep />}
           </div>
-
-          <Form {...form}>
-            <div className="space-y-4">
-              <AnimatePresence mode="wait">
-                {currentStep === 1 && (
-                  <motion.div
-                    key="step1"
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <TermsAgreement
-                      onAgreementChange={handleAgreementChange}
-                      isValid={watchedValues.termsAgreed || false}
-                    />
-                  </motion.div>
-                )}
-                {currentStep === 2 && (
-                  <motion.div
-                    key="step2"
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <IdInputField />
-                  </motion.div>
-                )}
-                {currentStep === 3 && (
-                  <motion.div
-                    key="step3"
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <PasswordInputField />
-                  </motion.div>
-                )}
-                {currentStep === 4 && (
-                  <motion.div
-                    key="step4"
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <NicknameInputField />
-                  </motion.div>
-                )}
-                {currentStep === 5 && (
-                  <motion.div
-                    key="step5"
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <GenderSelectField />
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </div>
-          </Form>
-        </motion.div>
+        </Form>
       </div>
 
-      {/* Bottom Button */}
-      <div className="border-t border-gray-100 bg-white p-6">
-        {currentStep < totalSteps ? (
-          <Button
-            onClick={handleNext}
-            disabled={!isCurrentStepValid}
-            className="h-14 w-full rounded-xl bg-blue-500 text-lg font-semibold shadow-lg transition-all duration-200 hover:bg-blue-600 disabled:bg-gray-200 disabled:text-gray-400"
-          >
-            다음
-          </Button>
-        ) : (
-          <Button
-            onClick={handleSubmitClick}
-            disabled={!isCurrentStepValid || isRegisting}
-            className="flex h-14 w-full items-center justify-center gap-2 rounded-xl bg-blue-500 text-lg font-semibold shadow-lg transition-all duration-200 hover:bg-blue-600 disabled:bg-gray-200 disabled:text-gray-400"
-          >
-            {isRegisting ? (
-              <>
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                회원가입 중...
-              </>
-            ) : (
-              <>
-                <Check className="h-5 w-5" />
-                회원가입 완료
-              </>
-            )}
-          </Button>
-        )}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-20 border-t border-dm-line px-4 py-4"
+        style={{
+          background: 'rgba(10,10,12,0.95)',
+          backdropFilter: 'blur(10px)',
+          maxWidth: 'var(--app-max-width)',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+        }}
+      >
+        <button
+          onClick={handleNext}
+          disabled={!isStepValid || isRegisting}
+          className="w-full py-3.5 text-[14px] font-bold text-white transition-opacity"
+          style={{
+            background: 'var(--dm-red)',
+            opacity: isStepValid && !isRegisting ? 1 : 0.4,
+          }}
+        >
+          {step < TOTAL ? '다음 →' : isRegisting ? '가입 중...' : '🎟  drunkenmovie 시작하기'}
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
디자인 스펙(`auth-screens.jsx` SignupScreen)에 맞춰 회원가입 화면을 전면 재설계.

## 변경
- 5단계(약관·이메일·비밀번호·닉네임·성별) → 4단계(이메일→비밀번호→닉네임→성별+약관) 재구성
- `StepDots` 진행 표시: 파란 progress bar → 빨간 pill 도트 (디자인 spec)
- 헤더: 서클 백버튼 + StepDots
- 타이틀: Playfair Display italic 26px
- 입력 필드 전체 dm-surface / dm-line-2 / dm-amber focus 스타일
- 비밀번호 규칙 표시: Lucide 아이콘 → `✓` / `○` mono 기호
- 성별 선택: 컬러 보더 flat (핑크/블루 rounded 제거)
- 약관: 전체 아코디언 마크다운 렌더러 → 한 줄 체크박스
- CTA: `🎟 drunkenmovie 시작하기` (최종 단계), opacity 0.4 disabled

## Test plan
- [ ] /register — 4단계 진행 확인
- [ ] 이메일 중복 검증 동작 확인
- [ ] 비밀번호 체크 ✓/○ 표시 확인
- [ ] 닉네임 중복 검증 동작 확인
- [ ] 성별 선택 + 약관 동의 후 가입 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)