### PR TITLE
💄 영화 상세 영상 모달 UX 개선

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/components/movie-vod-modal.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/components/movie-vod-modal.tsx
@@ -1,4 +1,12 @@
-import AppFormDialogue from '@/components/app/app-form-dialogue'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { ExternalLink, X } from 'lucide-react'
 import { FunctionComponent } from 'react'
 import { useVodModalContext } from '../hooks/use-vod-modal-context'
 
@@ -6,20 +14,57 @@ const MovieVodModal: FunctionComponent = () => {
   const { open, setOpen, src, title } = useVodModalContext()
 
   return (
-    <AppFormDialogue
-      title={<p>{title}</p>}
-      open={open}
-      setOpen={setOpen}
-      render={
-        <div className="flex h-full w-full items-center justify-center p-4">
-          <iframe
-            src={src}
-            allowFullScreen
-            className="h-[560px] max-h-[90vh] w-[880px] max-w-full rounded shadow-lg"
-          />
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogContent className="max-h-[92dvh] w-[calc(100vw-24px)] max-w-[960px] gap-0 overflow-hidden border border-white/10 bg-[#050505] p-0 text-white shadow-2xl sm:rounded-lg">
+        <AlertDialogCancel
+          aria-label="영상 닫기"
+          className="absolute right-3 top-3 z-10 mt-0 h-10 w-10 rounded-full border-white/15 bg-black/70 p-0 text-white hover:bg-white hover:text-black"
+        >
+          <X className="mx-auto h-5 w-5" aria-hidden />
+        </AlertDialogCancel>
+
+        <AlertDialogHeader className="space-y-1 px-4 pb-3 pt-4 text-left sm:px-5 sm:pt-5">
+          <AlertDialogTitle className="pr-12 text-base font-semibold text-white">
+            관련 영상
+          </AlertDialogTitle>
+          <AlertDialogDescription className="line-clamp-1 text-xs text-white/60">
+            {title
+              ? `${title} 예고편과 관련 영상을 확인합니다.`
+              : '영화 관련 영상을 확인합니다.'}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="bg-black px-3 pb-3 sm:px-5 sm:pb-5">
+          <div className="aspect-video w-full overflow-hidden rounded-md border border-white/10 bg-zinc-950">
+            {src ? (
+              <iframe
+                src={src}
+                title={title ? `${title} 관련 영상` : '영화 관련 영상'}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+                className="h-full w-full"
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center px-6 text-center text-sm text-white/65">
+                표시할 영상 정보를 불러오지 못했습니다.
+              </div>
+            )}
+          </div>
+
+          {src && (
+            <a
+              href={src}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-white/70 hover:text-white"
+            >
+              새 창에서 열기
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+            </a>
+          )}
         </div>
-      }
-    />
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 


### PR DESCRIPTION
## Summary
UI-4: 영화 상세의 영상 보기 모달을 흰 폼 다이얼로그에서 어두운 영상 전용 overlay로 개선합니다.

## 원인
- 기존 영상 모달은 폼용 `AppFormDialogue`를 재사용해 영화 상세 분위기와 맞지 않았습니다.
- 모바일에서 iframe 크기가 고정 높이 중심이라 답답하게 보일 수 있고, dialog description도 없어 접근성 경고 가능성이 있었습니다.

## 변경
- `MovieVodModal`을 Radix AlertDialog 기반 영상 전용 overlay로 재작성했습니다.
- 16:9 iframe 영역, 40px 닫기 버튼, `관련 영상` title/description을 추가했습니다.
- 영상 URL이 있을 때 `새 창에서 열기` 외부 링크를 제공합니다.
- src가 비어 있을 때 빈 iframe 대신 fallback 메시지를 표시합니다.

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: `movie-vod-modal.tsx` 71줄
- [x] 로컬 브라우저 `/movie/20252402`에서 영상 모달 열기/닫기 확인
- [x] 375px 폭에서 dialog 351px, video 325x183, 닫기 버튼 40px 확인
- [x] dialog title/description, iframe, 외부 링크 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)