### PR TITLE
🐛 매칭 동적 SEO 정적화 오류 수정

### DIFF
--- a/src/app/(root)/(routes)/match/page.tsx
+++ b/src/app/(root)/(routes)/match/page.tsx
@@ -2,27 +2,47 @@ import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import { MatchContainer } from './components/match-container'
 
-export const metadata: Metadata = {
-  title: '매칭 | 볼래',
-  description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
-  alternates: {
-    canonical: 'https://bollae.kr/match',
-  },
-  openGraph: {
-    title: '매칭 | 볼래',
-    description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
-    url: 'https://bollae.kr/match',
-    type: 'website',
-  },
-  twitter: {
-    title: '매칭 | 볼래',
-    description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
-  },
-}
+export const dynamic = 'force-dynamic'
+
+const SITE_URL = 'https://bollae.kr'
 
 interface PageProps {
   searchParams?: {
     movieTitle?: string
+  }
+}
+
+function withObjectParticle(text: string) {
+  const lastChar = text.charCodeAt(text.length - 1)
+  const hasFinalConsonant = lastChar >= 0xac00 && lastChar <= 0xd7a3 && (lastChar - 0xac00) % 28 > 0
+
+  return `${text}${hasFinalConsonant ? '을' : '를'}`
+}
+
+export function generateMetadata({ searchParams }: PageProps): Metadata {
+  const movieTitle = searchParams?.movieTitle?.trim()
+  const title = movieTitle ? `${movieTitle} 같이 볼 사람 찾기 | 볼래` : '매칭 | 볼래'
+  const description = movieTitle
+    ? `볼래에서 ${withObjectParticle(movieTitle)} 함께 볼 영화 친구와 매칭 약속을 찾아보세요.`
+    : '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.'
+  const canonical = movieTitle ? `${SITE_URL}/match?movieTitle=${encodeURIComponent(movieTitle)}` : `${SITE_URL}/match`
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: 'website',
+    },
+    twitter: {
+      title,
+      description,
+    },
   }
 }
 


### PR DESCRIPTION
## Summary
/match의 영화명 검색 SEO 메타를 복구하면서, Next 13.4가 해당 라우트를 정적으로 분류해 운영 500을 만들던 문제를 막습니다.

## 원인
- 이전 동적 SEO 구현은 `searchParams.movieTitle`로 title/description/canonical을 계산했습니다.
- 하지만 Next 13.4.12 빌드에서 `/match`가 `○` Static route로 분류됐고, 정적 생성 중 `DYNAMIC_SERVER_USAGE`가 발생했습니다.
- 그 결과 운영에서 `/match`, `/match?movieTitle=군체`가 500으로 응답했습니다.

## 변경
- `/match`에 `export const dynamic = 'force-dynamic'`을 추가해 런타임 렌더링을 명시했습니다.
- 영화명 기반 title/description/canonical/openGraph/twitter 메타를 복구했습니다.
- 기본 `/match` 메타는 기존 `매칭 | 볼래` 값을 유지했습니다.

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: `src/app/(root)/(routes)/match/page.tsx` 59줄
- [x] 임시 프로덕션 빌드에서 `/match`, `/match?movieTitle=군체` 200 확인
- [x] 로컬 브라우저에서 `/match?movieTitle=군체` title/canonical/description 동적 반영 확인
- [ ] `pnpm build`는 타입/컴파일/페이지 데이터 수집 이후 기존 로컬 standalone copy ENOENT로 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)