### PR TITLE
🚀 Release: 영화별 매칭 연결

### DIFF
--- a/src/app/(root)/(routes)/match/components/match-container.tsx
+++ b/src/app/(root)/(routes)/match/components/match-container.tsx
@@ -8,10 +8,17 @@ import { useMatchPosts } from '../hooks'
 import { MatchHeaderSection } from '../sections/match-header-section'
 import { MatchListSection } from '../sections/match-list-section'
 
-export const MatchContainer = () => {
+interface MatchContainerProps {
+  movieTitle?: string
+}
+
+export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
   const { status } = useSession()
   const router = useRouter()
   const pathname = usePathname() ?? '/match'
+  const callbackUrl = movieTitle
+    ? `${pathname}?movieTitle=${encodeURIComponent(movieTitle)}`
+    : pathname
   const { toast } = useToast()
   const [showApplyDialog, setShowApplyDialog] = useState(false)
   const [selectedMatch, setSelectedMatch] = useState<any>(null)
@@ -22,7 +29,7 @@ export const MatchContainer = () => {
     hasMore,
     loadMore,
     isLoading: isLoadingPosts,
-  } = useMatchPosts()
+  } = useMatchPosts(10, movieTitle)
   // 매치 신청 함수
   const handleApplyToMatch = async (matchId: string, message: string) => {
     try {
@@ -55,7 +62,7 @@ export const MatchContainer = () => {
   // 매치 신청
   const handleApply = (matchId: string) => {
     if (status === 'unauthenticated') {
-      router.push(`/login?callbackUrl=${encodeURIComponent(pathname)}`)
+      router.push(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`)
       return
     }
     const match = matchPosts.find((m) => m.id === matchId)
@@ -85,7 +92,7 @@ export const MatchContainer = () => {
 
   return (
     <>
-      <MatchHeaderSection />
+      <MatchHeaderSection movieTitle={movieTitle} />
 
       <MatchListSection
         matchPosts={matchPosts}

--- a/src/app/(root)/(routes)/match/hooks/use-match-posts.ts
+++ b/src/app/(root)/(routes)/match/hooks/use-match-posts.ts
@@ -19,15 +19,17 @@ const fetcher = async (url: string): Promise<MatchPostResponse> => {
 
 /** 매치 게시글 목록 key */
 const getKey =
-  (pageSize: number = 10) =>
+  (pageSize: number = 10, movieTitle?: string) =>
   (pageIndex: number, previousPageData: MatchPostResponse | null) => {
     if (previousPageData && !previousPageData.hasNext) return null
-    return AppClientApiEndpoint.getMatchPosts(pageIndex + 1, pageSize)
+    const url = AppClientApiEndpoint.getMatchPosts(pageIndex + 1, pageSize)
+    if (!movieTitle) return url
+    return `${url}&movieTitle=${encodeURIComponent(movieTitle)}`
   }
 
-export const useMatchPosts = (pageSize: number = 10) => {
+export const useMatchPosts = (pageSize: number = 10, movieTitle?: string) => {
   const { data, setSize, mutate, error, isLoading, isValidating } =
-    useSWRInfinite<MatchPostResponse>(getKey(pageSize), fetcher, {
+    useSWRInfinite<MatchPostResponse>(getKey(pageSize, movieTitle), fetcher, {
       refreshInterval: 30000, // 30초마다 새로고침
       revalidateOnFocus: true,
     })

--- a/src/app/(root)/(routes)/match/new/components/new-match-container.tsx
+++ b/src/app/(root)/(routes)/match/new/components/new-match-container.tsx
@@ -6,8 +6,15 @@ import { CreateMatchPostRequest } from '@/lib/type'
 import { useCreateMatch } from '../../hooks'
 import { MatchFormSection } from '../../sections/match-form-section'
 
-const NewMatchContainer = () => {
+interface NewMatchContainerProps {
+  movieTitle?: string
+}
+
+const NewMatchContainer = ({ movieTitle }: NewMatchContainerProps) => {
   const router = useRouter()
+  const matchListHref = movieTitle
+    ? `/match?movieTitle=${encodeURIComponent(movieTitle)}`
+    : '/match'
   const { toast } = useToast()
   const { createMatch } = useCreateMatch()
 
@@ -19,7 +26,7 @@ const NewMatchContainer = () => {
         title: '성공',
         description: '매치가 성공적으로 등록되었습니다.',
       })
-      router.push('/match')
+      router.push(matchListHref)
     } catch (error) {
       const message = error instanceof Error ? error.message : '매치 등록에 실패했습니다.'
       toast({
@@ -31,11 +38,15 @@ const NewMatchContainer = () => {
   }
 
   const handleCancel = () => {
-    router.push('/match')
+    router.push(matchListHref)
   }
 
   return (
-    <MatchFormSection onSubmit={handleCreateMatch} onCancel={handleCancel} />
+    <MatchFormSection
+      onSubmit={handleCreateMatch}
+      onCancel={handleCancel}
+      initialData={movieTitle ? { movieTitle } : undefined}
+    />
   )
 }
 

--- a/src/app/(root)/(routes)/match/new/page.tsx
+++ b/src/app/(root)/(routes)/match/new/page.tsx
@@ -1,7 +1,15 @@
 import { FunctionComponent } from 'react'
 import { NewMatchContainer } from './components/new-match-container'
 
-const Page: FunctionComponent = () => {
+interface PageProps {
+  searchParams?: {
+    movieTitle?: string
+  }
+}
+
+const Page: FunctionComponent<PageProps> = ({ searchParams }) => {
+  const movieTitle = searchParams?.movieTitle?.trim() || undefined
+
   return (
     <div className="min-h-page bg-background text-foreground">
       <div className="flex items-center border-b border-border px-4 py-3.5">
@@ -10,7 +18,7 @@ const Page: FunctionComponent = () => {
         </h1>
       </div>
       <div className="px-5 py-5">
-        <NewMatchContainer />
+        <NewMatchContainer movieTitle={movieTitle} />
       </div>
     </div>
   )

--- a/src/app/(root)/(routes)/match/page.tsx
+++ b/src/app/(root)/(routes)/match/page.tsx
@@ -1,12 +1,18 @@
 import { FunctionComponent } from 'react'
 import { MatchContainer } from './components/match-container'
 
-interface PageProps {}
+interface PageProps {
+  searchParams?: {
+    movieTitle?: string
+  }
+}
 
-const Page: FunctionComponent<PageProps> = () => {
+const Page: FunctionComponent<PageProps> = ({ searchParams }) => {
+  const movieTitle = searchParams?.movieTitle?.trim() || undefined
+
   return (
     <main className="min-h-page bg-background pb-5 text-foreground">
-      <MatchContainer />
+      <MatchContainer movieTitle={movieTitle} />
     </main>
   )
 }

--- a/src/app/(root)/(routes)/match/sections/match-header-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-header-section.tsx
@@ -1,14 +1,24 @@
 import { FunctionComponent } from 'react'
 import Link from 'next/link'
 
-const MatchHeaderSection: FunctionComponent = () => {
+interface MatchHeaderSectionProps {
+  movieTitle?: string
+}
+
+const MatchHeaderSection: FunctionComponent<MatchHeaderSectionProps> = ({
+  movieTitle,
+}) => {
+  const newMatchHref = movieTitle
+    ? `/match/new?movieTitle=${encodeURIComponent(movieTitle)}`
+    : '/match/new'
+
   return (
     <div className="flex items-center border-b border-border px-4 py-3.5">
       <h1 className="text-[18px] font-bold tracking-tight text-foreground">
-        같이 볼 사람
+        {movieTitle ? `${movieTitle} 같이 볼 사람` : '같이 볼 사람'}
       </h1>
       <Link
-        href="/match/new"
+        href={newMatchHref}
         className="ml-auto inline-flex h-8 items-center rounded-md bg-primary px-3 text-[13px] font-medium text-primary-foreground"
       >
         ＋ 만들기

--- a/src/app/api/match/route.ts
+++ b/src/app/api/match/route.ts
@@ -8,11 +8,12 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const page = parseInt(searchParams.get('page') || '1')
     const limit = parseInt(searchParams.get('pageSize') || searchParams.get('limit') || '10')
+    const movieTitle = searchParams.get('movieTitle')?.trim()
 
     const token = getTokenFromCookie()
     const matchRepository = new MatchPostRepository(token)
 
-    const data = await matchRepository.getMatchPosts(page, limit)
+    const data = await matchRepository.getMatchPosts(page, limit, movieTitle)
     return NextResponse.json(data)
   } catch (error) {
     console.error('Match list API error:', error)

--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -25,6 +25,7 @@ export function DmMovieDetail({
   const { h, c, lt, lb } = palette
   const rating = averageScore ?? movie.averageScore ?? 0
   const reviews = scoreCount ?? movie.scoreCount ?? 0
+  const matchHref = `/match?movieTitle=${encodeURIComponent(movie.title)}`
   const genres = movie.genre?.split(/[,/·]/).map((g) => g.trim()).filter(Boolean) ?? []
   const releaseYear = movie.openedAt ? new Date(movie.openedAt).getFullYear() : undefined
 
@@ -86,7 +87,7 @@ export function DmMovieDetail({
             </button>
           )}
           <Link
-            href="/match"
+            href={matchHref}
             className="flex flex-1 items-center justify-center rounded-md bg-primary py-2.5 text-[13px] font-medium text-primary-foreground"
           >
             같이 볼 사람 찾기

--- a/src/modules/match/match-post-datasource.ts
+++ b/src/modules/match/match-post-datasource.ts
@@ -23,10 +23,12 @@ export class MatchPostDataSource {
   async getMatchPosts(
     page: number = 1,
     pageSize: number = 10,
+    movieTitle?: string,
   ): Promise<MatchPostResponse> {
     try {
+      const url = AppBackEndApiEndpoint.getMatchPosts(page, pageSize)
       const response = await fetch(
-        AppBackEndApiEndpoint.getMatchPosts(page, pageSize),
+        movieTitle ? `${url}&movieTitle=${encodeURIComponent(movieTitle)}` : url,
         {
           method: 'GET',
           headers: this.getAuthHeaders(),

--- a/src/modules/match/match-post-repository.ts
+++ b/src/modules/match/match-post-repository.ts
@@ -15,6 +15,7 @@ export class MatchPostRepository {
   async getMatchPosts(
     page: number = 1,
     pageSize: number = 10,
+    movieTitle?: string,
   ): Promise<MatchPostResponse> {
     if (page < 1) {
       throw new Error('페이지 번호는 1 이상이어야 합니다.')
@@ -24,7 +25,7 @@ export class MatchPostRepository {
       throw new Error('페이지 크기는 1-100 사이여야 합니다.')
     }
 
-    return await this.dataSource.getMatchPosts(page, pageSize)
+    return await this.dataSource.getMatchPosts(page, pageSize, movieTitle)
   }
 
   async getMatchPost(matchId: string): Promise<MatchPost> {


### PR DESCRIPTION
## Summary
TASK-6 프론트 변경을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #324 — 영화 상세 CTA를 영화별 매칭 목록으로 연결
- `/match/new?movieTitle=...` 영화 제목 프리필 지원

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build` 컴파일/타입체크 통과 후 기존 로컬 Next standalone copy ENOENT에서 실패
- [x] 백엔드 릴리스 PR #71 배포 성공
- [ ] master 머지 후 GitHub Actions 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)