### PR TITLE
🐛 남은 브랜드 타이틀을 볼래로 교체

### DIFF
--- a/src/app/(root)/(routes)/(auth)/forgot-password/page.tsx
+++ b/src/app/(root)/(routes)/(auth)/forgot-password/page.tsx
@@ -39,7 +39,7 @@ export default function ForgotPasswordPage() {
     return (
       <main className="flex min-h-page flex-col px-6 py-10">
         <div className="mb-8 text-[22px] font-bold tracking-tight text-foreground">
-          drunken<span className="text-primary">movie</span>
+          볼래
         </div>
         <div className="rounded-lg border border-border bg-card p-5">
           <div className="mb-2 text-[15px] font-semibold text-foreground">이메일을 확인하세요</div>
@@ -60,7 +60,7 @@ export default function ForgotPasswordPage() {
   return (
     <main className="flex min-h-page flex-col px-6 py-10">
       <div className="mb-8 text-[22px] font-bold tracking-tight text-foreground">
-        drunken<span className="text-primary">movie</span>
+        볼래
       </div>
 
       <h2 className="mb-1.5 text-[22px] font-semibold tracking-tight text-foreground">비밀번호 찾기</h2>

--- a/src/app/(root)/(routes)/reset-password/page.tsx
+++ b/src/app/(root)/(routes)/reset-password/page.tsx
@@ -62,7 +62,7 @@ export default function ResetPasswordPage() {
   return (
     <main className="flex min-h-page flex-col px-6 py-10">
       <div className="mb-8 text-[22px] font-bold tracking-tight text-foreground">
-        drunken<span className="text-primary">movie</span>
+        볼래
       </div>
 
       <h2 className="mb-1.5 text-[22px] font-semibold tracking-tight text-foreground">새 비밀번호 설정</h2>

--- a/src/components/dm/dm-app-bar.tsx
+++ b/src/components/dm/dm-app-bar.tsx
@@ -21,7 +21,7 @@ export function DmAppBar() {
   return (
     <header className="sticky top-0 z-30 flex items-center border-b border-border bg-background/95 px-4 py-3 backdrop-blur-md">
       <Link href="/" className="text-[17px] font-bold tracking-[-0.02em] text-foreground">
-        drunken<span className="text-primary">movie</span>
+        볼래
       </Link>
 
       <div className="ml-auto flex items-center gap-1">

--- a/src/components/dm/dm-desktop-left-nav.tsx
+++ b/src/components/dm/dm-desktop-left-nav.tsx
@@ -65,7 +65,7 @@ export function DmDesktopLeftNav() {
     <aside className="hidden lg:sticky lg:top-0 lg:flex lg:h-screen lg:w-[240px] lg:shrink-0 lg:flex-col lg:overflow-y-auto lg:border-r lg:border-border">
       <div className="px-4 pb-4 pt-5">
         <Link href="/" className="text-[18px] font-bold tracking-[-0.02em] text-foreground">
-          drunken<span className="text-primary">movie</span>
+          볼래
         </Link>
       </div>
 


### PR DESCRIPTION
## Summary
화면에 남아 있던 `drunkenmovie` 브랜드 타이틀을 `볼래`로 교체합니다.

## 원인
TASK-8 브랜드 교체 이후 홈 상단바/데스크탑 좌측 네비, 비밀번호 관련 화면에 레거시 브랜드 조각이 남아 있었습니다.

## 변경
- 모바일 홈 상단바 브랜드 `볼래`로 교체
- 데스크탑 좌측 네비 브랜드 `볼래`로 교체
- 비밀번호 찾기/재설정 화면 브랜드 `볼래`로 교체

## Test plan
- [x] `rg`로 소스/정적 파일 내 `drunkenmovie`, `영화뭐함` 잔존 검색
- [x] 수정 파일 200줄 상한 점검
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)