### PR TITLE
🐛 홈 날짜를 KST 기준으로 계산

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -51,14 +51,23 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 }
 
-const TODAY_LABEL = (() => {
-  const d = new Date()
-  const days = ['일', '월', '화', '수', '목', '금', '토']
-  return `${days[d.getDay()]} · ${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`
-})()
+const getKstTodayLabel = () => {
+  const parts = new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    weekday: 'short',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date())
+
+  const getPart = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? ''
+
+  return `${getPart('weekday')} · ${getPart('month')}.${getPart('day')}`
+}
 
 const Page: FunctionComponent = async () => {
   const [data, liveCount] = await Promise.all([getMovieList(), getMatchLiveCount()])
+  const todayLabel = getKstTodayLabel()
 
   if (!data || data.length === 0) {
     return <AppSkeleton className="container min-h-[364px] p-6" />
@@ -69,7 +78,7 @@ const Page: FunctionComponent = async () => {
 
   return (
     <main className="pb-5">
-      <MatchHeroBanner todayLabel={TODAY_LABEL} liveCount={liveCount || undefined} />
+      <MatchHeroBanner todayLabel={todayLabel} liveCount={liveCount || undefined} />
 
       <div className="flex items-center gap-2 px-4 pb-3 pt-5">
         <h2 className="text-[16px] font-semibold text-foreground">박스오피스</h2>


### PR DESCRIPTION
## Summary
홈 Hero 날짜 라벨을 KST 현재일 기준으로 계산하도록 수정합니다.

## 원인
기존 날짜 라벨은 모듈 상단 상수에서 `new Date()`로 계산되어 서버 프로세스 시작/빌드 시점 값이 유지될 수 있었습니다.

## 변경
- `Intl.DateTimeFormat`에 `Asia/Seoul` 타임존을 지정해 요일/월/일을 계산
- 날짜 라벨을 페이지 렌더링 시점에 생성하도록 이동

## Test plan
- [x] `pnpm lint`
- [x] KST 라벨 계산 확인: `목 · 06.04`
- [x] 수정 파일 200줄 상한 확인: 101줄
- [ ] `pnpm build`는 컴파일/타입 체크 이후 standalone copy 단계에서 로컬 `node_modules/.pnpm` ENOENT로 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)