### PR TITLE
🚀 Release: 홈 영화 카드 리디자인

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -85,7 +85,7 @@ const Page: FunctionComponent = async () => {
         <span className="font-mono text-[10px] text-muted-foreground">KOFIC · TOP 10</span>
       </div>
 
-      <div className="flex flex-col gap-2 px-4">
+      <div className="grid gap-3 px-4 lg:grid-cols-2">
         {top10.map((movie) => (
           <MovieListCard key={movie.id} movie={movie} />
         ))}

--- a/src/components/dm/movie-list-card.tsx
+++ b/src/components/dm/movie-list-card.tsx
@@ -10,6 +10,7 @@ interface MovieListCardProps {
 export function MovieListCard({ movie }: MovieListCardProps) {
   const palette = paletteForMovie(movie.id, movie.title)
   const rating = movie.averageScore ?? 0
+  const hasRating = rating > 0
   const rankInten = movie.rankInten ?? 0
   const audience = movie.audience ?? 0
   const genres = movie.genre?.split(/[,/·]/).map((g) => g.trim()).filter(Boolean) ?? []
@@ -20,40 +21,67 @@ export function MovieListCard({ movie }: MovieListCardProps) {
     rankInten > 0 ? `▲${rankInten}` : rankInten < 0 ? `▼${-rankInten}` : '—'
 
   return (
-    <Link href={`/movie/${movie.id}`}>
-      <div className="flex cursor-pointer gap-3 rounded-lg border border-border bg-card p-2.5 transition-colors hover:bg-accent">
-        {/* 포스터 */}
-        <div className="w-[60px] shrink-0">
-          <Poster title={movie.title} palette={palette} imageUrl={movie.poster} />
+    <Link href={`/movie/${movie.id}`} className="block">
+      <article className="group grid grid-cols-[104px_minmax(0,1fr)] gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent sm:grid-cols-[124px_minmax(0,1fr)]">
+        <div className="relative">
+          <Poster
+            title={movie.title}
+            palette={palette}
+            imageUrl={movie.poster}
+            className="shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
+            rounded="md"
+          />
+          <span className="absolute left-2 top-2 inline-flex h-7 min-w-7 items-center justify-center rounded-full bg-primary px-2 font-mono text-[11px] font-semibold text-primary-foreground shadow">
+            {movie.rank}
+          </span>
         </div>
 
-        {/* 정보 */}
-        <div className="flex min-w-0 flex-1 flex-col justify-between">
+        <div className="flex min-w-0 flex-col justify-between py-0.5">
           <div>
-            <div className="flex items-center gap-1.5">
-              <span className="inline-flex items-center rounded-full bg-primary px-2 py-0.5 font-mono text-[10px] font-medium text-primary-foreground">
-                #{movie.rank}
-              </span>
-              <span className="font-mono text-[10px] text-muted-foreground">
-                {genres.slice(0, 2).join(' · ')}
-              </span>
+            <div className="flex flex-wrap items-center gap-1.5">
+              {genres.slice(0, 2).map((genre) => (
+                <span
+                  key={genre}
+                  className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] text-muted-foreground"
+                >
+                  {genre}
+                </span>
+              ))}
+              {movie.rankOldAndNew === 'NEW' && (
+                <span className="rounded-full bg-foreground px-2 py-0.5 font-mono text-[10px] text-background">
+                  NEW
+                </span>
+              )}
             </div>
-            <div className="mt-1.5 truncate text-[14px] font-semibold text-foreground">
+
+            <h3 className="mt-2 line-clamp-2 break-keep text-[19px] font-bold leading-tight text-foreground group-hover:text-primary sm:text-[21px]">
               {movie.title}
-            </div>
+            </h3>
           </div>
 
-          <div className="flex items-center gap-2.5 text-[11px] text-muted-foreground">
-            <span>
-              ★ <span className="font-medium text-foreground">{rating.toFixed(1)}</span>
+          <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-muted-foreground">
+            <span className="rounded-md bg-background/70 px-2 py-1.5">
+              <span className="block font-mono text-[9px] uppercase">평점</span>
+              <span className="font-semibold text-foreground">
+                {hasRating ? `★ ${rating.toFixed(1)}` : '평점 준비 중'}
+              </span>
             </span>
             {audience > 0 && (
-              <span>{(audience / 10000).toFixed(0)}만명</span>
+              <span className="rounded-md bg-background/70 px-2 py-1.5">
+                <span className="block font-mono text-[9px] uppercase">관객</span>
+                <span className="font-semibold text-foreground">
+                  {(audience / 10000).toFixed(0)}만명
+                </span>
+              </span>
             )}
-            <span className={`ml-auto font-mono ${intenColor}`}>{intenLabel}</span>
+
+            <span className="col-span-2 flex items-center justify-between border-t border-border pt-2 font-mono text-[10px]">
+              <span>순위 변동</span>
+              <span className={intenColor}>{intenLabel}</span>
+            </span>
           </div>
         </div>
-      </div>
+      </article>
     </Link>
   )
 }


### PR DESCRIPTION
## Summary
UI-1 홈 영화 카드 리디자인 변경을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #356 — 홈 박스오피스 카드를 포스터 중심 카드로 확대
- 긴 제목 2줄 clamp, 장르/관객/순위 변동 정보 위계 정리
- 0점 평점은 `평점 준비 중`으로 표시

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: `movie-list-card.tsx` 87줄, home `page.tsx` 101줄
- [x] 로컬 브라우저 홈 375px 폭 카드/포스터 치수 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 홈 카드 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)