### PR TITLE
💄 영화 댓글 입력창 fixed → inline 통합

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/components/comment-form.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/components/comment-form.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
 import { Form } from '@/components/ui/form'
 import { useRouter } from 'next/navigation'
 import { FunctionComponent } from 'react'
@@ -19,10 +18,7 @@ const CommentForm: FunctionComponent<CommentFormProps> = ({ id }) => {
 
   const handleSubmit = form.handleSubmit((data) => {
     createComment(
-      {
-        comment: data.comment,
-        movieId: id,
-      },
+      { comment: data.comment, movieId: id },
       {
         onSuccess: () => {
           form.reset()
@@ -35,15 +31,15 @@ const CommentForm: FunctionComponent<CommentFormProps> = ({ id }) => {
   return (
     <Form {...form}>
       <form onSubmit={handleSubmit}>
-        <div className="flex w-full flex-row items-center gap-2">
-          <CommentInputField />
-          <Button
+        <CommentInputField />
+        <div className="flex justify-end border-t border-dm-line px-3 py-2">
+          <button
             type="submit"
             disabled={isCreatingComment}
-            className="rounded-none border border-dm-red bg-dm-red px-3 text-[12px] font-semibold text-white hover:bg-dm-red-deep"
+            className="bg-dm-red px-4 py-1.5 font-dm-mono text-[11px] uppercase tracking-[0.5px] text-white disabled:bg-dm-surface-2 disabled:text-dm-text-faint"
           >
-            등록
-          </Button>
+            {isCreatingComment ? '등록 중...' : '등록 →'}
+          </button>
         </div>
       </form>
     </Form>

--- a/src/app/(root)/(routes)/movie/[id]/components/comment-input-field.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/components/comment-input-field.tsx
@@ -1,31 +1,21 @@
 import { FormControl, FormField, FormItem } from '@/components/ui/form'
-import { FunctionComponent, HTMLAttributes } from 'react'
-import { cn } from '@/lib/utils'
-import { Textarea } from '@/components/ui/textarea'
+import { FunctionComponent } from 'react'
 import { useCommentFormContext } from '../hooks/comment-form-context'
 
-interface CommentInputFieldProps extends HTMLAttributes<HTMLDivElement> {}
-
-const CommentInputField: FunctionComponent<CommentInputFieldProps> = ({
-  className,
-  ...props
-}) => {
+const CommentInputField: FunctionComponent = () => {
   const { form } = useCommentFormContext()
   return (
     <FormField
       control={form.control}
       name="comment"
       render={({ field }) => (
-        <FormItem className="w-full">
-          <FormControl className="w-full">
-            <Textarea
+        <FormItem>
+          <FormControl>
+            <textarea
               {...field}
-              className={cn(
-                'w-full resize-none rounded-none border border-dm-line-2 bg-dm-surface text-[13px] text-dm-text placeholder:text-dm-text-faint focus-visible:ring-1 focus-visible:ring-dm-amber focus-visible:ring-offset-0',
-                className,
-              )}
+              rows={3}
               placeholder="이 영화에 대해 쓰기..."
-              rows={1}
+              className="w-full resize-none bg-transparent px-3 py-3 text-[13px] text-dm-text placeholder:text-dm-text-faint focus:outline-none"
             />
           </FormControl>
         </FormItem>

--- a/src/app/(root)/(routes)/movie/[id]/page.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/page.tsx
@@ -5,7 +5,6 @@ import { ModifyCommentModalContextProvider } from './hooks/use-modify-comment-co
 import { VodModalContextProvider } from './hooks/use-vod-modal-context'
 import { buildBreadcrumbJsonLd, buildMovieJsonLd } from './json-ld'
 import { generateMovieMetadata } from './metadata'
-import ActiveSection from './sections/active-section'
 import CommentSection from './sections/comment-section'
 import DescriptionSection from './sections/description-section'
 
@@ -41,16 +40,15 @@ const Page: FunctionComponent<PageProps> = async ({ params: { id } }) => {
       />
       <div
         id="movie-detail-page"
-        className="relative flex flex-col bg-dm-bg pb-[140px] text-dm-text"
+        className="relative flex flex-col bg-dm-bg pb-[88px] text-dm-text"
       >
         <ModifyCommentModalContextProvider>
           <VodModalContextProvider>
             <DescriptionSection id={id} />
-            <CommentSection />
+            <CommentSection id={id} />
           </VodModalContextProvider>
         </ModifyCommentModalContextProvider>
       </div>
-      <ActiveSection id={id} />
     </>
   )
 }

--- a/src/app/(root)/(routes)/movie/[id]/sections/comment-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/comment-section.tsx
@@ -5,74 +5,90 @@ import { Reply } from '@/lib/type'
 import { useSession } from 'next-auth/react'
 import { FunctionComponent } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
+import { CommentForm } from '../components/comment-form'
 import { ModifyCommentModal } from '../components/modify-comment-modal'
+import { CommentFormProvider } from '../hooks/comment-form-context'
 import { ModifyCommentFormProvider } from '../hooks/modify-comment-context'
 import { useComments } from '../hooks/use-comments'
 import { useModifyCommentModalContext } from '../hooks/use-modify-comment-context'
 
-const CommentSection: FunctionComponent = () => {
+interface CommentSectionProps {
+  id: string
+}
+
+const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
   const { data, next, hasMore, isLoading, error } = useComments()
   const session = useSession()
   const userId = session.data?.user?.id
   const { deleteComment } = useComments()
   const { setOpen, setComment, setReplyId } = useModifyCommentModalContext()
+
   const handleModifyComment = (reply: Reply) => {
     setReplyId(reply.id)
     setComment(reply.content)
     setOpen(true)
   }
-  if (isLoading)
-    return (
-      <div className="flex h-[40vh] items-center justify-center text-dm-text-muted">
-        로딩 중...
-      </div>
-    )
-  if (!data) return null
 
-  const totalCount = data.reduce(
-    (acc, page) => acc + (page?.comments?.length ?? 0),
-    0,
-  )
+  const totalCount = data
+    ? data.reduce((acc, page) => acc + (page?.comments?.length ?? 0), 0)
+    : 0
 
   return (
-    <section className="bg-dm-bg px-4 pb-20 text-dm-text">
+    <section className="bg-dm-bg px-4 pb-10 text-dm-text">
       <SectionHead meta={totalCount.toLocaleString()}>리뷰</SectionHead>
-      <InfiniteScroll
-        dataLength={data.length}
-        next={next}
-        hasMore={hasMore}
-        loader={
-          <div className="py-4 text-center font-dm-mono text-[11px] text-dm-text-faint">
-            로딩 중...
-          </div>
-        }
-      >
-        <div>
-          {data.map((page) =>
-            page?.comments?.map((comment: Reply) => (
-              <DmReviewCard
-                key={comment.id}
-                reply={{
-                  id: comment.id,
-                  content: comment.content,
-                  userno: comment.userno,
-                  nickname: comment.nickname,
-                  updatedAt: new Date(comment.updatedAt),
-                  createdAt: new Date(comment.createdAt),
-                }}
-                onDelete={() => deleteComment({ commentId: comment.id })}
-                onModify={handleModifyComment}
-                userId={userId}
-              />
-            )),
-          )}
+
+      {/* 인라인 댓글 입력 */}
+      <div className="mb-5 border border-dm-line bg-dm-surface">
+        <CommentFormProvider>
+          <CommentForm id={id} />
+        </CommentFormProvider>
+      </div>
+
+      {/* 댓글 목록 */}
+      {isLoading ? (
+        <div className="flex h-[20vh] items-center justify-center font-dm-mono text-[12px] text-dm-text-faint">
+          loading...
         </div>
-      </InfiniteScroll>
+      ) : (
+        <InfiniteScroll
+          dataLength={data?.length ?? 0}
+          next={next}
+          hasMore={hasMore}
+          loader={
+            <div className="py-3 text-center font-dm-mono text-[11px] text-dm-text-faint">
+              loading...
+            </div>
+          }
+        >
+          <div>
+            {data?.map((page) =>
+              page?.comments?.map((comment: Reply) => (
+                <DmReviewCard
+                  key={comment.id}
+                  reply={{
+                    id: comment.id,
+                    content: comment.content,
+                    userno: comment.userno,
+                    nickname: comment.nickname,
+                    updatedAt: new Date(comment.updatedAt),
+                    createdAt: new Date(comment.createdAt),
+                  }}
+                  onDelete={() => deleteComment({ commentId: comment.id })}
+                  onModify={handleModifyComment}
+                  userId={userId}
+                />
+              )),
+            )}
+          </div>
+        </InfiniteScroll>
+      )}
+
       <ModifyCommentFormProvider>
         <ModifyCommentModal />
       </ModifyCommentFormProvider>
+
       {error && (
-        <div className="text-center text-dm-red">
+        <div className="py-4 text-center font-dm-mono text-[11px] text-dm-red">
           데이터를 불러오는데 실패했습니다.
         </div>
       )}


### PR DESCRIPTION
## Summary
fixed 댓글 입력바를 제거하고 댓글 섹션 상단에 inline으로 통합.

## 변경
- `ActiveSection` (fixed bottom) 완전 제거
- `CommentSection`에 `id` prop 추가 + 폼 상단 inline 배치
- 입력창: border 박스 내 textarea + 하단 오른쪽 정렬 등록 버튼
- `page.tsx`: `pb-[140px]` → `pb-[88px]`, ActiveSection import 제거

## Before / After
- Before: 댓글 입력창이 화면 하단에 fixed, footer·콘텐츠 위에 겹침
- After: 리뷰 섹션 상단에 자연스럽게 배치, 스크롤로 접근

🤖 Generated with [Claude Code](https://claude.com/claude-code)