### PR TITLE
🚀 Release: 매칭 동적 SEO 복구

### DIFF
--- a/src/app/(root)/(routes)/match/page.tsx
+++ b/src/app/(root)/(routes)/match/page.tsx
@@ -2,27 +2,47 @@ import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 import { MatchContainer } from './components/match-container'
 
-export const metadata: Metadata = {
-  title: '매칭 | 볼래',
-  description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
-  alternates: {
-    canonical: 'https://bollae.kr/match',
-  },
-  openGraph: {
-    title: '매칭 | 볼래',
-    description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
-    url: 'https://bollae.kr/match',
-    type: 'website',
-  },
-  twitter: {
-    title: '매칭 | 볼래',
-    description: '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.',
-  },
-}
+export const dynamic = 'force-dynamic'
+
+const SITE_URL = 'https://bollae.kr'
 
 interface PageProps {
   searchParams?: {
     movieTitle?: string
+  }
+}
+
+function withObjectParticle(text: string) {
+  const lastChar = text.charCodeAt(text.length - 1)
+  const hasFinalConsonant = lastChar >= 0xac00 && lastChar <= 0xd7a3 && (lastChar - 0xac00) % 28 > 0
+
+  return `${text}${hasFinalConsonant ? '을' : '를'}`
+}
+
+export function generateMetadata({ searchParams }: PageProps): Metadata {
+  const movieTitle = searchParams?.movieTitle?.trim()
+  const title = movieTitle ? `${movieTitle} 같이 볼 사람 찾기 | 볼래` : '매칭 | 볼래'
+  const description = movieTitle
+    ? `볼래에서 ${withObjectParticle(movieTitle)} 함께 볼 영화 친구와 매칭 약속을 찾아보세요.`
+    : '볼래에서 오늘 같이 볼 사람을 찾고 영화 약속을 만들어보세요.'
+  const canonical = movieTitle ? `${SITE_URL}/match?movieTitle=${encodeURIComponent(movieTitle)}` : `${SITE_URL}/match`
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: 'website',
+    },
+    twitter: {
+      title,
+      description,
+    },
   }
 }
 


### PR DESCRIPTION
## Summary
BOLLAE-22 매칭 페이지 동적 SEO 복구 변경을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #350 — `/match` force-dynamic 지정으로 Next 13.4 정적 분류 500 방지
- 영화명 검색 시 title/description/canonical 동적 메타 복구

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: 59줄
- [x] 임시 프로덕션 빌드에서 `/match`, `/match?movieTitle=군체` 200 확인
- [x] 로컬 브라우저에서 동적 title/canonical/description 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 `/match`, `/match?movieTitle=군체` 및 메타 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)