### PR TITLE
🐛 /account 미들웨어 callbackUrl 상대경로 사용

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,8 +9,13 @@ export function middleware(req: NextRequest) {
     req.cookies.get('__Secure-next-auth.session-token')?.value
 
   if (!token) {
-    const url = new URL('/login', req.url)
-    url.searchParams.set('callbackUrl', req.url)
+    // callbackUrl은 상대경로로 — req.url은 reverse proxy 뒤에서
+    // 내부 host(localhost:3000)를 가리킬 수 있어 절대 URL을 쓰면
+    // callbackUrl에 localhost가 박혀 외부 IP/도메인에서 깨짐
+    const callbackPath = req.nextUrl.pathname + (req.nextUrl.search || '')
+    const url = req.nextUrl.clone()
+    url.pathname = '/login'
+    url.search = `?callbackUrl=${encodeURIComponent(callbackPath)}`
     return NextResponse.redirect(url)
   }
   return NextResponse.next()


### PR DESCRIPTION
reverse proxy 뒤에서 req.url이 localhost:3000을 가리키는 문제 회피.

🤖 Generated with [Claude Code](https://claude.com/claude-code)