### PR TITLE
🐛 내 매칭 메뉴·기본 탭 정리

### DIFF
--- a/src/app/(root)/(routes)/match/my-matches/components/my-created-matches.tsx
+++ b/src/app/(root)/(routes)/match/my-matches/components/my-created-matches.tsx
@@ -16,7 +16,7 @@ const MyCreatedMatches: FunctionComponent<MyCreatedMatchesProps> = ({
   if (matches.length === 0)
     return (
       <div className="py-12 text-center font-mono text-[12px] text-muted-foreground">
-        작성한 매칭이 없습니다.
+        만든 매칭이 없습니다.
       </div>
     )
 

--- a/src/app/(root)/(routes)/match/my-matches/components/my-matches-container.tsx
+++ b/src/app/(root)/(routes)/match/my-matches/components/my-matches-container.tsx
@@ -10,13 +10,16 @@ import { MyCreatedMatches } from './my-created-matches'
 
 type Tab = 'applied' | 'created'
 
+const getInitialTab = (tab: string | null): Tab =>
+  tab === 'applied' || tab === 'created' ? tab : 'created'
+
 const MyMatchesContainer = () => {
   const { status } = useSession()
   const router = useRouter()
   const searchParams = useSearchParams()
   const { showToast } = useAppToast()
 
-  const initialTab = (searchParams?.get('tab') as Tab) ?? 'applied'
+  const initialTab = getInitialTab(searchParams?.get('tab') ?? null)
   const [activeTab, setActiveTab] = useState<Tab>(initialTab)
 
   const { applications, isLoading: loadingApplied, refetch } = useMyApplications()
@@ -65,7 +68,7 @@ const MyMatchesContainer = () => {
                 : 'text-muted-foreground hover:text-foreground'
             }`}
           >
-            {tab === 'applied' ? '신청한 매칭' : '내가 만든 매칭'}
+            {tab === 'applied' ? '신청한 매칭' : '만든 매칭'}
           </button>
         ))}
       </div>

--- a/src/app/(root)/account/sections/account-section.tsx
+++ b/src/app/(root)/account/sections/account-section.tsx
@@ -36,8 +36,7 @@ function MenuRow({ item, isLast }: { item: MenuItem; isLast: boolean }) {
 
 const AccountSection: FunctionComponent = () => {
   const items: MenuItem[] = [
-    { label: '내가 쓴 매칭', href: '/match/my-matches' },
-    { label: '내가 신청한 매칭', href: '/match/my-matches?tab=applied' },
+    { label: '내 매칭', href: '/match/my-matches' },
     { label: '알림 설정', href: AppPath.settings() },
     { label: '로그아웃', onClick: () => signOut({ callbackUrl: '/' }), destructive: true },
   ]


### PR DESCRIPTION
## Summary
계정의 중복 매칭 메뉴를 "내 매칭" 한 줄로 통합하고, 기본 진입 탭을 만든 매칭으로 맞췄습니다.

## 원인
기존 "내가 쓴 매칭" 메뉴가 탭 파라미터 없이 진입했지만 기본 탭이 신청한 매칭이라, 메뉴 라벨과 실제 화면이 어긋났습니다.

## 변경
- 계정 활동 메뉴의 "내가 쓴 매칭"/"내가 신청한 매칭"을 "내 매칭"으로 통합
- /match/my-matches 기본 탭을 created로 변경하고 잘못된 tab 쿼리는 created로 보정
- 탭/빈상태 문구를 "신청한 매칭"/"만든 매칭" 기준으로 정리

## Test plan
- [x] pnpm lint
- [x] 수정 파일 200줄 이하 확인

🤖 Generated with Codex