### PR TITLE
🐛 홈 매칭 모집 수 하드코딩 제거 및 PosterPalette 타입 오류 수정

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -3,6 +3,7 @@ import GoogleAd from '@/components/app/googleAd'
 import { MatchHeroBanner, MovieListCard } from '@/components/dm'
 import { Movie } from '@/modules/movie/movie.entity'
 import { MovieRepository } from '@/modules/movie/movie-repository'
+import { MatchPostRepository } from '@/modules/match/match-post-repository'
 import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 
@@ -14,6 +15,18 @@ const getMovieList = async (): Promise<Movie[]> => {
     return await repo.getMovie()
   } catch {
     return []
+  }
+}
+
+const getMatchLiveCount = async (): Promise<number> => {
+  try {
+    const repo = new MatchPostRepository()
+    const data = await repo.getMatchPosts(1, 100)
+    return data.matchPosts.filter(
+      (m) => m.currentParticipants < m.maxParticipants,
+    ).length
+  } catch {
+    return 0
   }
 }
 
@@ -45,7 +58,7 @@ const TODAY_LABEL = (() => {
 })()
 
 const Page: FunctionComponent = async () => {
-  const data = await getMovieList()
+  const [data, liveCount] = await Promise.all([getMovieList(), getMatchLiveCount()])
 
   if (!data || data.length === 0) {
     return <AppSkeleton className="container min-h-[364px] p-6" />
@@ -56,7 +69,7 @@ const Page: FunctionComponent = async () => {
 
   return (
     <main className="pb-5">
-      <MatchHeroBanner todayLabel={TODAY_LABEL} liveCount={24} />
+      <MatchHeroBanner todayLabel={TODAY_LABEL} liveCount={liveCount || undefined} />
 
       <div className="flex items-center gap-2 px-4 pb-3 pt-5">
         <h2 className="text-[16px] font-semibold text-foreground">박스오피스</h2>

--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -27,7 +27,7 @@ export function DmMovieDetail({ movie, averageScore, scoreCount }: DmMovieDetail
       <div
         className="h-[140px] w-full"
         style={{
-          background: `linear-gradient(160deg, ${palette[0]} 0%, ${palette[1]} 100%)`,
+          background: `linear-gradient(160deg, oklch(${palette.lt} ${palette.c} ${palette.h}) 0%, oklch(${palette.lb} ${palette.c * 0.6} ${palette.h}) 100%)`,
           filter: 'blur(0px)',
         }}
       />


### PR DESCRIPTION
## Summary
- 홈 배너의 모집 중 수가 24로 고정되어 있던 문제 수정
- 기존 ts 타입 에러(palette 인덱스 접근) 함께 수정

## 변경
- `(home)/page.tsx`: `getMatchLiveCount()` 추가, `movieList`와 `Promise.all`로 병렬 조회
- `dm-movie-detail.tsx`: `palette[0]/[1]` → `oklch(palette.lt/lb ...)` 표현식으로 수정

## Test plan
- [ ] 홈 화면 배너에 현재 모집 중인 매치 수 표시 확인
- [ ] 영화 상세 페이지 포스터 배경 그라디언트 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)