### PR TITLE
💄 매칭 작성 폼 하단 액션 고정

### DIFF
--- a/src/components/form/match/match-post-form.tsx
+++ b/src/components/form/match/match-post-form.tsx
@@ -46,7 +46,7 @@ const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
 
   return (
     <Form {...form}>
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4 pb-4 lg:pb-0">
         <TitleInputField />
         <ContentInputField />
 
@@ -59,7 +59,7 @@ const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
         <MaxParticipantsInputField />
         <LocationInputField />
 
-        <div className="flex gap-2 pt-2">
+        <div className="sticky bottom-0 z-10 flex gap-2 border-t border-border bg-background/95 py-3 backdrop-blur lg:static lg:border-t-0 lg:bg-transparent lg:py-0 lg:pt-2 lg:backdrop-blur-none">
           <button
             type="button"
             onClick={onCancel}


### PR DESCRIPTION
## Summary
BOLLAE-19: 모바일 매칭 작성 폼에서 마지막 입력, 등록 버튼, 푸터, 하단 탭바가 겹치지 않도록 하단 액션 영역을 정리합니다.

## 변경
- 매칭 작성 폼의 취소/등록 버튼을 모바일에서 sticky 하단 액션으로 전환
- 데스크톱에서는 기존 일반 흐름을 유지
- 폼 하단 여백을 추가해 버튼 접근성을 보완

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: `match-post-form.tsx` 83줄
- [x] 로컬 `/match/new?movieTitle=군체` 쿠키 포함 렌더링 확인
- [x] 로컬 비로그인 `/match/new?movieTitle=군체` 로그인 redirect 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)