### PR TITLE
🐛 영화 목록 rank 필드 매핑 누락 수정

### DIFF
--- a/src/modules/movie/movie-repository.ts
+++ b/src/modules/movie/movie-repository.ts
@@ -37,6 +37,7 @@ export class MovieRepository {
       createdAt: new Date(unknown.createdAt),
       updatedAt: new Date(unknown.updatedAt),
       poster: unknown.poster,
+      rank: Number(unknown.rank) || 0,
       rankInten: unknown.rankInten,
       plot: unknown.plot,
       rankOldAndNew: unknown.rankOldAndNew,


### PR DESCRIPTION
## Summary
홈 화면 영화 리스트에 순위 배지(`#1`, `#2`...)가 표시되지 않던 문제 수정

## 원인
`movie-repository.ts`의 `convertUnkownToMovie`에서 `rank` 필드 매핑이 누락됨.
백엔드는 `rank`를 정상 반환하나 프론트 변환 시 빠져 `movie.rank`가 항상 `undefined`.

## 변경
- `movie-repository.ts`: `rank: Number(unknown.rank) || 0` 추가

## Test plan
- [ ] 홈 화면 영화 카드에 `#1` ~ `#10` 순위 배지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)