### PR TITLE
🐛 회원가입 비밀번호 input Chrome 강력한 암호 강제 차단

### DIFF
--- a/src/app/(root)/(routes)/reset-password/page.tsx
+++ b/src/app/(root)/(routes)/reset-password/page.tsx
@@ -75,12 +75,16 @@ export default function ResetPasswordPage() {
           </label>
           <input
             id="password"
-            type="password"
-            autoComplete="new-password"
+            type="text"
+            autoComplete="off"
+            data-1p-ignore="true"
+            data-lpignore="true"
+            data-form-type="other"
             placeholder="••••••••"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className="h-10 w-full rounded-md border border-input bg-transparent px-3 text-[14px] text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+            style={{ WebkitTextSecurity: 'disc' } as React.CSSProperties}
           />
         </div>
 
@@ -90,11 +94,15 @@ export default function ResetPasswordPage() {
           </label>
           <input
             id="confirm"
-            type="password"
-            autoComplete="new-password"
+            type="text"
+            autoComplete="off"
+            data-1p-ignore="true"
+            data-lpignore="true"
+            data-form-type="other"
             placeholder="••••••••"
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
+            style={{ WebkitTextSecurity: 'disc' } as React.CSSProperties}
             className="h-10 w-full rounded-md border border-input bg-transparent px-3 text-[14px] text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
           />
         </div>

--- a/src/components/form/auth/register/fields/password-input-field.tsx
+++ b/src/components/form/auth/register/fields/password-input-field.tsx
@@ -4,7 +4,7 @@ import { FormControl, FormField, FormItem, FormMessage } from '@/components/ui/f
 import { FunctionComponent, useEffect, useState } from 'react'
 import { useRegisterFormContext } from '../hook/register-form-context'
 
-const inputCls = 'w-full border border-border bg-secondary px-3.5 py-3 text-[14px] text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none'
+const inputCls = 'w-full border border-border bg-secondary px-3.5 py-3 pr-12 text-[14px] text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none'
 const labelCls = 'mb-2 block font-mono text-[10px] uppercase tracking-[1px] text-muted-foreground'
 
 const rules = [
@@ -17,6 +17,7 @@ const rules = [
 const PasswordInputField: FunctionComponent = () => {
   const { form } = useRegisterFormContext()
   const [checks, setChecks] = useState({ length: false, letter: false, number: false, special: false })
+  const [show, setShow] = useState(false)
   const pw = form.watch('password')
 
   useEffect(() => {
@@ -32,7 +33,27 @@ const PasswordInputField: FunctionComponent = () => {
         <FormItem>
           <label className={labelCls}>비밀번호</label>
           <FormControl>
-            <input {...field} type="password" autoComplete="new-password" placeholder="••••••••" className={inputCls} />
+            <div className="relative">
+              <input
+                {...field}
+                type="text"
+                autoComplete="off"
+                data-1p-ignore="true"
+                data-lpignore="true"
+                data-form-type="other"
+                placeholder="••••••••"
+                className={inputCls}
+                style={show ? undefined : { WebkitTextSecurity: 'disc' } as React.CSSProperties}
+              />
+              <button
+                type="button"
+                onClick={() => setShow((v) => !v)}
+                tabIndex={-1}
+                className="absolute right-3 top-1/2 -translate-y-1/2 font-mono text-[10px] uppercase tracking-[1px] text-muted-foreground hover:text-foreground"
+              >
+                {show ? '숨김' : '보기'}
+              </button>
+            </div>
           </FormControl>
           <FormMessage className="font-mono text-[11px] text-primary" />
           {pw && (


### PR DESCRIPTION
## Summary
회원가입 비밀번호 입력 필드에서 Chrome이 강력한 암호를 강제 입력해 사용자가 직접 변경할 수 없는 문제 수정

## 원인
이전 패치 \`autoComplete=\"new-password\"\` 는 password manager 저장 hint이지만,
Chrome은 동시에 강력한 암호 생성을 강제하여 사용자 입력을 차단.

## 해결
- \`type=\"password\"\` → \`type=\"text\"\` 변경
- CSS \`WebkitTextSecurity: 'disc'\` 로 visual 마스킹
  → Chrome이 password 필드로 인식하지 않아 자동완성/강제 입력 미발동
  → 사용자 화면에는 비밀번호처럼 점으로 가려짐
- \`autoComplete=\"off\"\`, \`data-1p-ignore\`, \`data-lpignore\`, \`data-form-type=\"other\"\` 추가
- 회원가입에는 보기/숨김 토글 추가

## 변경
- \`register/fields/password-input-field.tsx\`
- \`reset-password/page.tsx\` (양쪽 input 모두)

## 트레이드오프
- 비밀번호 매니저 자동 저장 미지원 (1Password/LastPass 등)
- 사용자가 직접 입력 가능한 것을 우선

## Test plan
- [ ] 회원가입 비밀번호 단계: 강력한 암호 팝업 없이 자유롭게 타이핑 가능
- [ ] 입력값이 점으로 마스킹되어 표시
- [ ] 보기/숨김 토글 정상 동작
- [ ] 비밀번호 재설정 페이지도 동일하게 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)