### PR TITLE
🐛 마감 임박 고정 카피 제거

### DIFF
--- a/src/components/dm/dm-desktop-right-sidebar.tsx
+++ b/src/components/dm/dm-desktop-right-sidebar.tsx
@@ -87,18 +87,6 @@ export function DmDesktopRightSidebar() {
         >
           전체 매칭 보기 →
         </Link>
-
-        <div className="mt-3 rounded-md border border-border bg-primary/5 p-3">
-          <div className="flex items-center gap-1.5 font-mono text-[10px] text-primary">
-            <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
-            마감 임박
-          </div>
-          <div className="mt-1.5 text-[13px] leading-snug text-muted-foreground">
-            오늘 마감되는 매칭을
-            <br />
-            놓치지 마세요.
-          </div>
-        </div>
       </div>
     </aside>
   )


### PR DESCRIPTION
## Summary
데스크탑 우측 사이드바의 실제 데이터와 연결되지 않은 "마감 임박" 고정 카피 박스를 제거했습니다.

## 원인
사이드바 하단 카피가 실제 D-0/D-1 매칭 데이터와 무관하게 항상 노출되어 가짜 긴급성처럼 보일 수 있었습니다.

## 변경
- DmDesktopRightSidebar 하단의 "마감 임박" 고정 안내 박스 제거
- 실제 모집 목록과 전체 매칭 보기 CTA만 유지

## Test plan
- [x] pnpm lint
- [x] 수정 파일 200줄 이하 확인
- [x] "마감 임박"/고정 카피 잔존 검색

🤖 Generated with Codex