### PR TITLE
🐛 영화 상세 VOD 버튼 동작 연결

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
@@ -5,6 +5,7 @@ import { FunctionComponent } from 'react'
 import MovieCarousel from '../components/movie-carousel'
 import MovieVodModal from '../components/movie-vod-modal'
 import { useGetMovieDetail } from '../hooks/use-get-movie-detail'
+import { useVodModalContext } from '../hooks/use-vod-modal-context'
 
 interface DescriptionSectionProps {
   id: string
@@ -14,6 +15,7 @@ const DescriptionSection: FunctionComponent<DescriptionSectionProps> = ({
   id,
 }) => {
   const { data, isLoading, error } = useGetMovieDetail(id)
+  const { setOpen, setSrc, setTitle } = useVodModalContext()
 
   if (isLoading)
     return <p className="text-center text-muted-foreground">로딩 중...</p>
@@ -22,10 +24,19 @@ const DescriptionSection: FunctionComponent<DescriptionSectionProps> = ({
       <p className="text-center text-primary">데이터를 불러오지 못했습니다.</p>
     )
 
+  const firstVod = data.vods?.[0]
+  const handleVodClick = firstVod
+    ? () => {
+        setSrc(firstVod.vodUrl)
+        setTitle(data.title)
+        setOpen(true)
+      }
+    : undefined
+
   return (
     <>
       <MovieVodModal />
-      <DmMovieDetail movie={data} />
+      <DmMovieDetail movie={data} onVodClick={handleVodClick} />
       {data.vods && <MovieCarousel data={data.vods} title={data.title} />}
     </>
   )

--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -12,9 +12,15 @@ interface DmMovieDetailProps {
   movie: Movie & { rank?: number }
   averageScore?: number | null
   scoreCount?: number | null
+  onVodClick?: () => void
 }
 
-export function DmMovieDetail({ movie, averageScore, scoreCount }: DmMovieDetailProps) {
+export function DmMovieDetail({
+  movie,
+  averageScore,
+  scoreCount,
+  onVodClick,
+}: DmMovieDetailProps) {
   const palette = paletteForMovie(movie.id, movie.title)
   const { h, c, lt, lb } = palette
   const rating = averageScore ?? movie.averageScore ?? 0
@@ -70,9 +76,15 @@ export function DmMovieDetail({ movie, averageScore, scoreCount }: DmMovieDetail
 
         {/* CTA 버튼 */}
         <div className="mt-3 flex gap-2">
-          <button className="flex-1 rounded-md border border-border py-2.5 text-[13px] font-medium text-foreground hover:bg-accent">
-            ▶ VOD 보기
-          </button>
+          {onVodClick && (
+            <button
+              type="button"
+              onClick={onVodClick}
+              className="flex-1 rounded-md border border-border py-2.5 text-[13px] font-medium text-foreground hover:bg-accent"
+            >
+              ▶ VOD 보기
+            </button>
+          )}
           <Link
             href="/match"
             className="flex flex-1 items-center justify-center rounded-md bg-primary py-2.5 text-[13px] font-medium text-primary-foreground"


### PR DESCRIPTION
## Summary
영화 상세의 "VOD 보기" 버튼이 실제 VOD 모달을 열도록 연결했습니다.
VOD 데이터가 없을 때는 버튼을 렌더링하지 않아 죽은 CTA가 남지 않게 했습니다.

## 원인
기존 버튼은 클릭 핸들러가 없어 사용자에게 동작하지 않는 CTA로 노출됐습니다.

## 변경
- DmMovieDetail에 선택적 onVodClick prop 추가
- 영화 상세 섹션에서 첫 VOD URL을 모달 컨텍스트에 연결
- VOD 데이터가 없는 영화는 "VOD 보기" 버튼 미노출

## Test plan
- [x] pnpm lint
- [x] 수정 파일 200줄 이하 확인

🤖 Generated with Codex