### PR TITLE
🐛 매칭 작성 페이지 비로그인 접근 보호

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,5 +22,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/account/:path*'],
+  matcher: ['/account/:path*', '/match/new'],
 }


### PR DESCRIPTION
## Summary
BOLLAE-18: 비로그인 사용자가 `/match/new` 작성 폼에 바로 진입하지 못하도록 보호합니다.

## 원인
기존에는 `/match/new?movieTitle=...` 에 비로그인 상태로 접근해도 작성 폼이 열려, 제출 단계에서 인증 실패를 경험할 수 있었습니다.

## 변경
- Next middleware 보호 matcher에 `/match/new` 추가
- 기존 middleware callbackUrl 로직을 그대로 사용해 `movieTitle` 쿼리 보존

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: `src/middleware.ts` 26줄
- [ ] 배포 후 비로그인 `/match/new?movieTitle=군체` → `/login?callbackUrl=%2Fmatch%2Fnew%3FmovieTitle%3D...` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)