### PR TITLE
🚀 Release: 페이지별 SEO 메타

### DIFF
--- a/src/app/(root)/(routes)/articles/page.tsx
+++ b/src/app/(root)/(routes)/articles/page.tsx
@@ -1,6 +1,28 @@
+import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import Link from 'next/link'
 import ArticleSection from './components/article-section'
+
+export const metadata: Metadata = {
+  title: '커뮤니티 | 볼래',
+  description:
+    '볼래 커뮤니티에서 영화 후기, 추천, 같이 보고 싶은 영화 이야기를 나눠보세요.',
+  alternates: {
+    canonical: 'https://bollae.kr/articles',
+  },
+  openGraph: {
+    title: '커뮤니티 | 볼래',
+    description:
+      '볼래 커뮤니티에서 영화 후기, 추천, 같이 보고 싶은 영화 이야기를 나눠보세요.',
+    url: 'https://bollae.kr/articles',
+    type: 'website',
+  },
+  twitter: {
+    title: '커뮤니티 | 볼래',
+    description:
+      '볼래 커뮤니티에서 영화 후기, 추천, 같이 보고 싶은 영화 이야기를 나눠보세요.',
+  },
+}
 
 const Page: FunctionComponent = () => {
   return (

--- a/src/app/(root)/(routes)/match/new/page.tsx
+++ b/src/app/(root)/(routes)/match/new/page.tsx
@@ -1,5 +1,23 @@
+import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import { NewMatchContainer } from './components/new-match-container'
+
+export const metadata: Metadata = {
+  title: '매치 만들기 | 볼래',
+  description: '볼래에서 함께 볼 영화 약속을 직접 만들어보세요.',
+  alternates: {
+    canonical: 'https://bollae.kr/match/new',
+  },
+  openGraph: {
+    title: '매치 만들기 | 볼래',
+    description: '볼래에서 함께 볼 영화 약속을 직접 만들어보세요.',
+    url: 'https://bollae.kr/match/new',
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 interface PageProps {
   searchParams?: {

--- a/src/app/(root)/(routes)/match/page.tsx
+++ b/src/app/(root)/(routes)/match/page.tsx
@@ -1,9 +1,48 @@
+import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import { MatchContainer } from './components/match-container'
+
+const SITE_URL = 'https://bollae.kr'
+
+function withObjectParticle(text: string) {
+  const last = text.charCodeAt(text.length - 1)
+  const hasFinalConsonant =
+    last >= 0xac00 && last <= 0xd7a3 && (last - 0xac00) % 28 !== 0
+  return `${text}${hasFinalConsonant ? '을' : '를'}`
+}
 
 interface PageProps {
   searchParams?: {
     movieTitle?: string
+  }
+}
+
+export function generateMetadata({ searchParams }: PageProps): Metadata {
+  const movieTitle = searchParams?.movieTitle?.trim()
+  const title = movieTitle
+    ? `${movieTitle} 같이 볼 사람 찾기 | 볼래`
+    : '매칭 | 볼래'
+  const description = movieTitle
+    ? `볼래에서 ${withObjectParticle(movieTitle)} 함께 볼 영화 친구와 매칭 약속을 찾아보세요.`
+    : '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.'
+  const canonical = movieTitle
+    ? `${SITE_URL}/match?movieTitle=${encodeURIComponent(movieTitle)}`
+    : `${SITE_URL}/match`
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: 'website',
+    },
+    twitter: {
+      title,
+      description,
+    },
   }
 }
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,17 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/account/', '/api/'],
+        disallow: [
+          '/account/',
+          '/api/',
+          '/articles/new',
+          '/chat/',
+          '/match/my-matches',
+          '/match/new',
+          '/notifications',
+          '/settings',
+          '/setup-nickname',
+        ],
       },
     ],
     sitemap: 'https://bollae.kr/sitemap.xml',


### PR DESCRIPTION
## Summary
BOLLAE-22 페이지별 SEO 메타 정리 작업을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #346 — `/match`, `/match?movieTitle=`, `/articles` 페이지별 title/description/canonical/OG 분리
- PR #346 — `/match/new` noindex 및 robots.txt 작성/개인성 페이지 색인 제외

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인
- [x] 로컬 브라우저에서 `/match`, 영화 필터 매칭, `/articles`, `/robots.txt` 메타 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 URL 메타 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)