### PR TITLE
✨ 알림 시스템 프론트엔드 — 배지·목록·읽음 처리

### DIFF
--- a/src/app/(root)/(routes)/notifications/page.tsx
+++ b/src/app/(root)/(routes)/notifications/page.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import useSWR, { mutate } from 'swr'
+import { cn } from '@/lib/utils'
+import type { NotificationItem, NotificationListResponse } from '@/modules/notification'
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
+function typeLabel(type: string) {
+  if (type === 'match_apply') return '매칭 신청'
+  if (type === 'chat_message') return '채팅'
+  return '알림'
+}
+
+function typeHref(item: NotificationItem) {
+  if (item.type === 'match_apply' && item.targetId) return `/match/${item.targetId}`
+  if (item.type === 'chat_message' && item.targetId) return `/chat`
+  return null
+}
+
+export default function NotificationsPage() {
+  const router = useRouter()
+  const { data, isLoading } = useSWR<NotificationListResponse>(
+    '/api/notifications',
+    fetcher,
+  )
+
+  const handleRead = async (item: NotificationItem) => {
+    if (!item.isRead) {
+      await fetch(`/api/notifications/${item.id}`, { method: 'PATCH' })
+      mutate('/api/notifications')
+      mutate('/api/notifications/unread-count')
+    }
+    const href = typeHref(item)
+    if (href) router.push(href)
+  }
+
+  const handleReadAll = async () => {
+    await fetch('/api/notifications/read-all', { method: 'PATCH' })
+    mutate('/api/notifications')
+    mutate('/api/notifications/unread-count')
+  }
+
+  return (
+    <div className="min-h-screen">
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h1 className="text-[15px] font-semibold text-foreground">알림</h1>
+        {(data?.items?.some((n) => !n.isRead)) && (
+          <button
+            onClick={handleReadAll}
+            className="font-mono text-[11px] text-muted-foreground hover:text-foreground"
+          >
+            모두 읽음
+          </button>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="py-12 text-center font-mono text-[12px] text-muted-foreground">
+          불러오는 중...
+        </div>
+      )}
+
+      {!isLoading && (!data?.items?.length) && (
+        <div className="py-16 text-center text-muted-foreground">
+          <p className="text-[14px]">알림이 없습니다.</p>
+        </div>
+      )}
+
+      <ul>
+        {data?.items?.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              onClick={() => handleRead(item)}
+              className={cn(
+                'w-full border-b border-border px-4 py-3.5 text-left transition-colors hover:bg-accent',
+                !item.isRead && 'bg-accent/40',
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <span className={cn(
+                  'mt-0.5 shrink-0 rounded-full px-1.5 py-0.5 font-mono text-[9px] font-medium',
+                  item.type === 'match_apply'
+                    ? 'bg-primary/20 text-primary'
+                    : 'bg-muted text-muted-foreground',
+                )}>
+                  {typeLabel(item.type)}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[13px] font-medium text-foreground">
+                    {item.title}
+                  </p>
+                  <p className="mt-0.5 truncate text-[12px] text-muted-foreground">
+                    {item.body}
+                  </p>
+                  <p className="mt-1 font-mono text-[10px] text-muted-foreground/60">
+                    {new Date(item.createdAt).toLocaleString('ko-KR', {
+                      month: 'numeric',
+                      day: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </p>
+                </div>
+                {!item.isRead && (
+                  <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />
+                )}
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NotificationRepository } from '@/modules/notification'
+
+export async function PATCH(_: Request, { params }: { params: { id: string } }) {
+  const token = getTokenFromCookie()
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  try {
+    const repo = new NotificationRepository(token)
+    await repo.markAsRead(params.id)
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/notifications/read-all/route.ts
+++ b/src/app/api/notifications/read-all/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NotificationRepository } from '@/modules/notification'
+
+export async function PATCH() {
+  const token = getTokenFromCookie()
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  try {
+    const repo = new NotificationRepository(token)
+    await repo.markAllAsRead()
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NotificationRepository } from '@/modules/notification'
+
+export async function GET(request: NextRequest) {
+  const token = getTokenFromCookie()
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const page = Number(searchParams.get('page') || '1')
+  const pageSize = Number(searchParams.get('pageSize') || '20')
+
+  try {
+    const repo = new NotificationRepository(token)
+    const data = await repo.getNotifications(page, pageSize)
+    return NextResponse.json(data)
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/notifications/unread-count/route.ts
+++ b/src/app/api/notifications/unread-count/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NotificationRepository } from '@/modules/notification'
+
+export async function GET() {
+  const token = getTokenFromCookie()
+  if (!token) return NextResponse.json({ count: 0 })
+
+  try {
+    const repo = new NotificationRepository(token)
+    const data = await repo.getUnreadCount()
+    return NextResponse.json(data)
+  } catch {
+    return NextResponse.json({ count: 0 })
+  }
+}

--- a/src/components/dm/dm-app-bar.tsx
+++ b/src/components/dm/dm-app-bar.tsx
@@ -2,11 +2,21 @@
 
 import { signIn, useSession } from 'next-auth/react'
 import Link from 'next/link'
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
 export function DmAppBar() {
   const { status } = useSession()
   const isLogin = status === 'authenticated'
   const isLoading = status === 'loading'
+
+  const { data } = useSWR<{ count: number }>(
+    isLogin ? '/api/notifications/unread-count' : null,
+    fetcher,
+    { refreshInterval: 30000 },
+  )
+  const unread = data?.count ?? 0
 
   return (
     <header className="sticky top-0 z-30 flex items-center border-b border-border bg-background/95 px-4 py-3 backdrop-blur-md">
@@ -14,20 +24,36 @@ export function DmAppBar() {
         drunken<span className="text-primary">movie</span>
       </Link>
 
-      <div className="ml-auto flex items-center gap-2">
+      <div className="ml-auto flex items-center gap-1">
         {isLoading && (
           <span className="font-mono text-[11px] text-muted-foreground">···</span>
         )}
         {isLogin && (
-          <Link
-            href="/account"
-            className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="12" cy="8" r="4"/>
-              <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>
-            </svg>
-          </Link>
+          <>
+            <Link
+              href="/notifications"
+              className="relative flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 8a6 6 0 10-12 0c0 7-3 9-3 9h18s-3-2-3-9"/>
+                <path d="M13.7 21a2 2 0 01-3.4 0"/>
+              </svg>
+              {unread > 0 && (
+                <span className="absolute right-1 top-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary font-mono text-[9px] font-bold text-primary-foreground">
+                  {unread > 99 ? '99+' : unread}
+                </span>
+              )}
+            </Link>
+            <Link
+              href="/account"
+              className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="8" r="4"/>
+                <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>
+              </svg>
+            </Link>
+          </>
         )}
         {!isLoading && !isLogin && (
           <button

--- a/src/config/app-backend-api-endpoint.ts
+++ b/src/config/app-backend-api-endpoint.ts
@@ -223,6 +223,18 @@ const AppBackEndApiEndpoint = {
   getChatMessages: (chatRoomId: string) => {
     return `${_base}/chat/rooms/${chatRoomId}/messages`
   },
+  getNotifications: (page = 1, pageSize = 20) => {
+    return `${_base}/notifications?page=${page}&pageSize=${pageSize}`
+  },
+  getUnreadNotificationCount: () => {
+    return `${_base}/notifications/unread-count`
+  },
+  markNotificationRead: (id: string) => {
+    return `${_base}/notifications/${id}/read`
+  },
+  markAllNotificationsRead: () => {
+    return `${_base}/notifications/read-all`
+  },
 }
 
 export { AppBackEndApiEndpoint }

--- a/src/modules/notification/index.ts
+++ b/src/modules/notification/index.ts
@@ -1,0 +1,3 @@
+export * from './notification.entity'
+export * from './notification-datasource'
+export * from './notification-repository'

--- a/src/modules/notification/notification-datasource.ts
+++ b/src/modules/notification/notification-datasource.ts
@@ -1,0 +1,50 @@
+import { AppBackEndApiEndpoint } from '@/config/app-backend-api-endpoint'
+import type {
+  NotificationListResponse,
+  UnreadCountResponse,
+} from './notification.entity'
+
+export class NotificationDataSource {
+  constructor(private token?: string) {}
+
+  private headers(): HeadersInit {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.token}`,
+    }
+  }
+
+  async getNotifications(page = 1, pageSize = 20): Promise<NotificationListResponse> {
+    const res = await fetch(AppBackEndApiEndpoint.getNotifications(page, pageSize), {
+      headers: this.headers(),
+      cache: 'no-cache',
+    })
+    if (!res.ok) throw new Error(`[${res.status}] ${res.statusText}`)
+    return res.json()
+  }
+
+  async getUnreadCount(): Promise<UnreadCountResponse> {
+    const res = await fetch(AppBackEndApiEndpoint.getUnreadNotificationCount(), {
+      headers: this.headers(),
+      cache: 'no-cache',
+    })
+    if (!res.ok) throw new Error(`[${res.status}] ${res.statusText}`)
+    return res.json()
+  }
+
+  async markAsRead(id: string): Promise<void> {
+    const res = await fetch(AppBackEndApiEndpoint.markNotificationRead(id), {
+      method: 'PATCH',
+      headers: this.headers(),
+    })
+    if (!res.ok) throw new Error(`[${res.status}] ${res.statusText}`)
+  }
+
+  async markAllAsRead(): Promise<void> {
+    const res = await fetch(AppBackEndApiEndpoint.markAllNotificationsRead(), {
+      method: 'PATCH',
+      headers: this.headers(),
+    })
+    if (!res.ok) throw new Error(`[${res.status}] ${res.statusText}`)
+  }
+}

--- a/src/modules/notification/notification-repository.ts
+++ b/src/modules/notification/notification-repository.ts
@@ -1,0 +1,26 @@
+import { NotificationDataSource } from './notification-datasource'
+import type { NotificationListResponse, UnreadCountResponse } from './notification.entity'
+
+export class NotificationRepository {
+  private ds: NotificationDataSource
+
+  constructor(token?: string) {
+    this.ds = new NotificationDataSource(token)
+  }
+
+  getNotifications(page = 1, pageSize = 20): Promise<NotificationListResponse> {
+    return this.ds.getNotifications(page, pageSize)
+  }
+
+  getUnreadCount(): Promise<UnreadCountResponse> {
+    return this.ds.getUnreadCount()
+  }
+
+  markAsRead(id: string): Promise<void> {
+    return this.ds.markAsRead(id)
+  }
+
+  markAllAsRead(): Promise<void> {
+    return this.ds.markAllAsRead()
+  }
+}

--- a/src/modules/notification/notification.entity.ts
+++ b/src/modules/notification/notification.entity.ts
@@ -1,0 +1,20 @@
+export interface NotificationItem {
+  id: string
+  userId: number
+  type: 'match_apply' | 'chat_message' | string
+  title: string
+  body: string
+  isRead: boolean
+  targetId: string | null
+  createdAt: string
+}
+
+export interface NotificationListResponse {
+  items: NotificationItem[]
+  total: number
+  hasNext: boolean
+}
+
+export interface UnreadCountResponse {
+  count: number
+}


### PR DESCRIPTION
## Summary
매칭 신청/채팅 수신 알림을 헤더에서 확인하고 `/notifications` 페이지에서 관리

## 변경
- `modules/notification/`: 파사드 패턴 모듈 (entity/datasource/repository/index)
- BFF 라우트: GET /api/notifications, /unread-count, PATCH /read-all, /[id]
- `dm-app-bar`: 벨 아이콘(미읽음 수 배지, 30초 폴링) + 사람 아이콘 나란히 배치
- `/notifications` 페이지: 목록, 클릭 시 읽음 처리 후 관련 페이지 이동, 모두 읽음 버튼

## Test plan
- [ ] 배포 후 Prisma 마이그레이션 실행 필요
- [ ] 매칭 신청 → 작성자 헤더 배지에 숫자 표시 확인
- [ ] 채팅 메시지 → 수신자 배지 표시 확인
- [ ] /notifications 에서 알림 클릭 시 읽음 처리 및 페이지 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)