### PR TITLE
🐛 모바일 하단 탭바 고정

### DIFF
--- a/src/app/(root)/(routes)/articles/[id]/sections/active-section.tsx
+++ b/src/app/(root)/(routes)/articles/[id]/sections/active-section.tsx
@@ -15,7 +15,7 @@ const ActiveSection: FunctionComponent<ActiveSectionProps> = ({
   return (
     <div
       className={cn(
-        'fixed bottom-[72px] lg:bottom-0 z-40 w-full max-w-[460px] border-t border-border bg-background/95 px-3 py-2 backdrop-blur-md',
+        'fixed bottom-[calc(4rem+env(safe-area-inset-bottom)+0.5rem)] z-40 w-full max-w-[460px] border-t border-border bg-background/95 px-3 py-2 backdrop-blur-md lg:bottom-0',
         className,
       )}
     >

--- a/src/app/(root)/(routes)/articles/loading.tsx
+++ b/src/app/(root)/(routes)/articles/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/dm/skeleton'
 
 export default function Loading() {
   return (
-    <div className="min-h-page bg-background pb-[100px] lg:pb-4 text-foreground">
+    <div className="min-h-page bg-background pb-4 text-foreground">
       <div className="flex items-center border-b border-border px-4 py-3.5">
         <h1 className="font-dm-display text-[20px] italic font-bold text-foreground">
           커뮤니티

--- a/src/app/(root)/(routes)/match/[id]/components/match-author-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-author-view.tsx
@@ -33,7 +33,7 @@ const MatchAuthorView: FunctionComponent<MatchAuthorViewProps> = ({
   }
 
   return (
-    <div className="flex flex-col bg-background pb-[100px] lg:pb-4 text-foreground">
+    <div className="flex flex-col bg-background pb-4 text-foreground">
       <div className="flex items-center gap-3 border-b border-border px-4 py-3.5">
         <button
           onClick={() => router.push('/match')}

--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -112,7 +112,7 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
         )}
       </div>
 
-      <div className="fixed bottom-[72px] lg:bottom-0 left-1/2 z-25 w-full max-w-[460px] -translate-x-1/2 border-t border-border bg-background/95 px-3 py-3 backdrop-blur-md">
+      <div className="fixed bottom-[calc(4rem+env(safe-area-inset-bottom)+0.5rem)] left-1/2 z-25 w-full max-w-[460px] -translate-x-1/2 border-t border-border bg-background/95 px-3 py-3 backdrop-blur-md lg:bottom-0">
         {myApplication ? (
           <div className="flex flex-col items-center gap-2">
             <ApplicationStatusBadge status={myApplication.status} />

--- a/src/app/(root)/(routes)/match/[id]/loading.tsx
+++ b/src/app/(root)/(routes)/match/[id]/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/dm/skeleton'
 
 export default function Loading() {
   return (
-    <div className="min-h-page bg-background pb-[88px] lg:pb-4 text-foreground">
+    <div className="min-h-page bg-background pb-4 text-foreground">
       {/* 헤더 */}
       <div className="flex items-center border-b border-border px-4 py-3.5">
         <Skeleton className="h-4 w-12" />

--- a/src/app/(root)/(routes)/match/my-matches/page.tsx
+++ b/src/app/(root)/(routes)/match/my-matches/page.tsx
@@ -3,7 +3,7 @@ import { MyMatchesContainer } from './components/my-matches-container'
 
 const Page: FunctionComponent = () => {
   return (
-    <div className="min-h-page bg-background pb-[100px] lg:pb-4 text-foreground">
+    <div className="min-h-page bg-background pb-4 text-foreground">
       <div className="flex items-center border-b border-border px-4 py-3.5">
         <h1 className="font-dm-display text-[20px] italic font-bold text-foreground">
           내 매칭

--- a/src/app/(root)/(routes)/movie/[id]/loading.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/dm/skeleton'
 
 export default function Loading() {
   return (
-    <div className="flex flex-col bg-background pb-[88px] lg:pb-4 text-foreground">
+    <div className="flex flex-col bg-background pb-4 text-foreground">
       {/* backdrop */}
       <Skeleton className="h-[180px] w-full" />
 

--- a/src/app/(root)/(routes)/movie/[id]/page.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/page.tsx
@@ -40,7 +40,7 @@ const Page: FunctionComponent<PageProps> = async ({ params: { id } }) => {
       />
       <div
         id="movie-detail-page"
-        className="relative flex flex-col bg-background pb-[88px] lg:pb-4 text-foreground"
+        className="relative flex flex-col bg-background pb-4 text-foreground"
       >
         <ModifyCommentModalContextProvider>
           <VodModalContextProvider>

--- a/src/app/(root)/(routes)/settings/page.tsx
+++ b/src/app/(root)/(routes)/settings/page.tsx
@@ -57,7 +57,7 @@ export default function SettingsPage() {
   ]
 
   return (
-    <div className="min-h-page bg-background pb-[100px] lg:pb-4 text-foreground">
+    <div className="min-h-page bg-background pb-4 text-foreground">
       {/* 헤더 */}
       <div className="flex items-center border-b border-border px-4 py-3.5">
         <button

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -132,16 +132,16 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <MessageModalContextProvider>
               {/* mobile: single column max-w-[460px] centered
                   desktop lg+: 3-column [240px | 1fr | 320px] max-w-[1400px] */}
-              <div className="mx-auto flex min-h-screen w-full max-w-[460px] flex-col lg:max-w-[1400px] lg:flex-row lg:items-start">
+              <div className="mx-auto flex h-[100dvh] w-full max-w-[460px] flex-col overflow-hidden lg:h-auto lg:min-h-screen lg:max-w-[1400px] lg:flex-row lg:items-start lg:overflow-visible">
                 <DmDesktopLeftNav />
 
-                <div className="flex w-full min-w-0 flex-1 flex-col lg:border-x lg:border-border">
+                <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col lg:min-h-screen lg:border-x lg:border-border">
                   <div className="lg:hidden">
                     <DmAppBar />
                   </div>
-                  <main className="flex min-h-page flex-1 flex-col">
+                  <main className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain lg:min-h-page lg:overflow-visible">
                     {children}
-                    <DmAppFooter className="mt-auto pb-[88px] lg:pb-4 lg:pb-8" />
+                    <DmAppFooter className="mt-auto pb-4 lg:pb-8" />
                   </main>
                   <div className="lg:hidden">
                     <DmBottomNav />

--- a/src/components/dm/bottom-nav.tsx
+++ b/src/components/dm/bottom-nav.tsx
@@ -62,7 +62,7 @@ export function DmBottomNav() {
   const active = activeKey(pathname)
 
   return (
-    <nav className="sticky bottom-0 z-20 grid h-16 grid-cols-5 border-t border-border bg-background">
+    <nav className="z-20 grid h-[calc(4rem+env(safe-area-inset-bottom))] shrink-0 grid-cols-5 border-t border-border bg-background pb-[env(safe-area-inset-bottom)]">
       {ITEMS.map((it) => {
         const isActive = active === it.key
         return (


### PR DESCRIPTION
## Summary
모바일 레이아웃을 앱 셸 구조로 바꿔 하단 탭바가 항상 화면 하단에 고정되도록 정리했습니다.
데스크탑 3컬럼 구조는 유지하면서 모바일에서만 main 내부 스크롤을 사용합니다.

## 원인
기존 DmBottomNav가 문서 흐름 끝의 sticky 요소라 콘텐츠가 길면 페이지 끝까지 내려가야 보이는 문제가 있었습니다.
페이지별 pb-[88px]/pb-[100px] 보정도 이 문제를 땜질하고 있었습니다.

## 변경
- 모바일 루트 컨테이너를 h-[100dvh] 앱 셸로 전환하고 main을 내부 스크롤 영역으로 변경
- DmBottomNav를 스크롤 영역 밖 flex 형제로 유지하고 safe-area inset을 높이에 반영
- 탭바 보정용 pb-[88px]/pb-[100px] 제거
- 상세/댓글 고정 CTA는 탭바 + safe-area 위로 뜨도록 bottom 값을 보정

## Test plan
- [x] pnpm lint
- [x] 수정 파일 200줄 이하 확인
- [x] pb-[88px]/pb-[100px]/sticky bottom-0/bottom-[72px] 잔존 검색
- [x] pnpm dev 실행 후 / 페이지 200 응답 확인
- [ ] pnpm build: 컴파일/타입체크 이후 local standalone trace copy 단계에서 실패

빌드 실패 상세: 로컬 node_modules에는 next@13.4.12_react-dom@18.2.0_react@18.2.0 경로만 있는데, Next standalone copy가 next@13.4.12_react-dom@18.2.0_react@18.2.0__react@18.2.0 경로의 server-rendering-stub.js를 찾으며 ENOENT로 실패했습니다. 이번 레이아웃 변경 컴파일은 통과했습니다.

🤖 Generated with Codex