### PR TITLE
🐛 매칭 비로그인 열람 허용

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-detail-container.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-detail-container.tsx
@@ -2,7 +2,6 @@
 
 import { useAppToast } from '@/hooks/use-app-toast'
 import { useSession } from 'next-auth/react'
-import { useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import {
   useApplyMatch,
@@ -28,12 +27,11 @@ const MatchDetailContainer = () => {
     isAuthor ? matchId : '',
   )
 
-  useEffect(() => {
-    if (status === 'loading') return
-    if (status === 'unauthenticated') router.push('/login')
-  }, [status, router])
-
   const handleApplySubmit = async (message: string) => {
+    if (status === 'unauthenticated') {
+      router.push(`/login?callbackUrl=${encodeURIComponent(`/match/${matchId}`)}`)
+      return
+    }
     try {
       await applyToMatch({ message })
       showToast('매치 신청이 완료되었습니다.')
@@ -77,8 +75,6 @@ const MatchDetailContainer = () => {
         loading...
       </div>
     )
-
-  if (status === 'unauthenticated') return null
 
   if (matchError || !matchPost)
     return (

--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -8,6 +8,7 @@ import {
   SectionHead,
 } from '@/components/dm'
 import { MatchPost } from '@/lib/type'
+import { useSession } from 'next-auth/react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
@@ -40,11 +41,21 @@ function ApplicationStatusBadge({ status }: { status: string }) {
 
 const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   const router = useRouter()
+  const { status } = useSession()
   const [showApplyDialog, setShowApplyDialog] = useState(false)
-  const { application: myApplication } = useMyApplication(matchPost.id)
+  const { application: myApplication } = useMyApplication(
+    status === 'authenticated' ? matchPost.id : '',
+  )
   const handleApplySubmit = async (message: string) => {
     await onApply(message)
     setShowApplyDialog(false)
+  }
+  const handleApplyClick = () => {
+    if (status === 'unauthenticated') {
+      router.push(`/login?callbackUrl=${encodeURIComponent(`/match/${matchPost.id}`)}`)
+      return
+    }
+    setShowApplyDialog(true)
   }
   const palette = paletteForMovie(matchPost.id, matchPost.movieTitle)
   const isFull = matchPost.currentParticipants >= matchPost.maxParticipants
@@ -128,7 +139,7 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
         ) : (
           <button
             type="button"
-            onClick={() => setShowApplyDialog(true)}
+            onClick={handleApplyClick}
             disabled={isFull}
             className="w-full rounded-md bg-primary py-3.5 text-[15px] font-bold tracking-[-0.01em] text-primary-foreground disabled:bg-secondary disabled:text-muted-foreground disabled:shadow-none"
           >

--- a/src/app/(root)/(routes)/match/components/match-container.tsx
+++ b/src/app/(root)/(routes)/match/components/match-container.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
 import { useMatchPosts } from '../hooks'
 import { MatchHeaderSection } from '../sections/match-header-section'
@@ -11,6 +11,7 @@ import { MatchListSection } from '../sections/match-list-section'
 export const MatchContainer = () => {
   const { status } = useSession()
   const router = useRouter()
+  const pathname = usePathname() ?? '/match'
   const { toast } = useToast()
   const [showApplyDialog, setShowApplyDialog] = useState(false)
   const [selectedMatch, setSelectedMatch] = useState<any>(null)
@@ -43,7 +44,6 @@ export const MatchContainer = () => {
     }
   }
 
-  // 인증 체크
   if (status === 'loading') {
     return (
       <div className="py-8 text-center">
@@ -52,13 +52,12 @@ export const MatchContainer = () => {
     )
   }
 
-  if (status === 'unauthenticated') {
-    router.push('/login')
-    return null
-  }
-
   // 매치 신청
   const handleApply = (matchId: string) => {
+    if (status === 'unauthenticated') {
+      router.push(`/login?callbackUrl=${encodeURIComponent(pathname)}`)
+      return
+    }
     const match = matchPosts.find((m) => m.id === matchId)
     setSelectedMatch(match)
     setShowApplyDialog(true)

--- a/src/modules/match/match-post-datasource.ts
+++ b/src/modules/match/match-post-datasource.ts
@@ -13,10 +13,11 @@ export class MatchPostDataSource {
   }
 
   private getAuthHeaders(): HeadersInit {
-    return {
+    const headers: HeadersInit = {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${this.token}`,
     }
+    if (this.token) headers.Authorization = `Bearer ${this.token}`
+    return headers
   }
 
   async getMatchPosts(


### PR DESCRIPTION
## Summary
로그아웃 상태에서도 매칭 목록과 상세를 볼 수 있게 하고, 신청 시점에만 로그인으로 유도하도록 변경했습니다.

## 원인
기존 매칭 목록/상세 컨테이너가 비로그인 사용자를 즉시 /login으로 보내 핵심 가치인 매칭 게시글을 보기 전에 전환이 막혔습니다.

## 변경
- /match 진입 시 비로그인 즉시 리다이렉트 제거
- /match/[id] 상세 진입 시 비로그인 즉시 리다이렉트 제거
- 신청 버튼 클릭 시 비로그인이면 /login?callbackUrl=... 로 이동
- 로그인 상태에서만 내 신청 상태 API를 조회하도록 변경
- 토큰 없는 공개 GET 요청에서 Authorization: Bearer undefined 헤더가 붙지 않게 수정

## Test plan
- [x] 백엔드 API Gateway 확인: GET /match, GET /match/:matchId 는 JwtAuthGuard 없음; POST apply 등 액션은 JwtAuthGuard 있음
- [x] pnpm lint
- [x] 수정 파일 200줄 이하 확인
- [x] 비로그인 curl: /match 200 OK
- [x] 비로그인 curl: /api/match?page=1&pageSize=1 200 OK
- [x] 비로그인 curl: /match/:id 200 OK
- [x] 비로그인 curl: POST /api/match/:id/apply 401 Unauthorized

🤖 Generated with Codex