### PR TITLE
🚀 Release: 매칭 페이지 복구

### DIFF
--- a/src/app/(root)/(routes)/match/page.tsx
+++ b/src/app/(root)/(routes)/match/page.tsx
@@ -2,47 +2,27 @@ import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import { MatchContainer } from './components/match-container'
 
-const SITE_URL = 'https://bollae.kr'
-
-function withObjectParticle(text: string) {
-  const last = text.charCodeAt(text.length - 1)
-  const hasFinalConsonant =
-    last >= 0xac00 && last <= 0xd7a3 && (last - 0xac00) % 28 !== 0
-  return `${text}${hasFinalConsonant ? '을' : '를'}`
+export const metadata: Metadata = {
+  title: '매칭 | 볼래',
+  description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
+  alternates: {
+    canonical: 'https://bollae.kr/match',
+  },
+  openGraph: {
+    title: '매칭 | 볼래',
+    description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
+    url: 'https://bollae.kr/match',
+    type: 'website',
+  },
+  twitter: {
+    title: '매칭 | 볼래',
+    description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
+  },
 }
 
 interface PageProps {
   searchParams?: {
     movieTitle?: string
-  }
-}
-
-export function generateMetadata({ searchParams }: PageProps): Metadata {
-  const movieTitle = searchParams?.movieTitle?.trim()
-  const title = movieTitle
-    ? `${movieTitle} 같이 볼 사람 찾기 | 볼래`
-    : '매칭 | 볼래'
-  const description = movieTitle
-    ? `볼래에서 ${withObjectParticle(movieTitle)} 함께 볼 영화 친구와 매칭 약속을 찾아보세요.`
-    : '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.'
-  const canonical = movieTitle
-    ? `${SITE_URL}/match?movieTitle=${encodeURIComponent(movieTitle)}`
-    : `${SITE_URL}/match`
-
-  return {
-    title,
-    description,
-    alternates: { canonical },
-    openGraph: {
-      title,
-      description,
-      url: canonical,
-      type: 'website',
-    },
-    twitter: {
-      title,
-      description,
-    },
   }
 }
 


### PR DESCRIPTION
## Summary
`/match` 프로덕션 500 복구 변경을 배포 대상으로 올립니다.

## 변경
- PR #348 — `/match` 동적 SEO 메타 제거 및 정적 메타로 복구
- PR #346 — `/articles`, `/match/new`, robots.txt SEO 정리 유지

## Test plan
- [x] `pnpm lint`
- [x] 운영 `/api/match` 정상 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 `/match`, `/match?movieTitle=군체`, `/articles`, `/robots.txt` 운영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)