### PR TITLE
💄 영화 상세 영상 버튼 라벨 정리

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/components/movie-carousel.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/components/movie-carousel.tsx
@@ -16,7 +16,7 @@ const MovieCarousel: FunctionComponent<MovieCarouselProps> = ({ data, title }) =
   if (!data || data.length === 0)
     return (
       <p className="text-center font-mono text-[11px] text-muted-foreground">
-        VOD 데이터가 없습니다.
+        영상 데이터가 없습니다.
       </p>
     )
 

--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -83,7 +83,7 @@ export function DmMovieDetail({
               onClick={onVodClick}
               className="flex-1 rounded-md border border-border py-2.5 text-[13px] font-medium text-foreground hover:bg-accent"
             >
-              ▶ VOD 보기
+              ▶ 영상 보기
             </button>
           )}
           <Link


### PR DESCRIPTION
## Summary
BOLLAE-21: 영화 상세의 VOD 표현을 실제 iframe 영상 동작에 맞게 정리합니다.

## 변경
- `VOD 보기` 버튼 라벨을 `영상 보기`로 변경
- 영상 목록 빈 상태 문구를 `영상 데이터가 없습니다.`로 변경

## Test plan
- [x] `pnpm lint`
- [x] 사용자 노출 `VOD 보기`, `VOD 데이터` 잔여 검색
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)