### PR TITLE
💄 페이지별 SEO 메타 정리

### DIFF
--- a/src/app/(root)/(routes)/articles/page.tsx
+++ b/src/app/(root)/(routes)/articles/page.tsx
@@ -1,6 +1,28 @@
+import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import Link from 'next/link'
 import ArticleSection from './components/article-section'
+
+export const metadata: Metadata = {
+  title: '커뮤니티 | 볼래',
+  description:
+    '볼래 커뮤니티에서 영화 후기, 추천, 같이 보고 싶은 영화 이야기를 나눠보세요.',
+  alternates: {
+    canonical: 'https://bollae.kr/articles',
+  },
+  openGraph: {
+    title: '커뮤니티 | 볼래',
+    description:
+      '볼래 커뮤니티에서 영화 후기, 추천, 같이 보고 싶은 영화 이야기를 나눠보세요.',
+    url: 'https://bollae.kr/articles',
+    type: 'website',
+  },
+  twitter: {
+    title: '커뮤니티 | 볼래',
+    description:
+      '볼래 커뮤니티에서 영화 후기, 추천, 같이 보고 싶은 영화 이야기를 나눠보세요.',
+  },
+}
 
 const Page: FunctionComponent = () => {
   return (

--- a/src/app/(root)/(routes)/match/new/page.tsx
+++ b/src/app/(root)/(routes)/match/new/page.tsx
@@ -1,5 +1,23 @@
+import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import { NewMatchContainer } from './components/new-match-container'
+
+export const metadata: Metadata = {
+  title: '매치 만들기 | 볼래',
+  description: '볼래에서 함께 볼 영화 약속을 직접 만들어보세요.',
+  alternates: {
+    canonical: 'https://bollae.kr/match/new',
+  },
+  openGraph: {
+    title: '매치 만들기 | 볼래',
+    description: '볼래에서 함께 볼 영화 약속을 직접 만들어보세요.',
+    url: 'https://bollae.kr/match/new',
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 interface PageProps {
   searchParams?: {

--- a/src/app/(root)/(routes)/match/page.tsx
+++ b/src/app/(root)/(routes)/match/page.tsx
@@ -1,9 +1,48 @@
+import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import { MatchContainer } from './components/match-container'
+
+const SITE_URL = 'https://bollae.kr'
+
+function withObjectParticle(text: string) {
+  const last = text.charCodeAt(text.length - 1)
+  const hasFinalConsonant =
+    last >= 0xac00 && last <= 0xd7a3 && (last - 0xac00) % 28 !== 0
+  return `${text}${hasFinalConsonant ? '을' : '를'}`
+}
 
 interface PageProps {
   searchParams?: {
     movieTitle?: string
+  }
+}
+
+export function generateMetadata({ searchParams }: PageProps): Metadata {
+  const movieTitle = searchParams?.movieTitle?.trim()
+  const title = movieTitle
+    ? `${movieTitle} 같이 볼 사람 찾기 | 볼래`
+    : '매칭 | 볼래'
+  const description = movieTitle
+    ? `볼래에서 ${withObjectParticle(movieTitle)} 함께 볼 영화 친구와 매칭 약속을 찾아보세요.`
+    : '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.'
+  const canonical = movieTitle
+    ? `${SITE_URL}/match?movieTitle=${encodeURIComponent(movieTitle)}`
+    : `${SITE_URL}/match`
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: 'website',
+    },
+    twitter: {
+      title,
+      description,
+    },
   }
 }
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,17 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/account/', '/api/'],
+        disallow: [
+          '/account/',
+          '/api/',
+          '/articles/new',
+          '/chat/',
+          '/match/my-matches',
+          '/match/new',
+          '/notifications',
+          '/settings',
+          '/setup-nickname',
+        ],
       },
     ],
     sitemap: 'https://bollae.kr/sitemap.xml',


### PR DESCRIPTION
## Summary
BOLLAE-22: 주요 공개 페이지의 SEO 메타를 페이지별로 분리합니다.
운영 테스트 데이터 정리(BOLLAE-16)는 오너가 직접 처리하기로 한 항목이라 제외했습니다.

## 변경
- `/match` title/description/canonical/OG를 매칭 목록 페이지 기준으로 분리
- `/match?movieTitle=` 진입 시 영화명 기반 title/description/canonical 생성
- `/articles` title/description/canonical/OG를 커뮤니티 목록 페이지 기준으로 분리
- `/match/new`에 noindex 메타를 추가하고, robots.txt에서 작성/개인성 페이지 색인 제외

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인
- [x] 브라우저에서 `/match` 메타 확인: `매칭 | 볼래`, canonical `/match`
- [x] 브라우저에서 `/match?movieTitle=군체` 메타 확인: `군체 같이 볼 사람 찾기 | 볼래`, canonical 쿼리 유지
- [x] 브라우저에서 `/articles` 메타 확인: `커뮤니티 | 볼래`, canonical `/articles`
- [x] 브라우저에서 `/robots.txt` 색인 제외 경로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)