### PR TITLE
🐛 Google OAuth 이미지 폴백 수정 — ?? → ||

### DIFF
--- a/src/app/api/auth/[...nextauth]/next-option.ts
+++ b/src/app/api/auth/[...nextauth]/next-option.ts
@@ -79,7 +79,7 @@ export const authOptions: AuthOptions = {
           const result = await repo.signInWithProvider({ id: user.id })
           user.id = result.id ?? user.id
           user.nickname = result.nickname ?? user.nickname
-          user.image = result.image ?? user.image
+          user.image = result.image || user.image
           return true
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- Google OAuth 로그인 시 커스텀 업로드 이미지가 없는 경우 Google 프로필 이미지가 정상 표시되지 않던 문제 수정

## 원인
`result.image`가 빈 문자열(`''`)일 때 `?? user.image`는 폴백하지 않음 (`??`는 null/undefined에만 반응).
백엔드 수정(PR #36)으로 빈 이미지는 `''`를 반환하므로 `||` 연산자가 올바른 폴백.

## 변경
- `next-option.ts`: `result.image ?? user.image` → `result.image || user.image`

## Test plan
- [ ] nest-msa PR #36 머지 및 서버 env 업데이트 선행 필요
- [ ] Google OAuth 로그인 후 Google 프로필 이미지 정상 표시 확인
- [ ] 커스텀 이미지 업로드 유저는 업로드 이미지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)