### PR TITLE
✨ sitemap.xml, robots.txt 추가

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/account/', '/api/'],
+      },
+    ],
+    sitemap: 'https://drunkenmovie.shop/sitemap.xml',
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MovieRepository } from '@/modules/movie'
+import { MetadataRoute } from 'next'
+
+const BASE_URL = 'https://drunkenmovie.shop'
+
+const STATIC_ROUTES: MetadataRoute.Sitemap = [
+  { url: BASE_URL, lastModified: new Date() },
+  { url: `${BASE_URL}/match`, lastModified: new Date() },
+  { url: `${BASE_URL}/articles`, lastModified: new Date() },
+]
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  try {
+    const repo = new MovieRepository()
+    const movies = await repo.getMovie()
+
+    const movieRoutes: MetadataRoute.Sitemap = movies.map((movie) => ({
+      url: `${BASE_URL}/movie/${movie.id}`,
+      lastModified: movie.updatedAt ?? new Date(),
+    }))
+
+    return [...STATIC_ROUTES, ...movieRoutes]
+  } catch {
+    return STATIC_ROUTES
+  }
+}


### PR DESCRIPTION
## Summary
- `sitemap.ts`: 홈/매칭/아티클 정적 라우트 + 영화 상세 페이지 동적 생성 (MovieRepository 호출)
- `robots.ts`: `/account/`, `/api/` 크롤링 차단, sitemap URL 등록
- 영화 API 실패 시 정적 라우트만 반환하는 fallback 처리

## Test plan
- [ ] `/sitemap.xml` 접근 시 XML 정상 출력 확인
- [ ] `/robots.txt` 접근 시 내용 확인
- [ ] 영화 목록이 sitemap에 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)