### PR TITLE
🚀 Release: 목록 신청 상세 callback

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-detail-container.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-detail-container.tsx
@@ -29,7 +29,9 @@ const MatchDetailContainer = () => {
 
   const handleApplySubmit = async (message: string) => {
     if (status === 'unauthenticated') {
-      router.push(`/login?callbackUrl=${encodeURIComponent(`/match/${matchId}`)}`)
+      router.push(
+        `/login?callbackUrl=${encodeURIComponent(`/match/${matchId}?intent=apply`)}`,
+      )
       return
     }
     try {

--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -10,8 +10,8 @@ import {
 import { MatchPost } from '@/lib/type'
 import { useSession } from 'next-auth/react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
 import { useMyApplication } from '../../hooks/use-my-application'
 
 interface MatchViewerViewProps {
@@ -41,9 +41,11 @@ function ApplicationStatusBadge({ status }: { status: string }) {
 
 const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { status } = useSession()
   const [showApplyDialog, setShowApplyDialog] = useState(false)
-  const { application: myApplication } = useMyApplication(
+  const handledApplyIntentRef = useRef(false)
+  const { application: myApplication, isLoading: isMyApplicationLoading } = useMyApplication(
     status === 'authenticated' ? matchPost.id : '',
   )
   const handleApplySubmit = async (message: string) => {
@@ -52,13 +54,34 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   }
   const handleApplyClick = () => {
     if (status === 'unauthenticated') {
-      router.push(`/login?callbackUrl=${encodeURIComponent(`/match/${matchPost.id}`)}`)
+      router.push(
+        `/login?callbackUrl=${encodeURIComponent(`/match/${matchPost.id}?intent=apply`)}`,
+      )
       return
     }
     setShowApplyDialog(true)
   }
   const palette = paletteForMovie(matchPost.id, matchPost.movieTitle)
   const isFull = matchPost.currentParticipants >= matchPost.maxParticipants
+
+  useEffect(() => {
+    if (handledApplyIntentRef.current) return
+    if (searchParams?.get('intent') !== 'apply') return
+    if (status !== 'authenticated' || isMyApplicationLoading) return
+    if (isFull || myApplication) return
+
+    handledApplyIntentRef.current = true
+    setShowApplyDialog(true)
+    router.replace(`/match/${matchPost.id}`)
+  }, [
+    isFull,
+    isMyApplicationLoading,
+    matchPost.id,
+    myApplication,
+    router,
+    searchParams,
+    status,
+  ])
 
   return (
     <div className="relative min-h-page bg-background pb-[140px] lg:pb-6 text-foreground">

--- a/src/app/(root)/(routes)/match/components/match-container.tsx
+++ b/src/app/(root)/(routes)/match/components/match-container.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { usePathname, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
 import { useMatchPosts } from '../hooks'
 import type { MatchPostFilter } from '../hooks'
@@ -17,10 +17,6 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
   const { data: session, status } = useSession()
   const userId = session?.user?.id ? Number(session.user.id) : null
   const router = useRouter()
-  const pathname = usePathname() ?? '/match'
-  const callbackUrl = movieTitle
-    ? `${pathname}?movieTitle=${encodeURIComponent(movieTitle)}`
-    : pathname
   const { toast } = useToast()
   const [filter, setFilter] = useState<MatchPostFilter>('all')
   const [showApplyDialog, setShowApplyDialog] = useState(false)
@@ -65,7 +61,9 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
   // 매치 신청
   const handleApply = (matchId: string) => {
     if (status === 'unauthenticated') {
-      router.push(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`)
+      router.push(
+        `/login?callbackUrl=${encodeURIComponent(`/match/${matchId}?intent=apply`)}`,
+      )
       return
     }
     const match = matchPosts.find((m) => m.id === matchId)


### PR DESCRIPTION
## Summary
BOLLAE-20 목록 신청 callback 개선을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #336 — 목록 신청 로그인 후 `/match/<matchId>?intent=apply`로 복귀
- 로그인 후 상세에서 신청 모달 자동 오픈

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)