### PR TITLE
🐛 매치 목록 undefined 오류 수정

### DIFF
--- a/src/app/(root)/(routes)/match/hooks/use-match-posts.ts
+++ b/src/app/(root)/(routes)/match/hooks/use-match-posts.ts
@@ -32,8 +32,12 @@ export const useMatchPosts = (pageSize: number = 10) => {
       revalidateOnFocus: true,
     })
 
-  // 모든 페이지의 matchPosts를 평면화
-  const matchPosts = data ? data.flatMap((page) => page.matchPosts) : []
+  // 모든 페이지의 matchPosts를 평면화 (null/undefined 방어)
+  const matchPosts = data
+    ? data.flatMap((page) => page?.matchPosts ?? []).filter(
+        (m): m is NonNullable<typeof m> => m != null,
+      )
+    : []
 
   // 다음 페이지가 있는지 확인
   const hasMore =

--- a/src/app/(root)/(routes)/match/sections/match-list-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-list-section.tsx
@@ -85,7 +85,7 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
   return (
     <>
       <div className="flex flex-col gap-3.5 px-4 py-4">
-        {matchPosts.map((match) => (
+        {matchPosts.filter(Boolean).map((match) => (
           <div key={match.id} className="relative">
             <DmMatchTicket match={match} />
             <button

--- a/src/app/api/match/route.ts
+++ b/src/app/api/match/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const page = parseInt(searchParams.get('page') || '1')
-    const limit = parseInt(searchParams.get('limit') || '10')
+    const limit = parseInt(searchParams.get('pageSize') || searchParams.get('limit') || '10')
 
     const token = getTokenFromCookie()
     const matchRepository = new MatchPostRepository(token)


### PR DESCRIPTION
## 원인
`matchPosts.map()` 중 배열에 `undefined` 항목 포함 → `e.currentParticipants` 접근 시 TypeError.

백엔드 gRPC 응답에서 `matchPosts` 필드 또는 배열 내 항목이 null/undefined로 내려오는 경우 방어 미흡.

## 변경
- `use-match-posts.ts`: `flatMap` 후 `.filter(m => m != null)` 추가
- `match-list-section.tsx`: `.map()` 전 `.filter(Boolean)` 추가
- `/api/match` BFF: `searchParams.get('limit')` → `pageSize || limit` 우선순위 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)