### PR TITLE
🚀 Release: 모바일 로그인 레이아웃

### DIFF
--- a/src/app/(root)/(routes)/(auth)/login/page.tsx
+++ b/src/app/(root)/(routes)/(auth)/login/page.tsx
@@ -32,14 +32,7 @@ const Page: FunctionComponent = () => {
   }
 
   return (
-    <main className="flex min-h-page flex-col px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-10 lg:pb-10">
-      <div className="mb-8">
-        <div className="text-[22px] font-bold tracking-tight text-foreground">
-          볼래
-        </div>
-        <p className="mt-1 text-[13px] text-muted-foreground">오늘 밤, 같이 볼 사람을 찾아보세요</p>
-      </div>
-
+    <main className="flex flex-col px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-10 lg:min-h-page lg:pb-10">
       <h2 className="mb-1.5 text-[22px] font-semibold tracking-tight text-foreground">로그인</h2>
       <p className="mb-6 text-[13px] text-muted-foreground">이메일과 비밀번호를 입력하세요</p>
 


### PR DESCRIPTION
## Summary
모바일 로그인 화면 레이아웃 정리 사항을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #344 — 로그인 상단 브랜드 안내 문구 제거
- PR #344 — 모바일에서 Google 로그인 버튼이 footer와 겹치지 않도록 높이 흐름 수정

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인
- [x] 375x667 로컬 모바일에서 Google 버튼 레이아웃 및 hit-test 확인
- [x] 로컬 로그인 링크 `/forgot-password`, `/register` 이동 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 모바일 화면 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)