### PR TITLE
🐛 로그인 액션 중복 클릭 방지

### DIFF
--- a/src/app/(root)/(routes)/(auth)/login/page.tsx
+++ b/src/app/(root)/(routes)/(auth)/login/page.tsx
@@ -5,10 +5,11 @@ import { AppPath } from '@/config/app-path'
 import { signIn } from 'next-auth/react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { FunctionComponent } from 'react'
+import { FunctionComponent, useState } from 'react'
 
 const Page: FunctionComponent = () => {
   const searchParams = useSearchParams()
+  const [isGoogleSubmitting, setIsGoogleSubmitting] = useState(false)
   const rawCallback = searchParams?.get('callbackUrl') ?? AppPath.home()
   const callbackUrl = (() => {
     try {
@@ -19,8 +20,19 @@ const Page: FunctionComponent = () => {
     }
   })()
 
+  const handleGoogleSignIn = async () => {
+    if (isGoogleSubmitting) return
+
+    setIsGoogleSubmitting(true)
+    try {
+      await signIn('google', { callbackUrl })
+    } catch {
+      setIsGoogleSubmitting(false)
+    }
+  }
+
   return (
-    <main className="flex min-h-page flex-col px-6 py-10">
+    <main className="flex min-h-page flex-col px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-10 lg:pb-10">
       <div className="mb-8">
         <div className="text-[22px] font-bold tracking-tight text-foreground">
           볼래
@@ -41,8 +53,9 @@ const Page: FunctionComponent = () => {
 
       <button
         type="button"
-        onClick={() => signIn('google', { callbackUrl })}
-        className="flex h-10 w-full items-center justify-center gap-2 rounded-md border border-border text-[14px] font-medium text-foreground hover:bg-accent"
+        onClick={handleGoogleSignIn}
+        disabled={isGoogleSubmitting}
+        className="flex h-10 w-full items-center justify-center gap-2 rounded-md border border-border text-[14px] font-medium text-foreground hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
           <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
@@ -50,10 +63,10 @@ const Page: FunctionComponent = () => {
           <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
           <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
         </svg>
-        Google로 계속하기
+        {isGoogleSubmitting ? 'Google로 이동 중...' : 'Google로 계속하기'}
       </button>
 
-      <div className="mt-auto pt-8 space-y-2 text-center">
+      <div className="mt-8 space-y-2 text-center">
         <div>
           <Link href={AppPath.forgotPassword()} className="text-[13px] text-muted-foreground hover:text-foreground">
             비밀번호 찾기

--- a/src/components/dm/dm-login-form.tsx
+++ b/src/components/dm/dm-login-form.tsx
@@ -24,23 +24,29 @@ export function DmLoginForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!userId.trim() || !password) return
+    if (isSubmitting || !userId.trim() || !password) return
     setIsSubmitting(true)
     setError(null)
-    const res = await signIn('credentials', {
-      userId,
-      password,
-      redirect: false,
-      callbackUrl,
-    })
-    if (res?.error) {
+
+    try {
+      const res = await signIn('credentials', {
+        userId,
+        password,
+        redirect: false,
+        callbackUrl,
+      })
+      if (res?.error) {
+        setIsSubmitting(false)
+        setError('이메일 또는 비밀번호가 올바르지 않습니다.')
+        return
+      }
+      // router.push는 클라이언트 사이드 네비게이션이라 방금 설정된 세션 쿠키가
+      // 미들웨어에 전파되기 전에 실행될 수 있음 → 풀 페이지 로드로 강제
+      window.location.href = res?.url ? toRelativePath(res.url) : callbackUrl
+    } catch {
       setIsSubmitting(false)
-      setError('이메일 또는 비밀번호가 올바르지 않습니다.')
-      return
+      setError('로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
     }
-    // router.push는 클라이언트 사이드 네비게이션이라 방금 설정된 세션 쿠키가
-    // 미들웨어에 전파되기 전에 실행될 수 있음 → 풀 페이지 로드로 강제
-    window.location.href = callbackUrl
   }
 
   return (
@@ -82,7 +88,7 @@ export function DmLoginForm() {
       <button
         type="submit"
         disabled={isSubmitting || !userId || !password}
-        className="h-11 w-full rounded-md bg-primary text-[14px] font-medium text-primary-foreground disabled:opacity-50"
+        className="h-11 w-full rounded-md bg-primary text-[14px] font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isSubmitting ? '로그인 중...' : '로그인'}
       </button>


### PR DESCRIPTION
## Summary
로그인 페이지에서 Google 로그인 버튼을 여러 번 클릭하면 NextAuth error 페이지로 이동할 수 있는 문제를 방지합니다.
회원가입/비밀번호 찾기 링크가 모바일 하단 UI와 겹치지 않도록 배치를 조정합니다.

## 원인
- Google 로그인 버튼이 진행 중 상태 없이 `signIn`을 반복 호출할 수 있었습니다.
- 로그인 하단 링크가 `mt-auto`로 화면 하단에 밀려 모바일 하단 탭바/푸터 영역과 가까워졌습니다.

## 변경
- Google 로그인 버튼에 진행 중 상태와 disabled 처리를 추가
- 이메일 로그인 폼의 중복 제출 방어 및 예외 처리 추가
- 로그인 하단 링크를 본문 흐름에 배치하고 모바일 하단 여백 보강

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: login/page.tsx 86줄, dm-login-form.tsx 97줄
- [x] 로컬 모바일 폭에서 회원가입 링크 클릭 시 `/register` 이동 확인
- [x] 로컬 모바일 폭에서 비밀번호 찾기 링크 클릭 시 `/forgot-password` 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)