### PR TITLE
🐛 목록 신청 로그인 후 상세 맥락 유지

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-detail-container.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-detail-container.tsx
@@ -29,7 +29,9 @@ const MatchDetailContainer = () => {
 
   const handleApplySubmit = async (message: string) => {
     if (status === 'unauthenticated') {
-      router.push(`/login?callbackUrl=${encodeURIComponent(`/match/${matchId}`)}`)
+      router.push(
+        `/login?callbackUrl=${encodeURIComponent(`/match/${matchId}?intent=apply`)}`,
+      )
       return
     }
     try {

--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -10,8 +10,8 @@ import {
 import { MatchPost } from '@/lib/type'
 import { useSession } from 'next-auth/react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
 import { useMyApplication } from '../../hooks/use-my-application'
 
 interface MatchViewerViewProps {
@@ -41,9 +41,11 @@ function ApplicationStatusBadge({ status }: { status: string }) {
 
 const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { status } = useSession()
   const [showApplyDialog, setShowApplyDialog] = useState(false)
-  const { application: myApplication } = useMyApplication(
+  const handledApplyIntentRef = useRef(false)
+  const { application: myApplication, isLoading: isMyApplicationLoading } = useMyApplication(
     status === 'authenticated' ? matchPost.id : '',
   )
   const handleApplySubmit = async (message: string) => {
@@ -52,13 +54,34 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   }
   const handleApplyClick = () => {
     if (status === 'unauthenticated') {
-      router.push(`/login?callbackUrl=${encodeURIComponent(`/match/${matchPost.id}`)}`)
+      router.push(
+        `/login?callbackUrl=${encodeURIComponent(`/match/${matchPost.id}?intent=apply`)}`,
+      )
       return
     }
     setShowApplyDialog(true)
   }
   const palette = paletteForMovie(matchPost.id, matchPost.movieTitle)
   const isFull = matchPost.currentParticipants >= matchPost.maxParticipants
+
+  useEffect(() => {
+    if (handledApplyIntentRef.current) return
+    if (searchParams?.get('intent') !== 'apply') return
+    if (status !== 'authenticated' || isMyApplicationLoading) return
+    if (isFull || myApplication) return
+
+    handledApplyIntentRef.current = true
+    setShowApplyDialog(true)
+    router.replace(`/match/${matchPost.id}`)
+  }, [
+    isFull,
+    isMyApplicationLoading,
+    matchPost.id,
+    myApplication,
+    router,
+    searchParams,
+    status,
+  ])
 
   return (
     <div className="relative min-h-page bg-background pb-[140px] lg:pb-6 text-foreground">

--- a/src/app/(root)/(routes)/match/components/match-container.tsx
+++ b/src/app/(root)/(routes)/match/components/match-container.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { usePathname, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
 import { useMatchPosts } from '../hooks'
 import type { MatchPostFilter } from '../hooks'
@@ -17,10 +17,6 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
   const { data: session, status } = useSession()
   const userId = session?.user?.id ? Number(session.user.id) : null
   const router = useRouter()
-  const pathname = usePathname() ?? '/match'
-  const callbackUrl = movieTitle
-    ? `${pathname}?movieTitle=${encodeURIComponent(movieTitle)}`
-    : pathname
   const { toast } = useToast()
   const [filter, setFilter] = useState<MatchPostFilter>('all')
   const [showApplyDialog, setShowApplyDialog] = useState(false)
@@ -65,7 +61,9 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
   // 매치 신청
   const handleApply = (matchId: string) => {
     if (status === 'unauthenticated') {
-      router.push(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`)
+      router.push(
+        `/login?callbackUrl=${encodeURIComponent(`/match/${matchId}?intent=apply`)}`,
+      )
       return
     }
     const match = matchPosts.find((m) => m.id === matchId)


### PR DESCRIPTION
## Summary
BOLLAE-20: 매칭 목록에서 신청하기를 누른 비로그인 사용자가 로그인 후 해당 매칭 상세 맥락으로 돌아오도록 수정합니다.

## 원인
기존 목록 신청 callback은 `/match`만 전달해 로그인 후 사용자가 눌렀던 매칭을 다시 찾아야 했습니다.

## 변경
- 목록 신청 callback을 `/match/<matchId>?intent=apply`로 변경
- 상세 신청 로그인 callback도 `intent=apply`를 보존
- 로그인 후 상세에서 `intent=apply`가 있으면 내 신청 상태 확인 후 신청 모달 자동 오픈
- 모달 오픈 후 URL의 intent 쿼리를 제거해 반복 오픈 방지

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)