### PR TITLE
🐛 회원가입 이메일·닉네임 검증 BFF 라우트 추가

### DIFF
--- a/src/app/api/auth/validate/email/route.ts
+++ b/src/app/api/auth/validate/email/route.ts
@@ -1,0 +1,29 @@
+import { AppBackEndApiEndpoint } from '@/config/app-backend-api-endpoint'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const { email } = await request.json()
+
+    if (!email) {
+      return NextResponse.json({ isAvailable: false, message: '이메일을 입력해주세요.' }, { status: 400 })
+    }
+
+    const res = await fetch(AppBackEndApiEndpoint.validateEmail(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+
+    if (!res.ok) throw new Error(`Backend responded ${res.status}`)
+
+    const data = await res.json()
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('validate/email error:', error)
+    return NextResponse.json(
+      { isAvailable: false, message: '이메일 검증 중 오류가 발생했습니다.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/auth/validate/nickname/route.ts
+++ b/src/app/api/auth/validate/nickname/route.ts
@@ -1,0 +1,29 @@
+import { AppBackEndApiEndpoint } from '@/config/app-backend-api-endpoint'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const { nickname } = await request.json()
+
+    if (!nickname) {
+      return NextResponse.json({ isAvailable: false, message: '닉네임을 입력해주세요.' }, { status: 400 })
+    }
+
+    const res = await fetch(AppBackEndApiEndpoint.validateNickname(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nickname }),
+    })
+
+    if (!res.ok) throw new Error(`Backend responded ${res.status}`)
+
+    const data = await res.json()
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('validate/nickname error:', error)
+    return NextResponse.json(
+      { isAvailable: false, message: '닉네임 검증 중 오류가 발생했습니다.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/modules/auth/auth-datasource.ts
+++ b/src/modules/auth/auth-datasource.ts
@@ -9,52 +9,31 @@ import {
 export class AuthDataSource {
   async validateEmail(email: string): Promise<ValidationResponse> {
     try {
-      const response = await fetch(AppBackEndApiEndpoint.validateEmail(), {
+      const response = await fetch('/api/auth/validate/email', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        cache: 'default',
-        body: JSON.stringify({
-          email: email,
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
       })
-
-      if (!response.ok) {
-        throw new Error('Failed to validate email')
-      }
-
+      if (!response.ok) throw new Error('Failed to validate email')
       return await response.json()
     } catch (error) {
       console.error('Email validation error:', error)
-      return {
-        isAvailable: false,
-        message: '이메일 검증 중 오류가 발생했습니다.',
-      }
+      return { isAvailable: false, message: '이메일 검증 중 오류가 발생했습니다.' }
     }
   }
 
   async validateNickname(nickname: string): Promise<ValidationResponse> {
     try {
-      const response = await fetch(AppBackEndApiEndpoint.validateNickname(), {
+      const response = await fetch('/api/auth/validate/nickname', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ nickname }),
       })
-
-      if (!response.ok) {
-        throw new Error('Failed to validate nickname')
-      }
-
+      if (!response.ok) throw new Error('Failed to validate nickname')
       return await response.json()
     } catch (error) {
       console.error('Nickname validation error:', error)
-      return {
-        isAvailable: false,
-        message: '닉네임 검증 중 오류가 발생했습니다.',
-      }
+      return { isAvailable: false, message: '닉네임 검증 중 오류가 발생했습니다.' }
     }
   }
 


### PR DESCRIPTION
## 원인
`auth-datasource.ts`가 `AppBackEndApiEndpoint`(= `NEXT_PUBLIC_SERVER_API/auth/validate/...`) 를 클라이언트 사이드에서 직접 호출.
프로덕션 환경에서 브라우저가 백엔드 내부 URL에 접근 불가 → fetch 실패 → "이메일 검증 중 오류" 표시.

## 변경
- `POST /api/auth/validate/email` BFF 라우트 추가 (서버 사이드에서 백엔드 호출)
- `POST /api/auth/validate/nickname` BFF 라우트 추가
- `auth-datasource.ts` validate 메서드: 백엔드 직접 호출 → `/api/auth/validate/*` BFF 경유

## Test plan
- [ ] /register 이메일 입력 → "사용 가능한 이메일입니다." 정상 표시 확인
- [ ] 중복 이메일 입력 → "이미 사용 중인 이메일입니다." 정상 표시 확인
- [ ] 닉네임 입력 → 검증 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)