### PR TITLE
💄 헤더 account 링크 아이콘 벨 → 사람으로 변경

### DIFF
--- a/src/components/dm/dm-app-bar.tsx
+++ b/src/components/dm/dm-app-bar.tsx
@@ -24,8 +24,8 @@ export function DmAppBar() {
             className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M18 8a6 6 0 10-12 0c0 7-3 9-3 9h18s-3-2-3-9"/>
-              <path d="M13.7 21a2 2 0 01-3.4 0"/>
+              <circle cx="12" cy="8" r="4"/>
+              <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>
             </svg>
           </Link>
         )}


### PR DESCRIPTION
- dm-app-bar의 /account 링크 아이콘을 벨에서 사람 아이콘으로 교체

🤖 Generated with [Claude Code](https://claude.com/claude-code)