### PR TITLE
🐛 모바일 로그인 링크 터치 영역 수정

### DIFF
--- a/src/app/(root)/(routes)/(auth)/login/page.tsx
+++ b/src/app/(root)/(routes)/(auth)/login/page.tsx
@@ -45,6 +45,20 @@ const Page: FunctionComponent = () => {
 
       <DmLoginForm />
 
+      <div className="relative z-30 mt-5 space-y-2 text-center">
+        <div>
+          <Link href={AppPath.forgotPassword()} className="text-[13px] text-muted-foreground hover:text-foreground">
+            비밀번호 찾기
+          </Link>
+        </div>
+        <div>
+          <span className="text-[13px] text-muted-foreground">아직 계정이 없으신가요? </span>
+          <Link href={AppPath.register()} className="text-[13px] font-medium text-foreground hover:underline">
+            회원가입
+          </Link>
+        </div>
+      </div>
+
       <div className="my-5 flex items-center gap-3">
         <span className="h-px flex-1 bg-border" />
         <span className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">or</span>
@@ -65,20 +79,6 @@ const Page: FunctionComponent = () => {
         </svg>
         {isGoogleSubmitting ? 'Google로 이동 중...' : 'Google로 계속하기'}
       </button>
-
-      <div className="mt-8 space-y-2 text-center">
-        <div>
-          <Link href={AppPath.forgotPassword()} className="text-[13px] text-muted-foreground hover:text-foreground">
-            비밀번호 찾기
-          </Link>
-        </div>
-        <div>
-          <span className="text-[13px] text-muted-foreground">아직 계정이 없으신가요? </span>
-          <Link href={AppPath.register()} className="text-[13px] font-medium text-foreground hover:underline">
-            회원가입
-          </Link>
-        </div>
-      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
작은 모바일 화면에서 로그인 페이지의 비밀번호 찾기/회원가입 링크가 footer 또는 하단 탭바에 가려져 터치되지 않는 문제를 수정합니다.

## 원인
- 375x667 모바일 높이에서 링크 터치 지점 위에 하단 탭바 또는 footer가 올라와 있었습니다.
- 이전 확인은 390x844 기준이라 작은 화면의 레이어 겹침을 놓쳤습니다.

## 변경
- 로그인 보조 링크를 로그인 폼 바로 아래로 이동
- 링크 묶음에 `relative z-30`을 적용해 footer보다 위 터치 레이어에 배치

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: login/page.tsx 86줄
- [x] 375x667 로컬 모바일 hit-test에서 두 링크 모두 최상단 터치 요소로 확인
- [x] 375x667 로컬 모바일에서 회원가입 클릭 시 `/register` 이동 확인
- [x] 375x667 로컬 모바일에서 비밀번호 찾기 클릭 시 `/forgot-password` 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)