### PR TITLE
🐛 매치 생성 에러 메시지 전파 — BFF 400/500 구분 및 toast 실제 메시지 표시

### DIFF
--- a/src/app/(root)/(routes)/match/new/components/new-match-container.tsx
+++ b/src/app/(root)/(routes)/match/new/components/new-match-container.tsx
@@ -21,9 +21,10 @@ const NewMatchContainer = () => {
       })
       router.push('/match')
     } catch (error) {
+      const message = error instanceof Error ? error.message : '매치 등록에 실패했습니다.'
       toast({
         title: '오류',
-        description: '매치 등록에 실패했습니다.',
+        description: message,
         variant: 'destructive',
       })
     }

--- a/src/app/api/match/route.ts
+++ b/src/app/api/match/route.ts
@@ -37,10 +37,16 @@ export async function POST(request: NextRequest) {
     const data = await matchRepository.createMatchPost(body)
     return NextResponse.json(data)
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error'
+    const isValidationError =
+      message.includes('입력해주세요') ||
+      message.includes('이어야 합니다') ||
+      message.includes('필요합니다') ||
+      message.includes('미래여야')
     console.error('Match create API error:', error)
     return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 },
+      { error: message },
+      { status: isValidationError ? 400 : 500 },
     )
   }
 }


### PR DESCRIPTION
## Summary
매치 생성 실패 시 원인을 알 수 없는 문제 수정

## 원인
BFF에서 모든 에러를 500으로 반환 → 프론트에서 고정 문구만 표시하여 실제 원인 파악 불가

## 변경
- `route.ts`: 검증 에러(상영시간, 필수 필드 등)는 400으로 구분해 실제 메시지 전달
- `new-match-container.tsx`: catch에서 error.message를 toast에 표시

## Test plan
- [ ] 상영 시간을 과거로 설정하면 "상영 시간은 현재 시간보다 미래여야 합니다." 토스트 표시 확인
- [ ] 정상 생성 시 성공 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)