### PR TITLE
💄 shadcn dark zinc 디자인 전면 적용

### DIFF
--- a/src/app/(root)/(routes)/(auth)/login/page.tsx
+++ b/src/app/(root)/(routes)/(auth)/login/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import AuthButton from '@/app/(root)/(routes)/(auth)/login/components/oAuthButton'
-import { DmLoginForm, DmLoginMarquee } from '@/components/dm'
+import { DmLoginForm } from '@/components/dm'
 import { AppPath } from '@/config/app-path'
 import { signIn } from 'next-auth/react'
 import Link from 'next/link'
@@ -13,47 +12,44 @@ const Page: FunctionComponent = () => {
   const callbackUrl = searchParams?.get('callbackUrl') ?? AppPath.home()
 
   return (
-    <main className="flex min-h-page flex-col bg-dm-bg text-dm-text">
-      <DmLoginMarquee />
-
-      <div className="flex-1 px-6 py-6">
-        <DmLoginForm />
-
-        <div className="my-5 flex items-center gap-2">
-          <span
-            aria-hidden
-            className="h-px flex-1 border-t border-dashed border-dm-line-2"
-          />
-          <span className="font-dm-mono text-[10px] text-dm-text-faint">
-            OR
-          </span>
-          <span
-            aria-hidden
-            className="h-px flex-1 border-t border-dashed border-dm-line-2"
-          />
+    <main className="flex min-h-page flex-col px-6 py-10">
+      <div className="mb-8">
+        <div className="text-[22px] font-bold tracking-tight text-foreground">
+          drunken<span className="text-primary">movie</span>
         </div>
+        <p className="mt-1 text-[13px] text-muted-foreground">오늘 밤, 같이 볼 사람을 찾아보세요</p>
+      </div>
 
-        <AuthButton
-          provider="google"
-          onClick={() => signIn('google', { callbackUrl })}
-          className="flex w-full items-center justify-center gap-2 border border-dm-line-2 bg-transparent px-3 py-3 text-[13px] text-dm-text hover:border-dm-amber"
-        >
-          <span className="font-bold">G</span> Google로 계속하기
-        </AuthButton>
+      <h2 className="mb-1.5 text-[22px] font-semibold tracking-tight text-foreground">로그인</h2>
+      <p className="mb-6 text-[13px] text-muted-foreground">이메일과 비밀번호를 입력하세요</p>
 
-        <div className="mt-5 text-center text-[12px] text-dm-text-muted">
-          아직 계정이 없으신가요?{' '}
-          <Link
-            href={AppPath.register()}
-            className="text-dm-text underline underline-offset-2 hover:text-dm-amber"
-          >
-            회원가입
-          </Link>
-        </div>
+      <DmLoginForm />
 
-        <div className="mt-2 text-center font-dm-mono text-[10px] tracking-[0.5px] text-dm-amber">
-          ※ 매칭 이용을 위해 성별 정보가 필요해요
-        </div>
+      <div className="my-5 flex items-center gap-3">
+        <span className="h-px flex-1 bg-border" />
+        <span className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">or</span>
+        <span className="h-px flex-1 bg-border" />
+      </div>
+
+      <button
+        type="button"
+        onClick={() => signIn('google', { callbackUrl })}
+        className="flex h-10 w-full items-center justify-center gap-2 rounded-md border border-border text-[14px] font-medium text-foreground hover:bg-accent"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
+          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+        </svg>
+        Google로 계속하기
+      </button>
+
+      <div className="mt-auto pt-8 text-center">
+        <span className="text-[13px] text-muted-foreground">아직 계정이 없으신가요? </span>
+        <Link href={AppPath.register()} className="text-[13px] font-medium text-foreground hover:underline">
+          회원가입
+        </Link>
       </div>
     </main>
   )

--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -68,22 +68,17 @@ const Page: FunctionComponent = async () => {
   const grid = top10.slice(1)
 
   return (
-    <main className="bg-dm-bg pb-5 text-dm-text">
+    <main className="pb-5">
       <MatchHeroBanner todayLabel={TODAY_LABEL} liveCount={24} nearbyCount={7} />
 
-      <div className="flex items-baseline px-4 pt-3 pb-2">
-        <h2 className="font-dm-display text-[18px] font-bold">
-          박스오피스{' '}
-          <span className="italic text-dm-red">TOP 10</span>
-        </h2>
-        <span className="ml-auto font-dm-mono text-[10px] tracking-[0.5px] text-dm-text-faint">
-          KOFIC
-        </span>
+      <div className="flex items-center gap-2 px-4 pb-2 pt-5">
+        <h2 className="text-[16px] font-semibold text-foreground">박스오피스</h2>
+        <span className="font-mono text-[11px] text-muted-foreground">KOFIC · TOP 10</span>
       </div>
 
       {featured && <TopFeaturedCard movie={featured} />}
 
-      <div className="mx-4 mb-4 grid grid-cols-3 gap-2 md:grid-cols-4">
+      <div className="mx-4 mb-4 grid grid-cols-3 gap-3 md:grid-cols-4">
         {grid.map((movie, i) => (
           <TopGridCard key={movie.id} movie={movie} rank={i + 2} />
         ))}

--- a/src/app/(root)/(routes)/match/sections/match-header-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-header-section.tsx
@@ -3,15 +3,15 @@ import Link from 'next/link'
 
 const MatchHeaderSection: FunctionComponent = () => {
   return (
-    <div className="flex items-center border-b border-dm-line px-4 py-3.5">
-      <h1 className="break-keep whitespace-nowrap font-dm-display text-[20px] italic font-bold text-dm-text">
+    <div className="flex items-center border-b border-border px-4 py-3.5">
+      <h1 className="text-[18px] font-bold tracking-tight text-foreground">
         같이 볼 사람
       </h1>
       <Link
         href="/match/new"
-        className="ml-auto inline-flex items-center gap-1 whitespace-nowrap bg-dm-red px-2.5 py-1.5 text-[11px] font-semibold text-white"
+        className="ml-auto inline-flex h-8 items-center rounded-md bg-primary px-3 text-[13px] font-medium text-primary-foreground"
       >
-        ＋ 쓰기
+        ＋ 만들기
       </Link>
     </div>
   )

--- a/src/app/(root)/(routes)/match/sections/match-list-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-list-section.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent, useEffect, useRef, useCallback } from 'react'
-import { Button } from '@/components/ui/button'
 import { DmMatchTicket } from '@/components/dm'
 import { MatchApplyDialog } from '@/components/app/match-apply-dialog'
 
@@ -29,13 +28,10 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
   const observerRef = useRef<IntersectionObserver | null>(null)
   const loadMoreElementRef = useRef<HTMLDivElement | null>(null)
 
-  // Intersection Observer를 사용한 무한 스크롤 구현
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
       const [target] = entries
-      if (target.isIntersecting && hasMore && !isLoading) {
-        loadMore()
-      }
+      if (target.isIntersecting && hasMore && !isLoading) loadMore()
     },
     [hasMore, isLoading, loadMore],
   )
@@ -43,27 +39,15 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
   useEffect(() => {
     const element = loadMoreElementRef.current
     if (!element) return
-
-    if (observerRef.current) {
-      observerRef.current.disconnect()
-    }
-
-    observerRef.current = new IntersectionObserver(handleObserver, {
-      threshold: 0.1,
-    })
-
+    observerRef.current?.disconnect()
+    observerRef.current = new IntersectionObserver(handleObserver, { threshold: 0.1 })
     observerRef.current.observe(element)
-
-    return () => {
-      if (observerRef.current) {
-        observerRef.current.disconnect()
-      }
-    }
+    return () => observerRef.current?.disconnect()
   }, [handleObserver])
 
   if (isLoading && matchPosts.length === 0) {
     return (
-      <div className="py-8 text-center font-dm-mono text-[11px] text-dm-text-muted">
+      <div className="py-8 text-center font-mono text-[12px] text-muted-foreground">
         매치를 불러오는 중...
       </div>
     )
@@ -71,34 +55,26 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
 
   if (matchPosts.length === 0 && !isLoading) {
     return (
-      <div className="py-12 text-center text-dm-text-muted">
-        <p>아직 등록된 매치가 없습니다.</p>
-        <p className="mt-1 text-[12px] text-dm-text-faint">
-          첫 번째 매치를 등록해보세요!
-        </p>
+      <div className="py-12 text-center text-muted-foreground">
+        <p className="text-[14px]">아직 등록된 매치가 없습니다.</p>
+        <p className="mt-1 text-[12px]">첫 번째 매치를 등록해보세요!</p>
       </div>
     )
   }
 
-  const onTicketApply = (matchId: string) => onApply(matchId)
-
   return (
     <>
-      <div className="flex flex-col gap-3.5 px-4 py-4">
+      <div className="flex flex-col gap-3 px-4 py-3">
         {matchPosts.filter(Boolean).map((match) => (
-          <div key={match.id} className="relative">
+          <div key={match.id}>
             <DmMatchTicket match={match} />
             <button
               type="button"
-              onClick={() => onTicketApply(match.id)}
-              className="mt-1.5 w-full border border-dm-line-2 bg-dm-surface-2 py-2 text-[12px] font-semibold text-dm-text hover:border-dm-amber"
-              disabled={
-                match.currentParticipants >= match.maxParticipants
-              }
+              onClick={() => onApply(match.id)}
+              disabled={match.currentParticipants >= match.maxParticipants}
+              className="mt-2 h-9 w-full rounded-md border border-border text-[13px] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {match.currentParticipants >= match.maxParticipants
-                ? '모집완료'
-                : '🎟 신청하기'}
+              {match.currentParticipants >= match.maxParticipants ? '모집완료' : '신청하기'}
             </button>
           </div>
         ))}
@@ -106,25 +82,10 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
 
       <div ref={loadMoreElementRef} className="py-4">
         {isLoading && matchPosts.length > 0 && (
-          <div className="text-center font-dm-mono text-[11px] text-dm-text-muted">
-            불러오는 중...
-          </div>
-        )}
-        {hasMore && !isLoading && (
-          <div className="px-4 text-center">
-            <Button
-              variant="outline"
-              onClick={loadMore}
-              className="w-full max-w-xs border-dm-line-2 bg-transparent text-dm-text hover:bg-dm-surface"
-            >
-              더 보기
-            </Button>
-          </div>
+          <div className="text-center font-mono text-[11px] text-muted-foreground">불러오는 중...</div>
         )}
         {!hasMore && matchPosts.length > 0 && (
-          <div className="text-center font-dm-mono text-[11px] text-dm-text-faint">
-            — END —
-          </div>
+          <div className="text-center font-mono text-[11px] text-muted-foreground">— 끝 —</div>
         )}
       </div>
 

--- a/src/app/(root)/(routes)/movie/[id]/components/comment-form.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/components/comment-form.tsx
@@ -32,13 +32,13 @@ const CommentForm: FunctionComponent<CommentFormProps> = ({ id }) => {
     <Form {...form}>
       <form onSubmit={handleSubmit}>
         <CommentInputField />
-        <div className="flex justify-end border-t border-dm-line px-3 py-2">
+        <div className="flex justify-end border-t border-border px-3 py-2">
           <button
             type="submit"
             disabled={isCreatingComment}
-            className="bg-dm-red px-4 py-1.5 font-dm-mono text-[11px] uppercase tracking-[0.5px] text-white disabled:bg-dm-surface-2 disabled:text-dm-text-faint"
+            className="h-8 rounded-md bg-primary px-4 font-mono text-[12px] text-primary-foreground disabled:opacity-50"
           >
-            {isCreatingComment ? '등록 중...' : '등록 →'}
+            {isCreatingComment ? '등록 중...' : '등록'}
           </button>
         </div>
       </form>

--- a/src/app/(root)/(routes)/movie/[id]/components/comment-input-field.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/components/comment-input-field.tsx
@@ -15,7 +15,7 @@ const CommentInputField: FunctionComponent = () => {
               {...field}
               rows={3}
               placeholder="이 영화에 대해 쓰기..."
-              className="w-full resize-none bg-transparent px-3 py-3 text-[13px] text-dm-text placeholder:text-dm-text-faint focus:outline-none"
+              className="w-full resize-none bg-transparent px-3 py-3 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none"
             />
           </FormControl>
         </FormItem>

--- a/src/app/(root)/(routes)/movie/[id]/sections/comment-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/comment-section.tsx
@@ -34,19 +34,17 @@ const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
     : 0
 
   return (
-    <section className="bg-dm-bg px-4 pb-10 text-dm-text">
+    <section className="px-4 pb-10">
       <SectionHead meta={totalCount.toLocaleString()}>리뷰</SectionHead>
 
-      {/* 인라인 댓글 입력 */}
-      <div className="mb-5 border border-dm-line bg-dm-surface">
+      <div className="mb-5 rounded-lg border border-border bg-card">
         <CommentFormProvider>
           <CommentForm id={id} />
         </CommentFormProvider>
       </div>
 
-      {/* 댓글 목록 */}
       {isLoading ? (
-        <div className="flex h-[20vh] items-center justify-center font-dm-mono text-[12px] text-dm-text-faint">
+        <div className="flex h-[20vh] items-center justify-center font-mono text-[12px] text-muted-foreground">
           loading...
         </div>
       ) : (
@@ -55,7 +53,7 @@ const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
           next={next}
           hasMore={hasMore}
           loader={
-            <div className="py-3 text-center font-dm-mono text-[11px] text-dm-text-faint">
+            <div className="py-3 text-center font-mono text-[11px] text-muted-foreground">
               loading...
             </div>
           }
@@ -88,7 +86,7 @@ const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
       </ModifyCommentFormProvider>
 
       {error && (
-        <div className="py-4 text-center font-dm-mono text-[11px] text-dm-red">
+        <div className="py-4 text-center font-mono text-[11px] text-destructive">
           데이터를 불러오는데 실패했습니다.
         </div>
       )}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,17 +11,16 @@ import { MessageModalContextProvider } from '@/hooks/use-message-modal-context'
 import { cn } from '@/lib/utils'
 import { SessionProvider } from '@/providers/session-provider'
 import '@/styles/globals.css'
-import { Roboto } from 'next/font/google'
+import { Inter } from 'next/font/google'
 import Script from 'next/script'
 import { siteMetadata, siteJsonLd } from './site-metadata'
 
 export const metadata = siteMetadata
 
-const roboto = Roboto({
-  weight: ['400', '700'],
-  style: ['normal', 'italic'],
+const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
+  variable: '--font-inter',
 })
 
 // dm 폰트는 runtime <link> 로 로드한다.
@@ -37,7 +36,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <head>
-        {/* dm 폰트 — runtime fetch (build network 우회) */}
+        {/* Geist Mono — runtime fetch (build network 우회) */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"
@@ -45,7 +44,7 @@ export default function RootLayout({
           crossOrigin="anonymous"
         />
         <link
-          href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=IBM+Plex+Mono:wght@400;500&family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&display=swap"
           rel="stylesheet"
         />
         {/* Google Tag Manager */}
@@ -114,7 +113,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           href="/favicon/favicon-256x256.png"
         />
       </head>
-      <body className={cn('bg-dm-bg text-dm-text', roboto.className)}>
+      <body className={cn('bg-background text-foreground antialiased', inter.className, inter.variable)}>
         {/* Google Tag Manager (noscript) */}
         <noscript>
           <iframe

--- a/src/components/dm/bottom-nav.tsx
+++ b/src/components/dm/bottom-nav.tsx
@@ -9,7 +9,6 @@ interface NavItem {
   label: string
   href: string
   icon: JSX.Element
-  isMatch?: boolean
 }
 
 const ITEMS: NavItem[] = [
@@ -23,8 +22,7 @@ const ITEMS: NavItem[] = [
     key: 'match',
     label: '매칭',
     href: '/match',
-    icon: <path d="M4 7h16M4 12h10M4 17h7M18 14l3 3-3 3M16 17h5" />,
-    isMatch: true,
+    icon: <path d="M4 7h16M4 12h10M4 17h7" />,
   },
   {
     key: 'chat',
@@ -50,48 +48,33 @@ function activeKey(pathname: string): NavItem['key'] {
 export function DmBottomNav() {
   const pathname = usePathname() ?? '/'
   const active = activeKey(pathname)
+
   return (
-    <nav className="sticky bottom-0 z-20 flex h-[72px] border-t border-dm-line bg-dm-bg/[0.92] backdrop-blur-md">
+    <nav className="sticky bottom-0 z-20 grid h-16 grid-cols-4 border-t border-border bg-background">
       {ITEMS.map((it) => {
         const isActive = active === it.key
-        const accentRed = it.isMatch && isActive
         return (
           <Link
             key={it.key}
             href={it.href}
             className={cn(
-              'relative flex flex-1 flex-col items-center gap-0.5 pt-2.5',
-              isActive
-                ? accentRed
-                  ? 'text-dm-red'
-                  : 'text-dm-text'
-                : 'text-dm-text-faint',
+              'flex flex-col items-center justify-center gap-0.5 text-[11px] font-medium transition-colors',
+              isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
             )}
           >
-            {isActive && (
-              <span
-                className={cn(
-                  'absolute top-0 h-0.5 w-7',
-                  accentRed ? 'bg-dm-red' : 'bg-dm-amber',
-                )}
-                aria-hidden
-              />
-            )}
             <svg
-              width="22"
-              height="22"
+              width="20"
+              height="20"
               viewBox="0 0 24 24"
-              fill={accentRed ? 'currentColor' : 'none'}
+              fill="none"
               stroke="currentColor"
-              strokeWidth="1.6"
+              strokeWidth="1.8"
               strokeLinecap="round"
               strokeLinejoin="round"
             >
               {it.icon}
             </svg>
-            <span className="font-dm-mono text-[10px] uppercase tracking-[0.5px]">
-              {it.label}
-            </span>
+            {it.label}
           </Link>
         )
       })}

--- a/src/components/dm/dm-app-bar.tsx
+++ b/src/components/dm/dm-app-bar.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import HeaderActiveButton from '@/components/layout/header-active-button'
 import { signIn, useSession } from 'next-auth/react'
 import Link from 'next/link'
 
@@ -10,28 +9,33 @@ export function DmAppBar() {
   const isLoading = status === 'loading'
 
   return (
-    <header className="sticky top-0 z-30 flex items-center border-b border-dm-line bg-dm-bg/95 px-4 py-2.5 backdrop-blur-md">
-      <Link
-        href="/"
-        className="font-dm-display text-[20px] italic font-bold tracking-[-0.01em] text-dm-text"
-      >
-        drunken<span className="text-dm-red">movie</span>
+    <header className="sticky top-0 z-30 flex items-center border-b border-border bg-background/95 px-4 py-3 backdrop-blur-md">
+      <Link href="/" className="text-[17px] font-bold tracking-[-0.02em] text-foreground">
+        drunken<span className="text-primary">movie</span>
       </Link>
 
       <div className="ml-auto flex items-center gap-2">
         {isLoading && (
-          <span className="font-dm-mono text-[10px] text-dm-text-faint">
-            ···
-          </span>
+          <span className="font-mono text-[11px] text-muted-foreground">···</span>
         )}
-        {isLogin && <HeaderActiveButton />}
+        {isLogin && (
+          <Link
+            href="/account"
+            className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 8a6 6 0 10-12 0c0 7-3 9-3 9h18s-3-2-3-9"/>
+              <path d="M13.7 21a2 2 0 01-3.4 0"/>
+            </svg>
+          </Link>
+        )}
         {!isLoading && !isLogin && (
           <button
             type="button"
             onClick={() => signIn()}
-            className="border border-dm-line-2 px-3 py-1.5 font-dm-mono text-[11px] uppercase tracking-[0.5px] text-dm-text-muted hover:border-dm-amber hover:text-dm-amber"
+            className="h-9 rounded-md border border-border px-3 text-[13px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
           >
-            Login
+            로그인
           </button>
         )}
       </div>

--- a/src/components/dm/dm-desktop-left-nav.tsx
+++ b/src/components/dm/dm-desktop-left-nav.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useSession } from 'next-auth/react'
+import { cn } from '@/lib/utils'
 
 const NAV = [
   {
@@ -13,8 +14,8 @@ const NAV = [
   },
   {
     href: '/match',
-    label: '같이 볼 사람',
-    icon: <><path d="M4 7h16M4 12h10M4 17h7" /><path d="M18 14l3 3-3 3M16 17h5" /></>,
+    label: '매칭',
+    icon: <path d="M4 7h16M4 12h10M4 17h7" />,
   },
   {
     href: '/chat',
@@ -33,8 +34,6 @@ const NAV = [
   },
 ]
 
-const BROWSE = ['박스오피스', '장르별', '개봉 예정작']
-
 function NavItem({ href, label, icon, exact }: (typeof NAV)[number]) {
   const pathname = usePathname()
   const isActive = exact ? pathname === href : !!pathname?.startsWith(href)
@@ -42,13 +41,14 @@ function NavItem({ href, label, icon, exact }: (typeof NAV)[number]) {
   return (
     <Link
       href={href}
-      className={`flex items-center gap-2.5 px-3 py-2.5 text-[13px] transition-colors ${
+      className={cn(
+        'flex items-center gap-2.5 rounded-md px-3 py-2 text-[14px] transition-colors',
         isActive
-          ? 'border-l-2 border-dm-red bg-dm-surface pl-[10px] text-dm-text'
-          : 'text-dm-text-muted hover:text-dm-text'
-      }`}
+          ? 'bg-secondary text-foreground'
+          : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+      )}
     >
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
         {icon}
       </svg>
       {label}
@@ -62,43 +62,28 @@ export function DmDesktopLeftNav() {
   const initial = user?.nickname?.charAt(0).toUpperCase() ?? '?'
 
   return (
-    <aside className="hidden lg:sticky lg:top-0 lg:flex lg:h-screen lg:w-[240px] lg:shrink-0 lg:flex-col lg:overflow-y-auto lg:border-r lg:border-dm-line" style={{ background: '#0e0e12' }}>
+    <aside className="hidden lg:sticky lg:top-0 lg:flex lg:h-screen lg:w-[240px] lg:shrink-0 lg:flex-col lg:overflow-y-auto lg:border-r lg:border-border">
       <div className="px-4 pb-4 pt-5">
-        <Link href="/" className="font-dm-display text-[22px] italic font-bold tracking-[-0.01em]">
-          drunken<span className="text-dm-red">movie</span>
+        <Link href="/" className="text-[18px] font-bold tracking-[-0.02em] text-foreground">
+          drunken<span className="text-primary">movie</span>
         </Link>
       </div>
 
-      <nav className="flex-1 px-2">
+      <nav className="flex-1 space-y-0.5 px-2">
         {NAV.map((item) => (
           <NavItem key={item.href} {...item} />
-        ))}
-
-        <div className="mt-4 px-3 pb-1.5 font-dm-mono text-[10px] uppercase tracking-[1.5px] text-dm-text-faint">
-          탐색
-        </div>
-        {BROWSE.map((label) => (
-          <div
-            key={label}
-            className="px-3 py-2 text-[13px] text-dm-text-muted"
-          >
-            {label}
-          </div>
         ))}
       </nav>
 
       {user && (
-        <div className="border-t border-dm-line px-4 py-3.5">
+        <div className="border-t border-border px-4 py-3.5">
           <div className="flex items-center gap-2.5">
-            <div
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[13px] font-bold text-white"
-              style={{ background: 'linear-gradient(135deg, var(--dm-red) 0%, var(--dm-red-deep) 100%)' }}
-            >
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-secondary text-[13px] font-bold text-foreground">
               {initial}
             </div>
             <div className="min-w-0">
-              <div className="truncate text-[12px] font-semibold text-dm-text">{user.nickname}</div>
-              <div className="font-dm-mono text-[10px] text-dm-text-faint">Lv.1</div>
+              <div className="truncate text-[13px] font-semibold text-foreground">{user.nickname}</div>
+              <div className="font-mono text-[10px] text-muted-foreground">멤버</div>
             </div>
           </div>
         </div>

--- a/src/components/dm/dm-login-form.tsx
+++ b/src/components/dm/dm-login-form.tsx
@@ -4,11 +4,6 @@ import { signIn } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 
-const inputCls =
-  'w-full border border-dm-line-2 bg-dm-surface px-3.5 py-3 text-[14px] text-dm-text placeholder:text-dm-text-faint focus:border-dm-amber focus:outline-none'
-const labelCls =
-  'mb-1.5 block font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-text-muted'
-
 export function DmLoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -38,49 +33,47 @@ export function DmLoginForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div className="mb-4 font-dm-display text-[22px] italic text-dm-text">
-        Sign in.
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="userId" className="mb-1.5 block text-[13px] font-medium text-foreground">
+          이메일
+        </label>
+        <input
+          id="userId"
+          type="text"
+          autoComplete="username"
+          placeholder="name@example.com"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          className="h-10 w-full rounded-md border border-input bg-transparent px-3 text-[14px] text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+        />
       </div>
 
-      <label className={labelCls} htmlFor="userId">
-        이메일
-      </label>
-      <input
-        id="userId"
-        type="text"
-        autoComplete="username"
-        placeholder="you@email.com"
-        value={userId}
-        onChange={(e) => setUserId(e.target.value)}
-        className={inputCls}
-      />
-
-      <label className={`${labelCls} mt-3.5`} htmlFor="password">
-        비밀번호
-      </label>
-      <input
-        id="password"
-        type="password"
-        autoComplete="current-password"
-        placeholder="••••••••"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        className={inputCls}
-      />
+      <div>
+        <label htmlFor="password" className="mb-1.5 block text-[13px] font-medium text-foreground">
+          비밀번호
+        </label>
+        <input
+          id="password"
+          type="password"
+          autoComplete="current-password"
+          placeholder="••••••••"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="h-10 w-full rounded-md border border-input bg-transparent px-3 text-[14px] text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+        />
+      </div>
 
       {error && (
-        <div className="mt-2 font-dm-mono text-[11px] text-dm-red">
-          {error}
-        </div>
+        <p className="text-[12px] text-destructive">{error}</p>
       )}
 
       <button
         type="submit"
         disabled={isSubmitting || !userId || !password}
-        className="mt-4 w-full bg-dm-red py-3.5 text-[14px] font-bold text-white disabled:bg-dm-surface-2 disabled:text-dm-text-faint"
+        className="h-11 w-full rounded-md bg-primary text-[14px] font-medium text-primary-foreground disabled:opacity-50"
       >
-        {isSubmitting ? '로그인 중...' : '로그인 →'}
+        {isSubmitting ? '로그인 중...' : '로그인'}
       </button>
     </form>
   )

--- a/src/components/dm/dm-match-ticket.tsx
+++ b/src/components/dm/dm-match-ticket.tsx
@@ -2,21 +2,12 @@
 
 import { MatchPost } from '@/lib/type'
 import { useRouter } from 'next/navigation'
-import { Pill } from './pill'
 
 interface DmMatchTicketProps {
   match: MatchPost
 }
 
-const DOW = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
-
-function ticketSerial(match: MatchPost): string {
-  const showTime = new Date(match.showTime)
-  const mm = String(showTime.getMonth() + 1).padStart(2, '0')
-  const dd = String(showTime.getDate()).padStart(2, '0')
-  const idShort = String(match.id).slice(0, 5).toUpperCase().padStart(5, '0')
-  return `DM-${idShort}-${mm}${dd}`
-}
+const DOW = ['일', '월', '화', '수', '목', '금', '토']
 
 function dDay(showTime: string): number {
   const target = new Date(showTime).getTime()
@@ -27,6 +18,7 @@ function dDay(showTime: string): number {
 export function DmMatchTicket({ match }: DmMatchTicketProps) {
   const router = useRouter()
   const showTime = new Date(match.showTime)
+  const month = String(showTime.getMonth() + 1).padStart(2, '0')
   const day = String(showTime.getDate()).padStart(2, '0')
   const dow = DOW[showTime.getDay()]
   const time = showTime.toLocaleTimeString('ko-KR', {
@@ -36,95 +28,41 @@ export function DmMatchTicket({ match }: DmMatchTicketProps) {
   })
   const dd = dDay(match.showTime)
   const initial = match.author?.trim().charAt(0).toUpperCase() ?? '?'
-  const tags: string[] = []
-  if (match.gender === 'male') tags.push('남성만')
-  else if (match.gender === 'female') tags.push('여성만')
+  const isFull = match.currentParticipants >= match.maxParticipants
 
   return (
     <button
       type="button"
       onClick={() => router.push(`/match/${match.id}`)}
-      className="relative grid w-full cursor-pointer grid-cols-[62px_1fr_56px] border border-dm-line-2 bg-dm-surface text-left shadow-[0_2px_0_rgba(0,0,0,0.3)]"
+      className="w-full cursor-pointer rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-accent"
     >
-      {/* punch holes */}
-      <span
-        aria-hidden
-        className="absolute left-[-9px] top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border border-dm-line-2 bg-dm-bg shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)]"
-      />
-      <span
-        aria-hidden
-        className="absolute right-[-9px] top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border border-dm-line-2 bg-dm-bg shadow-[inset_0_1px_2px_rgba(0,0,0,0.6)]"
-      />
+      <div className="flex items-center gap-3">
+        {/* poster/date stub */}
+        <div className="flex h-12 w-12 shrink-0 flex-col items-center justify-center rounded-md bg-secondary text-center">
+          <div className="font-mono text-[18px] font-bold leading-none text-foreground">{day}</div>
+          <div className="mt-0.5 font-mono text-[10px] text-muted-foreground">{month}월 {dow}요일</div>
+        </div>
 
-      {/* date stub */}
-      <div
-        className="border-r border-dashed border-dm-line-2 px-1 pb-2.5 pt-3.5 text-center"
-        style={{
-          background:
-            'linear-gradient(180deg, transparent 0%, rgba(192,48,40,0.05) 100%)',
-        }}
-      >
-        <div className="font-dm-rank text-[28px] leading-none text-dm-amber">
-          {day}
-        </div>
-        <div className="mt-0.5 font-dm-mono text-[9px] tracking-[0.5px] text-dm-text-muted">
-          {dow}
-        </div>
-        <div className="mt-1.5 font-dm-mono text-[11px] text-dm-text">
-          {time}
-        </div>
-        <div
-          className="mt-2 h-4 opacity-55"
-          style={{
-            background:
-              'repeating-linear-gradient(90deg, var(--dm-text) 0 1px, transparent 1px 2px, var(--dm-text) 2px 4px, transparent 4px 5px, var(--dm-text) 5px 7px, transparent 7px 9px)',
-          }}
-          aria-hidden
-        />
-      </div>
-
-      {/* body */}
-      <div className="min-w-0 px-3 py-2.5">
-        <div className="mb-0.5 font-dm-mono text-[8px] tracking-[0.5px] text-dm-text-faint">
-          {ticketSerial(match)}
-        </div>
-        <div className="truncate font-dm-display text-[13px] italic font-semibold text-dm-text">
-          {match.movieTitle}
-        </div>
-        <div className="mt-1 truncate text-[11px] text-dm-text-muted">
-          📍 {match.theaterName}
-        </div>
-        <div className="mt-0.5 text-[11px] text-dm-text-muted">
-          👥{' '}
-          <span className="font-semibold text-dm-amber">
-            {match.currentParticipants}
-          </span>
-          <span className="text-dm-text-faint">
-            /{match.maxParticipants}명
-          </span>
-          <span className="ml-1.5 font-dm-mono text-[10px] text-dm-red">
-            D-{dd >= 0 ? dd : 0}
-          </span>
-        </div>
-        {tags.length > 0 && (
-          <div className="mt-1.5 flex flex-wrap gap-1">
-            {tags.map((t) => (
-              <Pill key={t}>{t}</Pill>
-            ))}
+        {/* body */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-[13px] font-semibold text-foreground">{match.movieTitle}</span>
+            <span className={`ml-auto shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px] font-medium ${isFull ? 'bg-muted text-muted-foreground' : 'border border-border text-muted-foreground'}`}>
+              D-{dd >= 0 ? dd : 0}
+            </span>
           </div>
-        )}
-      </div>
-
-      {/* host */}
-      <div className="flex min-w-0 flex-col items-center justify-center border-l border-dashed border-dm-line-2 px-1 py-2.5 text-center">
-        <div className="font-dm-mono text-[8px] tracking-[0.5px] text-dm-text-faint">
-          HOST
-        </div>
-        <div className="mt-1 flex h-8 w-8 items-center justify-center rounded-full border border-dm-line-2 bg-dm-surface-2 text-[13px] font-bold text-dm-text">
-          {initial}
-        </div>
-        <div className="mt-1 max-w-[54px] truncate font-dm-mono text-[9px] text-dm-text">
-          @{match.author}
+          <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+            📍 {match.theaterName}
+          </div>
+          <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span>{time}</span>
+            <span className="font-mono">
+              👥 <span className="text-foreground font-medium">{match.currentParticipants}</span>/{match.maxParticipants}명
+            </span>
+            <div className="ml-auto flex h-5 w-5 items-center justify-center rounded-full bg-secondary text-[10px] font-bold text-foreground">
+              {initial}
+            </div>
+          </div>
         </div>
       </div>
     </button>

--- a/src/components/dm/dm-review-card.tsx
+++ b/src/components/dm/dm-review-card.tsx
@@ -24,29 +24,22 @@ function formatWhen(input: Date | string | undefined): string {
   return d.toLocaleDateString('ko-KR')
 }
 
-export function DmReviewCard({
-  reply,
-  userId,
-  onModify,
-  onDelete,
-}: DmReviewCardProps) {
+export function DmReviewCard({ reply, userId, onModify, onDelete }: DmReviewCardProps) {
   if (!reply) return null
   const initial = reply.nickname?.trim().charAt(0).toUpperCase() ?? '?'
   const isOwner = userId !== undefined && +userId === reply.userno
 
   return (
-    <article className="border-b border-dm-line py-3">
+    <article className="border-b border-border py-3">
       <header className="flex items-center gap-2">
         <span
           aria-hidden
-          className="flex h-7 w-7 items-center justify-center rounded-full border border-dm-line-2 bg-dm-surface-2 text-[11px] font-bold text-dm-text"
+          className="flex h-7 w-7 items-center justify-center rounded-full bg-secondary text-[11px] font-bold text-foreground"
         >
           {initial}
         </span>
-        <span className="text-[13px] font-semibold text-dm-text">
-          {reply.nickname}
-        </span>
-        <span className="ml-auto font-dm-mono text-[10px] text-dm-text-faint">
+        <span className="text-[13px] font-medium text-foreground">{reply.nickname}</span>
+        <span className="ml-auto font-mono text-[11px] text-muted-foreground">
           {formatWhen(reply.updatedAt)}
         </span>
         {isOwner && (
@@ -56,7 +49,7 @@ export function DmReviewCard({
                 type="button"
                 aria-label="수정"
                 onClick={() => onModify(reply)}
-                className="text-dm-text-faint transition hover:text-dm-amber"
+                className="text-muted-foreground transition hover:text-foreground"
               >
                 <Pencil className="h-3.5 w-3.5" />
               </button>
@@ -66,7 +59,7 @@ export function DmReviewCard({
                 type="button"
                 aria-label="삭제"
                 onClick={() => onDelete(reply)}
-                className="text-dm-text-faint transition hover:text-dm-red"
+                className="text-muted-foreground transition hover:text-destructive"
               >
                 <X className="h-3.5 w-3.5" />
               </button>
@@ -74,7 +67,7 @@ export function DmReviewCard({
           </span>
         )}
       </header>
-      <p className="mt-1.5 break-keep text-[13px] leading-[1.6] text-dm-text">
+      <p className="mt-1.5 break-keep text-[13px] leading-relaxed text-foreground">
         {reply.content}
       </p>
     </article>

--- a/src/components/dm/match-hero-banner.tsx
+++ b/src/components/dm/match-hero-banner.tsx
@@ -6,52 +6,33 @@ interface MatchHeroBannerProps {
   nearbyCount?: number
 }
 
-export function MatchHeroBanner({
-  todayLabel,
-  liveCount,
-  nearbyCount,
-}: MatchHeroBannerProps) {
+export function MatchHeroBanner({ todayLabel, liveCount, nearbyCount }: MatchHeroBannerProps) {
   return (
-    <Link
-      href="/match"
-      className="relative m-4 block overflow-hidden rounded border border-dm-line-2 p-4"
-      style={{
-        background: 'linear-gradient(135deg, var(--dm-surface) 0%, #1a0a0a 100%)',
-      }}
-    >
-      <div
-        className="pointer-events-none absolute right-0 top-0 h-full w-20"
-        style={{
-          background:
-            'repeating-linear-gradient(90deg, transparent 0 8px, rgba(192,48,40,0.12) 8px 10px)',
-        }}
-        aria-hidden
-      />
-      <div className="font-dm-mono text-[10px] uppercase tracking-[1px] text-dm-amber">
-        {todayLabel}
-      </div>
-      <div className="mt-1 mb-0.5 font-dm-display text-[22px] italic leading-[1.2] text-dm-text break-keep [text-wrap:balance]">
-        오늘 밤, 같이 볼래요?
-      </div>
-      <div className="mb-3 text-[12px] text-dm-text-muted">
-        지금 매칭 중인 사람{' '}
-        <span className="font-semibold text-dm-amber">
-          {liveCount ?? 0}명
-        </span>
-        {nearbyCount !== undefined && (
-          <>
-            {' · '}내 근처 <b className="text-dm-text">{nearbyCount}명</b>
-          </>
+    <div className="px-4 pt-5 pb-2">
+      <div className="font-mono text-[11px] text-muted-foreground">{todayLabel}</div>
+      <h1 className="mt-1 text-[24px] font-bold leading-[1.2] tracking-tight text-foreground">
+        오늘 밤,<br />같이 볼래요?
+      </h1>
+      <p className="mt-1.5 text-[13px] text-muted-foreground">
+        지금 모집 중인 영화 약속
+        {liveCount !== undefined && (
+          <> · 모집 <span className="font-semibold text-foreground">{liveCount}개</span></>
         )}
+      </p>
+      <div className="mt-4 flex gap-2">
+        <Link
+          href="/match/new"
+          className="flex h-9 flex-1 items-center justify-center rounded-md bg-primary text-[13px] font-medium text-primary-foreground"
+        >
+          ＋ 매칭 만들기
+        </Link>
+        <Link
+          href="/match"
+          className="flex h-9 flex-1 items-center justify-center rounded-md border border-border text-[13px] font-medium text-foreground hover:bg-accent"
+        >
+          둘러보기
+        </Link>
       </div>
-      <div className="flex gap-2">
-        <span className="inline-flex items-center gap-1.5 bg-dm-red px-4 py-2.5 text-[13px] font-semibold tracking-[-0.01em] text-white">
-          🎟 매칭 둘러보기
-        </span>
-        <span className="border border-dm-line-2 px-3 py-2.5 text-[13px] text-dm-text">
-          ＋ 내 글 쓰기
-        </span>
-      </div>
-    </Link>
+    </div>
   )
 }

--- a/src/components/dm/section-head.tsx
+++ b/src/components/dm/section-head.tsx
@@ -11,13 +11,13 @@ export function SectionHead({ children, meta, className }: SectionHeadProps) {
   return (
     <div
       className={cn(
-        'mt-5 mb-2 flex items-baseline font-dm-display text-[15px] font-bold text-dm-text',
+        'mt-5 mb-2 flex items-baseline text-[15px] font-semibold text-foreground',
         className,
       )}
     >
       <span>{children}</span>
       {meta !== undefined && (
-        <span className="ml-1.5 font-dm-mono text-[11px] text-dm-text-faint">
+        <span className="ml-1.5 font-mono text-[11px] text-muted-foreground">
           {meta}
         </span>
       )}

--- a/src/components/dm/top-featured-card.tsx
+++ b/src/components/dm/top-featured-card.tsx
@@ -1,6 +1,5 @@
 import { Movie } from '@/modules/movie/movie.entity'
 import Link from 'next/link'
-import { Pill } from './pill'
 import { Poster } from './poster'
 import { paletteForMovie } from './poster-palette'
 import { Stars } from './stars'
@@ -16,51 +15,44 @@ export function TopFeaturedCard({ movie }: TopFeaturedCardProps) {
   const audience = movie.audience ?? 0
   const rankInten = movie.rankInten ?? 0
   const genres = movie.genre?.split(/[,/·]/).map((g) => g.trim()).filter(Boolean) ?? []
-  const year = movie.openedAt
-    ? new Date(movie.openedAt).getFullYear()
-    : undefined
+  const year = movie.openedAt ? new Date(movie.openedAt).getFullYear() : undefined
 
   return (
     <Link
       href={`/movie/${movie.id}`}
-      className="mx-4 mb-2.5 grid cursor-pointer grid-cols-[110px_1fr] gap-3 border border-dm-line bg-dm-surface p-2.5"
+      className="mx-4 mb-3 flex cursor-pointer gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent"
     >
-      <div className="relative">
+      <div className="relative w-[100px] shrink-0">
         <Poster title={movie.title} palette={palette} imageUrl={movie.poster} />
-        <span className="absolute left-0 top-0 bg-dm-red px-2 py-0.5 font-dm-rank text-[22px] leading-none text-white">
-          01
-        </span>
-        <span className="absolute right-1.5 top-1.5 border border-dm-amber/30 bg-black/70 px-1.5 py-0.5 font-dm-mono text-[9px] tracking-[0.5px] text-dm-amber">
-          🔥 HOT
+        <span className="absolute left-0 top-0 rounded-br rounded-tl bg-primary px-2 py-0.5 font-mono text-[11px] font-bold text-primary-foreground">
+          #1
         </span>
       </div>
-      <div className="flex flex-col justify-between pb-1">
+      <div className="flex min-w-0 flex-col justify-between py-0.5">
         <div>
-          <div className="font-dm-mono text-[10px] uppercase tracking-[0.8px] text-dm-text-muted">
+          <div className="font-mono text-[11px] text-muted-foreground">
             {[...genres.slice(0, 2), year].filter(Boolean).join(' · ')}
           </div>
-          <div className="mt-1 font-dm-display text-[24px] italic leading-[1.1] text-dm-text">
+          <div className="mt-1.5 text-[20px] font-bold leading-tight tracking-tight text-foreground">
             {movie.title}
           </div>
         </div>
         <div>
           <div className="flex items-center gap-1.5">
-            <Stars value={rating} size={11} />
-            <span className="font-dm-rank text-[18px] leading-none text-dm-amber">
-              {rating.toFixed(1)}
-            </span>
-            <span className="text-[11px] text-dm-text-faint">
-              · 리뷰 {reviews.toLocaleString()}
-            </span>
+            <Stars value={rating} size={12} />
+            <span className="text-[16px] font-bold text-foreground">{rating.toFixed(1)}</span>
+            <span className="text-[11px] text-muted-foreground">· 리뷰 {reviews.toLocaleString()}</span>
           </div>
-          <div className="mt-1.5 flex gap-1">
-            {rankInten !== 0 && (
-              <Pill>
-                {rankInten > 0 ? `▲ ${rankInten}` : `▼ ${-rankInten}`}
-              </Pill>
-            )}
-            {audience > 0 && <Pill>{(audience / 10000).toFixed(0)}만명</Pill>}
-          </div>
+          {audience > 0 && (
+            <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+              👥 {(audience / 10000).toFixed(0)}만명
+              {rankInten !== 0 && (
+                <span className={rankInten > 0 ? ' ml-2 text-green-400' : ' ml-2 text-primary'}>
+                  {rankInten > 0 ? `▲${rankInten}` : `▼${-rankInten}`}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/src/components/dm/top-grid-card.tsx
+++ b/src/components/dm/top-grid-card.tsx
@@ -21,11 +21,7 @@ export function TopGridCard({ movie, rank }: TopGridCardProps) {
   const rating = movie.averageScore ?? 0
   const rankInten = movie.rankInten ?? 0
   const intenColor =
-    rankInten > 0
-      ? 'text-[#6fc96f]'
-      : rankInten < 0
-      ? 'text-dm-red'
-      : 'text-dm-text-faint'
+    rankInten > 0 ? 'text-green-400' : rankInten < 0 ? 'text-primary' : 'text-muted-foreground'
   const intenLabel =
     rankInten > 0 ? `▲${rankInten}` : rankInten < 0 ? `▼${-rankInten}` : '—'
   const audience = formatAudienceMan(movie.audience)
@@ -34,28 +30,20 @@ export function TopGridCard({ movie, rank }: TopGridCardProps) {
     <Link href={`/movie/${movie.id}`} className="block">
       <div className="relative">
         <Poster title={movie.title} palette={palette} imageUrl={movie.poster} />
-        <span className="absolute left-0 top-0 border-b border-r border-dm-line bg-dm-bg/[0.85] px-1.5 py-px font-dm-rank text-[15px] leading-[1.1] text-dm-text">
-          {String(rank).padStart(2, '0')}
+        <span className="absolute left-0 top-0 rounded-br rounded-tl bg-background/80 px-1.5 py-0.5 font-mono text-[12px] font-semibold text-foreground backdrop-blur-sm">
+          #{rank}
         </span>
       </div>
-      <div className="mt-1 truncate text-[11px] leading-tight text-dm-text">
+      <div className="mt-1.5 truncate text-[12px] font-medium text-foreground">
         {movie.title}
       </div>
-      <div className="mt-px flex items-center gap-[3px]">
-        <span className="text-[10px] text-dm-amber">★</span>
-        <span className="font-dm-mono text-[10px] text-dm-text-muted">
-          {rating.toFixed(1)}
-        </span>
-        <span
-          className={cn('ml-auto font-dm-mono text-[9px]', intenColor)}
-        >
-          {intenLabel}
-        </span>
+      <div className="mt-0.5 flex items-center gap-1">
+        <span className="text-[11px] text-yellow-400">★</span>
+        <span className="font-mono text-[11px] text-muted-foreground">{rating.toFixed(1)}</span>
+        <span className={cn('ml-auto font-mono text-[10px]', intenColor)}>{intenLabel}</span>
       </div>
       {audience && (
-        <div className="mt-0.5 font-dm-mono text-[9px] tracking-[0.3px] text-dm-text-faint">
-          👥 {audience}
-        </div>
+        <div className="mt-0.5 font-mono text-[10px] text-muted-foreground">{audience}</div>
       )}
     </Link>
   )

--- a/src/styles/dm/tokens.css
+++ b/src/styles/dm/tokens.css
@@ -1,41 +1,17 @@
 /*
- * Cinéma Noir 디자인 토큰
- * Phase 1 — 신규 dm.* 네임스페이스, 기존 토큰과 분리.
- * 사용 방법: Tailwind className `text-dm-text`, `bg-dm-red`, `font-dm-display` 등.
- *
- * NOTE: @layer base 로 감싸지 않는다. postcss-import 가 globals.css 최상단에
- * inline 시키면 @tailwind base 보다 먼저 @layer 가 등장해 빌드 실패.
- * CSS variable 정의는 layer 없이도 정상 작동.
+ * dm 토큰 — shadcn dark (zinc) 기반으로 업데이트.
+ * dark.css 의 :root 토큰에서 실제 값이 결정되고, 여기서는 dm-* alias 폰트 변수만 관리.
  */
 
 :root {
-  /* surfaces */
-  --dm-bg: #0a0a0c;
-  --dm-bg-deep: #050506;
-  --dm-surface: #15151a;
-  --dm-surface-2: #1e1e24;
-  --dm-line: #2a2a30;
-  --dm-line-2: #3a3a42;
-
-  /* text */
-  --dm-text: #f2ece1;
-  --dm-text-muted: #9a948a;
-  --dm-text-faint: #5c5853;
-
-  /* accents */
-  --dm-red: #c0302a;
-  --dm-red-deep: #8f1f1a;
-  --dm-amber: #d99520;
-  --dm-amber-light: #ecb85a;
-
-  /* poster default oklch palette (per-movie override 가능) */
+  /* poster default palette (per-movie override 가능) */
   --dm-poster-h: 18;
   --dm-poster-c: 0.11;
   --dm-poster-l-top: 0.32;
   --dm-poster-l-bot: 0.09;
 
-  /* fonts (runtime <link> 으로 로드, layout.tsx 참고) */
-  --dm-font-display: 'Playfair Display', serif;
-  --dm-font-mono: 'IBM Plex Mono', monospace;
-  --dm-font-rank: 'Bebas Neue', sans-serif;
+  /* fonts */
+  --dm-font-display: 'Inter', -apple-system, system-ui, sans-serif;
+  --dm-font-mono: 'Geist Mono', monospace;
+  --dm-font-rank: 'Inter', sans-serif;
 }

--- a/src/styles/themes/dark.css
+++ b/src/styles/themes/dark.css
@@ -1,102 +1,54 @@
 /*
- * 다크 테마 토큰 — `[data-theme='dark']` (AppThemeProvider 토글) + `.dark` (next-themes 호환).
- * 라이트 토큰은 globals.css 의 `:root` 블록.
- *
- * NOTE: @layer base 로 감싸지 않는다. postcss-import 가 globals.css 최상단에
- * inline 시키면 @tailwind base 보다 먼저 @layer 가 등장해 빌드 실패.
+ * shadcn dark (zinc) 토큰 — 앱 항상 다크 모드.
+ * :root 에 직접 override — [data-theme='dark'] 와 .dark 모두 동일하게 적용.
  */
 
-[data-theme='dark'] {
-    --background: 0 0% 10%;
-    --foreground: 222.2 84% 96.1%;
-
-    --muted: 210 40% 4.9%;
-    --muted-foreground: 215.4 16.3% 86.9%;
-
-    --popover: 0 0% 10%;
-    --popover-foreground: 222.2 84% 96.1%;
-
-    --card: 0 0% 10%;
-    --card-foreground: 222.2 84% 96.1%;
-
-    --border: 214.3 31.8% 8.6%;
-    --input: var(--gray-006);
-
-    --primary: var(--blue-002);
-    --primary-foreground: 0 0% 98%;
-
-    --secondary: 210 40% 4.9%;
-    --secondary-foreground: 222.2 47.4% 96.1%;
-
-    --accent: 210 40% 4.9%;
-    --accent-foreground: 222.2 47.4% 96.1%;
-
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 4.9%;
-
-    --ring: 215 20.2% 34.9%;
-
-    --gray-001: #000000;
-    --gray-002: #0a0a0a;
-    --gray-003: #141414;
-    --gray-004: #1e1e1e;
-    --gray-005: #282828;
-    --gray-006: #333333;
-    --gray-007: #4d4d4d;
-    --gray-010: #ffffff;
-
-    /* Button variants - Dark mode */
-    --button-primary: var(--blue-002);
-    --button-primary-hover: var(--blue-001);
-    --button-primary-text: #ffffff;
-    --button-outline-border: #374151;
-    --button-outline-border-hover: #6b7280;
-    --button-outline-bg: transparent;
-    --button-outline-bg-hover: #1f2937;
-    --button-outline-text: #d1d5db;
-    --button-link: var(--blue-001);
-    --button-link-hover: var(--blue-002);
-    --button-disabled: #4b5563;
-    --button-disabled-text: #9ca3af;
-}
-
+:root,
+[data-theme='dark'],
 .dark {
-    --background: 0 0% 3.9%;
+    /* shadcn zinc dark */
+    --background: 240 10% 3.9%;
     --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
+
+    --card: 240 10% 5.5%;
     --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
+
+    --popover: 240 10% 5.5%;
     --popover-foreground: 0 0% 98%;
-    --primary: var(--blue-002);
+
+    --primary: 0 72% 51%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 14.9%;
+
+    --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
+
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+
+    --accent: 240 3.7% 15.9%;
     --accent-foreground: 0 0% 98%;
+
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
 
-    /* Button variants - Dark mode (.dark class) */
-    --button-primary: var(--blue-002);
-    --button-primary-hover: var(--blue-001);
-    --button-primary-text: #ffffff;
-    --button-outline-border: #374151;
-    --button-outline-border-hover: #6b7280;
-    --button-outline-bg: transparent;
-    --button-outline-bg-hover: #1f2937;
-    --button-outline-text: #d1d5db;
-    --button-link: var(--blue-001);
-    --button-link-hover: var(--blue-002);
-    --button-disabled: #4b5563;
-    --button-disabled-text: #9ca3af;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 0 72% 51%;
+
+    --radius: 0.5rem;
+
+    /* dm 토큰 — shadcn 토큰과 매핑 */
+    --dm-bg: hsl(240 10% 3.9%);
+    --dm-bg-deep: hsl(240 10% 2%);
+    --dm-surface: hsl(240 10% 5.5%);
+    --dm-surface-2: hsl(240 3.7% 10%);
+    --dm-line: hsl(240 3.7% 15.9%);
+    --dm-line-2: hsl(240 3.7% 20%);
+    --dm-text: hsl(0 0% 98%);
+    --dm-text-muted: hsl(240 5% 64.9%);
+    --dm-text-faint: hsl(240 5% 45%);
+    --dm-red: hsl(0 72% 51%);
+    --dm-red-deep: hsl(0 72% 36%);
+    --dm-amber: hsl(38 92% 50%);
+    --dm-amber-light: hsl(38 92% 65%);
 }


### PR DESCRIPTION
## Summary
shadcn/ui dark (zinc) 토큰 기반 전체 디자인 적용.

## 변경
- **토큰**: Cinéma Noir custom → shadcn dark zinc (`--background`, `--card`, `--primary` 등)
- **폰트**: Playfair Display + IBM Plex Mono → **Inter + Geist Mono**
- **border-radius**: 0(sharp) → 0.5rem (rounded)
- **AppBar** / **BottomNav** / **DesktopLeftNav**: shadcn 스타일로 리디자인
- **홈**: 히어로 타이포 + CTA 2버튼 패턴, 박스오피스 카드형
- **로그인**: Google OAuth만 유지, 이메일/비밀번호 shadcn 폼
- **매칭 목록**: 티켓 → 카드 형태, primary 버튼
- **리뷰 카드** / **댓글 입력** / **SectionHead**: 토큰 전환

## 백엔드 작업 필요 항목 (다음 작업)
- 비밀번호 찾기 이메일 발송 API
- 회원가입 이메일 인증 코드 발송/검증 API

## Test plan
- [ ] 홈 화면 박스오피스 목록 정상 출력
- [ ] 로그인 (이메일 + Google OAuth) 동작
- [ ] 매칭 목록 카드 정상 렌더링
- [ ] 영화 상세 댓글 입력/등록
- [ ] 데스크톱 사이드바 활성 상태

🤖 Generated with [Claude Code](https://claude.com/claude-code)