### PR TITLE
🐛 회원가입 최종 제출 BFF 라우트 추가

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,25 @@
+import { UsersRepository } from '@/modules/users/users-repository'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const { email, password, nickname, gender } = await request.json()
+
+    if (!email || !password || !nickname || !gender) {
+      return NextResponse.json(
+        { success: false, message: '모든 필드를 입력해주세요.' },
+        { status: 400 },
+      )
+    }
+
+    const repo = new UsersRepository()
+    const data = await repo.signUp({ userId: email, password, nickname, gender })
+    return NextResponse.json({ success: true, message: '회원가입이 완료되었습니다.', ...data })
+  } catch (error) {
+    console.error('signup route error:', error)
+    return NextResponse.json(
+      { success: false, message: '회원가입 중 오류가 발생했습니다.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/modules/auth/auth-datasource.ts
+++ b/src/modules/auth/auth-datasource.ts
@@ -39,11 +39,9 @@ export class AuthDataSource {
 
   async register(data: RegisterRequest): Promise<AuthResponse> {
     try {
-      const response = await fetch(AppBackEndApiEndpoint.signUp(), {
+      const response = await fetch('/api/auth/signup', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           email: data.userId,
           password: data.password,
@@ -52,23 +50,12 @@ export class AuthDataSource {
           marketingAgreed: data.marketingAgreed || false,
         }),
       })
-
-      if (!response.ok) {
-        throw new Error('Failed to register')
-      }
-
+      if (!response.ok) throw new Error('Failed to register')
       const result = await response.json()
-      return {
-        success: true,
-        message: '회원가입이 완료되었습니다.',
-        ...result,
-      }
+      return { success: true, message: '회원가입이 완료되었습니다.', ...result }
     } catch (error) {
       console.error('Register error:', error)
-      return {
-        success: false,
-        message: '회원가입 중 오류가 발생했습니다.',
-      }
+      return { success: false, message: '회원가입 중 오류가 발생했습니다.' }
     }
   }
 


### PR DESCRIPTION
## 원인
`auth-datasource.register()`가 `AppBackEndApiEndpoint.signUp()`(= `NEXT_PUBLIC_SERVER_API/user`)를 브라우저 클라이언트에서 직접 fetch. 프로덕션에서 백엔드 내부 URL 접근 불가 → "회원가입 중 오류" 반환.

## 변경
- `POST /api/auth/signup` BFF 라우트 추가: `UsersRepository.signUp()` 서버 사이드 경유
- `auth-datasource.ts` register: 백엔드 직접 호출 → `/api/auth/signup` BFF 경유

## Test plan
- [ ] /register 4단계 완료 후 "🎟 drunkenmovie 시작하기" 클릭 → 회원가입 성공 확인
- [ ] /login 으로 리다이렉트 + 토스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)