### PR TITLE
💄 모바일 로그인 화면 레이아웃 정리

### DIFF
--- a/src/app/(root)/(routes)/(auth)/login/page.tsx
+++ b/src/app/(root)/(routes)/(auth)/login/page.tsx
@@ -32,14 +32,7 @@ const Page: FunctionComponent = () => {
   }
 
   return (
-    <main className="flex min-h-page flex-col px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-10 lg:pb-10">
-      <div className="mb-8">
-        <div className="text-[22px] font-bold tracking-tight text-foreground">
-          볼래
-        </div>
-        <p className="mt-1 text-[13px] text-muted-foreground">오늘 밤, 같이 볼 사람을 찾아보세요</p>
-      </div>
-
+    <main className="flex flex-col px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-10 lg:min-h-page lg:pb-10">
       <h2 className="mb-1.5 text-[22px] font-semibold tracking-tight text-foreground">로그인</h2>
       <p className="mb-6 text-[13px] text-muted-foreground">이메일과 비밀번호를 입력하세요</p>
 


### PR DESCRIPTION
## Summary
모바일 로그인 화면에서 상단 브랜드 안내 문구를 제거하고, Google 로그인 버튼이 footer와 겹치지 않도록 레이아웃을 정리합니다.

## 원인
- 로그인 페이지가 모바일에서 `min-h-page` 높이로 고정되어 컨텐츠가 아래로 넘쳤습니다.
- 넘친 Google 버튼 영역 위에 footer가 시작되어 버튼 높이와 터치 영역이 깨졌습니다.

## 변경
- 로그인 화면 최상단의 `볼래 / 오늘 밤, 같이 볼 사람을 찾아보세요` 블록 제거
- 모바일에서는 로그인 페이지가 콘텐츠 높이대로 흐르도록 `min-h-page`를 데스크톱에만 적용

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: login/page.tsx 79줄
- [x] 375x667 로컬 모바일에서 상단 안내 문구 미노출 확인
- [x] 375x667 로컬 모바일에서 Google 버튼 높이 40px 및 hit-test 최상단 요소 버튼 확인
- [x] 로컬 로그인 링크 `/forgot-password`, `/register` 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)