### PR TITLE
🐛 매칭 필터를 서버 쿼리로 전환

### DIFF
--- a/src/app/(root)/(routes)/match/components/match-container.tsx
+++ b/src/app/(root)/(routes)/match/components/match-container.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
 import { useMatchPosts } from '../hooks'
+import type { MatchPostFilter } from '../hooks'
 import { MatchHeaderSection } from '../sections/match-header-section'
 import { MatchListSection } from '../sections/match-list-section'
 
@@ -13,13 +14,15 @@ interface MatchContainerProps {
 }
 
 export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
-  const { status } = useSession()
+  const { data: session, status } = useSession()
+  const userId = session?.user?.id ? Number(session.user.id) : null
   const router = useRouter()
   const pathname = usePathname() ?? '/match'
   const callbackUrl = movieTitle
     ? `${pathname}?movieTitle=${encodeURIComponent(movieTitle)}`
     : pathname
   const { toast } = useToast()
+  const [filter, setFilter] = useState<MatchPostFilter>('all')
   const [showApplyDialog, setShowApplyDialog] = useState(false)
   const [selectedMatch, setSelectedMatch] = useState<any>(null)
 
@@ -29,7 +32,7 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
     hasMore,
     loadMore,
     isLoading: isLoadingPosts,
-  } = useMatchPosts(10, movieTitle)
+  } = useMatchPosts(10, { movieTitle, filter, userno: userId })
   // 매치 신청 함수
   const handleApplyToMatch = async (matchId: string, message: string) => {
     try {
@@ -99,6 +102,8 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
         isLoading={isLoadingPosts}
         hasMore={hasMore}
         loadMore={loadMore}
+        filter={filter}
+        onFilterChange={setFilter}
         selectedMatch={selectedMatch}
         showApplyDialog={showApplyDialog}
         onApply={handleApply}

--- a/src/app/(root)/(routes)/match/hooks/index.ts
+++ b/src/app/(root)/(routes)/match/hooks/index.ts
@@ -1,5 +1,6 @@
 // SWR hooks for match functionality
 export { useMatchPosts } from './use-match-posts'
+export type { MatchPostFilter } from './use-match-posts'
 export { useMatchPost } from './use-match-post'
 export { useMatchApplications } from './use-match-applications'
 export {

--- a/src/app/(root)/(routes)/match/hooks/use-match-posts.ts
+++ b/src/app/(root)/(routes)/match/hooks/use-match-posts.ts
@@ -2,6 +2,14 @@ import { AppClientApiEndpoint } from '@/config/app-client-api-endpoint'
 import { MatchPostResponse } from '@/lib/type'
 import useSWRInfinite from 'swr/infinite'
 
+export type MatchPostFilter = 'all' | 'available' | 'week' | 'mine'
+
+interface MatchPostQuery {
+  movieTitle?: string
+  filter?: MatchPostFilter
+  userno?: number | null
+}
+
 const fetcher = async (url: string): Promise<MatchPostResponse> => {
   const response = await fetch(url, {
     method: 'GET',
@@ -19,17 +27,27 @@ const fetcher = async (url: string): Promise<MatchPostResponse> => {
 
 /** 매치 게시글 목록 key */
 const getKey =
-  (pageSize: number = 10, movieTitle?: string) =>
+  (pageSize: number = 10, query: MatchPostQuery = {}) =>
   (pageIndex: number, previousPageData: MatchPostResponse | null) => {
     if (previousPageData && !previousPageData.hasNext) return null
+    if (query.filter === 'mine' && !query.userno) return null
     const url = AppClientApiEndpoint.getMatchPosts(pageIndex + 1, pageSize)
-    if (!movieTitle) return url
-    return `${url}&movieTitle=${encodeURIComponent(movieTitle)}`
+    const params = new URLSearchParams()
+    if (query.movieTitle) params.set('movieTitle', query.movieTitle)
+    if (query.filter && query.filter !== 'all') params.set('filter', query.filter)
+    if (query.filter === 'mine' && query.userno) {
+      params.set('userno', String(query.userno))
+    }
+    const filterQuery = params.toString()
+    return filterQuery ? `${url}&${filterQuery}` : url
   }
 
-export const useMatchPosts = (pageSize: number = 10, movieTitle?: string) => {
+export const useMatchPosts = (
+  pageSize: number = 10,
+  query: MatchPostQuery = {},
+) => {
   const { data, setSize, mutate, error, isLoading, isValidating } =
-    useSWRInfinite<MatchPostResponse>(getKey(pageSize, movieTitle), fetcher, {
+    useSWRInfinite<MatchPostResponse>(getKey(pageSize, query), fetcher, {
       refreshInterval: 30000, // 30초마다 새로고침
       revalidateOnFocus: true,
     })

--- a/src/app/(root)/(routes)/match/sections/match-list-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-list-section.tsx
@@ -1,16 +1,18 @@
 'use client'
 
-import { FunctionComponent, useEffect, useRef, useCallback, useState } from 'react'
-import { useSession } from 'next-auth/react'
+import { FunctionComponent, useEffect, useRef, useCallback } from 'react'
 import { DmMatchTicket } from '@/components/dm'
 import { MatchApplyDialog } from '@/components/app/match-apply-dialog'
 import { cn } from '@/lib/utils'
+import type { MatchPostFilter } from '../hooks'
 
 interface MatchListSectionProps {
   matchPosts: any[]
   isLoading: boolean
   hasMore: boolean
   loadMore: () => void
+  filter: MatchPostFilter
+  onFilterChange: (_filter: MatchPostFilter) => void
   selectedMatch: any
   showApplyDialog: boolean
   onApply: (_matchId: string) => void
@@ -18,36 +20,26 @@ interface MatchListSectionProps {
   onCloseApplyDialog: () => void
 }
 
-const FILTERS = [
+const FILTERS: { key: MatchPostFilter; label: string }[] = [
   { key: 'all',       label: '전체' },
   { key: 'available', label: '모집 중' },
   { key: 'week',      label: '이번 주' },
   { key: 'mine',      label: '내 매칭' },
-] as const
-
-type FilterKey = (typeof FILTERS)[number]['key']
-
-function isThisWeek(showTime: string): boolean {
-  const now = Date.now()
-  const target = new Date(showTime).getTime()
-  const sevenDays = 7 * 24 * 60 * 60 * 1000
-  return target >= now && target <= now + sevenDays
-}
+]
 
 const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
   matchPosts,
   isLoading,
   hasMore,
   loadMore,
+  filter,
+  onFilterChange,
   selectedMatch,
   showApplyDialog,
   onApply,
   onApplySubmit,
   onCloseApplyDialog,
 }) => {
-  const { data: session } = useSession()
-  const userId = session?.user?.id ? Number(session.user.id) : null
-  const [filter, setFilter] = useState<FilterKey>('all')
   const observerRef = useRef<IntersectionObserver | null>(null)
   const loadMoreElementRef = useRef<HTMLDivElement | null>(null)
 
@@ -68,16 +60,8 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
     return () => observerRef.current?.disconnect()
   }, [handleObserver])
 
-  const filtered = matchPosts.filter(Boolean).filter((m) => {
-    switch (filter) {
-      case 'available': return m.currentParticipants < m.maxParticipants
-      case 'week':      return isThisWeek(m.showTime)
-      case 'mine':      return userId !== null && m.userno === userId
-      default:          return true
-    }
-  })
-
-  const emptyMessages: Record<FilterKey, { title: string; sub: string }> = {
+  const list = matchPosts.filter(Boolean)
+  const emptyMessages: Record<MatchPostFilter, { title: string; sub: string }> = {
     all:       { title: '아직 등록된 매치가 없습니다.', sub: '첫 번째 매치를 등록해보세요!' },
     available: { title: '모집 중인 매치가 없습니다.', sub: '잠시 후 다시 확인해보세요.' },
     week:      { title: '이번 주 예정된 매치가 없습니다.', sub: '직접 매치를 만들어보세요!' },
@@ -102,7 +86,7 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
           {FILTERS.map(({ key, label }) => (
             <button
               key={key}
-              onClick={() => setFilter(key)}
+              onClick={() => onFilterChange(key)}
               className={cn(
                 'rounded px-3 py-1.5 text-[12px] font-medium transition-colors',
                 filter === key
@@ -116,22 +100,14 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
         </div>
       </div>
 
-      {filtered.length === 0 && !isLoading ? (
+      {list.length === 0 && !isLoading ? (
         <div className="py-12 text-center text-muted-foreground">
           <p className="text-[14px]">{emptyTitle}</p>
           <p className="mt-1 text-[12px]">{emptySub}</p>
-          {(filter === 'week' || filter === 'mine') && hasMore && (
-            <button
-              onClick={loadMore}
-              className="mt-4 rounded-md border border-border px-4 py-2 font-mono text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              더 불러오기
-            </button>
-          )}
         </div>
       ) : (
         <div className="flex flex-col gap-3 px-4 py-2">
-          {filtered.map((match) => (
+          {list.map((match) => (
             <div key={match.id}>
               <DmMatchTicket match={match} />
               <button
@@ -151,7 +127,7 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
         {isLoading && matchPosts.length > 0 && (
           <div className="text-center font-mono text-[11px] text-muted-foreground">불러오는 중...</div>
         )}
-        {!hasMore && filtered.length > 0 && (
+        {!hasMore && list.length > 0 && (
           <div className="text-center font-mono text-[11px] text-muted-foreground">— 끝 —</div>
         )}
       </div>

--- a/src/app/api/match/route.ts
+++ b/src/app/api/match/route.ts
@@ -9,11 +9,17 @@ export async function GET(request: NextRequest) {
     const page = parseInt(searchParams.get('page') || '1')
     const limit = parseInt(searchParams.get('pageSize') || searchParams.get('limit') || '10')
     const movieTitle = searchParams.get('movieTitle')?.trim()
+    const filter = searchParams.get('filter')?.trim()
+    const userno = Number(searchParams.get('userno')) || undefined
 
     const token = getTokenFromCookie()
     const matchRepository = new MatchPostRepository(token)
 
-    const data = await matchRepository.getMatchPosts(page, limit, movieTitle)
+    const data = await matchRepository.getMatchPosts(page, limit, {
+      movieTitle,
+      filter,
+      userno,
+    })
     return NextResponse.json(data)
   } catch (error) {
     console.error('Match list API error:', error)

--- a/src/modules/match/match-post-datasource.ts
+++ b/src/modules/match/match-post-datasource.ts
@@ -5,6 +5,12 @@ import type {
   CreateMatchPostRequest,
 } from './match.entity'
 
+interface MatchPostQuery {
+  movieTitle?: string
+  filter?: string
+  userno?: number
+}
+
 export class MatchPostDataSource {
   private token?: string
 
@@ -23,12 +29,17 @@ export class MatchPostDataSource {
   async getMatchPosts(
     page: number = 1,
     pageSize: number = 10,
-    movieTitle?: string,
+    query: MatchPostQuery = {},
   ): Promise<MatchPostResponse> {
     try {
       const url = AppBackEndApiEndpoint.getMatchPosts(page, pageSize)
+      const params = new URLSearchParams()
+      if (query.movieTitle) params.set('movieTitle', query.movieTitle)
+      if (query.filter) params.set('filter', query.filter)
+      if (query.userno) params.set('userno', String(query.userno))
+      const filterQuery = params.toString()
       const response = await fetch(
-        movieTitle ? `${url}&movieTitle=${encodeURIComponent(movieTitle)}` : url,
+        filterQuery ? `${url}&${filterQuery}` : url,
         {
           method: 'GET',
           headers: this.getAuthHeaders(),

--- a/src/modules/match/match-post-repository.ts
+++ b/src/modules/match/match-post-repository.ts
@@ -5,6 +5,12 @@ import type {
   CreateMatchPostRequest,
 } from './match.entity'
 
+interface MatchPostQuery {
+  movieTitle?: string
+  filter?: string
+  userno?: number
+}
+
 export class MatchPostRepository {
   private dataSource: MatchPostDataSource
 
@@ -15,7 +21,7 @@ export class MatchPostRepository {
   async getMatchPosts(
     page: number = 1,
     pageSize: number = 10,
-    movieTitle?: string,
+    query: MatchPostQuery = {},
   ): Promise<MatchPostResponse> {
     if (page < 1) {
       throw new Error('페이지 번호는 1 이상이어야 합니다.')
@@ -25,7 +31,7 @@ export class MatchPostRepository {
       throw new Error('페이지 크기는 1-100 사이여야 합니다.')
     }
 
-    return await this.dataSource.getMatchPosts(page, pageSize, movieTitle)
+    return await this.dataSource.getMatchPosts(page, pageSize, query)
   }
 
   async getMatchPost(matchId: string): Promise<MatchPost> {


### PR DESCRIPTION
## Summary
매칭 목록 필터를 클라이언트 후처리에서 서버 쿼리 기반으로 전환합니다.

## 원인
기존에는 로드된 페이지만 필터링해 “결과 없음”과 “더 불러오기”가 동시에 나오는 등 전체 데이터 기준 필터 결과가 부정확할 수 있었습니다.

## 변경
- 필터 상태를 목록 컨테이너로 올려 SWR key에 반영
- `/api/match` BFF, repository, datasource에 `filter`, `userno` 전달
- 목록 섹션의 클라이언트 필터링 제거
- 빈 결과에서 필터 보정용 “더 불러오기” 버튼 제거
- 비로그인 `내 매칭`은 요청 없이 빈 결과 처리

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 점검
- [ ] 백엔드 PR #72 배포 후 필터별 API 동작 확인

## Related
- Backend: https://github.com/sihun0105/movie-review-msa/pull/72

🤖 Generated with [Claude Code](https://claude.com/claude-code)