### PR TITLE
🐛 매치 상영 시간 날짜 선택 제한 및 타임존 검증 수정

### DIFF
--- a/src/components/form/match/fields/show-time-input-field.tsx
+++ b/src/components/form/match/fields/show-time-input-field.tsx
@@ -5,6 +5,8 @@ import { useMatchPostFormContext } from '../hooks/match-post-form-context'
 const cls = 'w-full border border-border bg-secondary px-3.5 py-3 text-[14px] text-foreground focus:border-primary focus:outline-none [color-scheme:dark]'
 const labelCls = 'mb-1.5 block font-mono text-[10px] uppercase tracking-[1px] text-muted-foreground'
 
+const today = new Date().toISOString().split('T')[0]
+
 const ShowTimeInputField: FunctionComponent = () => {
   const { form } = useMatchPostFormContext()
   return (
@@ -17,6 +19,7 @@ const ShowTimeInputField: FunctionComponent = () => {
           <FormControl>
             <input
               type="date"
+              min={today}
               value={field.value ?? ''}
               onChange={(e) => field.onChange(e.target.value || undefined)}
               className={cls}

--- a/src/modules/match/match-post-repository.ts
+++ b/src/modules/match/match-post-repository.ts
@@ -56,10 +56,11 @@ export class MatchPostRepository {
       throw new Error('상영 시간을 입력해주세요.')
     }
 
-    const showTime = new Date(data.showTime)
-    const now = new Date()
-    if (showTime <= now) {
-      throw new Error('상영 시간은 현재 시간보다 미래여야 합니다.')
+    const showTimeDate = new Date(data.showTime + 'T00:00:00')
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    if (showTimeDate < today) {
+      throw new Error('상영 시간은 오늘 이후여야 합니다.')
     }
 
     if (


### PR DESCRIPTION
## Summary
매치 생성 시 상영 날짜 선택 UX 개선 및 타임존 검증 버그 수정

## 원인
1. 날짜 입력에 min 제한이 없어 과거 날짜 선택 가능
2. 선택한 날짜(`2026-05-07`)를 `new Date()`로 변환 시 UTC 자정(00:00Z)이 되어
   한국시간(UTC+9) 오전에 오늘 날짜를 선택해도 "현재 시간보다 미래"가 아님으로 판단

## 변경
- `show-time-input-field.tsx`: `min={today}` 추가 — 오늘 이전 날짜 선택 불가
- `match-post-repository.ts`: `showTime <= now` → 날짜 단위 비교로 변경 (타임존 독립)

## Test plan
- [ ] 오늘 날짜 선택 후 매치 생성 성공 확인
- [ ] 어제 날짜 선택 불가(회색 처리) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)