### PR TITLE
🐛 매칭 페이지 SEO 런타임 복구

### DIFF
--- a/src/app/(root)/(routes)/match/page.tsx
+++ b/src/app/(root)/(routes)/match/page.tsx
@@ -2,47 +2,27 @@ import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import { MatchContainer } from './components/match-container'
 
-const SITE_URL = 'https://bollae.kr'
-
-function withObjectParticle(text: string) {
-  const last = text.charCodeAt(text.length - 1)
-  const hasFinalConsonant =
-    last >= 0xac00 && last <= 0xd7a3 && (last - 0xac00) % 28 !== 0
-  return `${text}${hasFinalConsonant ? '을' : '를'}`
+export const metadata: Metadata = {
+  title: '매칭 | 볼래',
+  description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
+  alternates: {
+    canonical: 'https://bollae.kr/match',
+  },
+  openGraph: {
+    title: '매칭 | 볼래',
+    description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
+    url: 'https://bollae.kr/match',
+    type: 'website',
+  },
+  twitter: {
+    title: '매칭 | 볼래',
+    description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
+  },
 }
 
 interface PageProps {
   searchParams?: {
     movieTitle?: string
-  }
-}
-
-export function generateMetadata({ searchParams }: PageProps): Metadata {
-  const movieTitle = searchParams?.movieTitle?.trim()
-  const title = movieTitle
-    ? `${movieTitle} 같이 볼 사람 찾기 | 볼래`
-    : '매칭 | 볼래'
-  const description = movieTitle
-    ? `볼래에서 ${withObjectParticle(movieTitle)} 함께 볼 영화 친구와 매칭 약속을 찾아보세요.`
-    : '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.'
-  const canonical = movieTitle
-    ? `${SITE_URL}/match?movieTitle=${encodeURIComponent(movieTitle)}`
-    : `${SITE_URL}/match`
-
-  return {
-    title,
-    description,
-    alternates: { canonical },
-    openGraph: {
-      title,
-      description,
-      url: canonical,
-      type: 'website',
-    },
-    twitter: {
-      title,
-      description,
-    },
   }
 }
 


### PR DESCRIPTION
## Summary
BOLLAE-22 배포 후 `/match`가 프로덕션에서 500으로 떨어지는 문제를 복구합니다.

## 원인
- `/match/page.tsx`에서 `searchParams` 기반 동적 `generateMetadata`를 추가한 뒤 프로덕션 런타임에서 해당 라우트가 500을 반환했습니다.
- 서비스 복구를 우선해 `/match`는 정적 페이지 메타로 되돌리고, 영화별 동적 메타는 별도 안정화 작업으로 분리합니다.

## 변경
- `/match` 동적 `generateMetadata` 제거
- `/match` 정적 title/description/canonical/OG 유지

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: match/page.tsx 39줄
- [x] 운영 `/api/match` 정상 확인
- [ ] master 머지 후 `/match` 200 복구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)