### PR TITLE
💄 홈 영화 카드 평점 CTA 문구 개선

### DIFF
--- a/src/components/dm/movie-list-card.tsx
+++ b/src/components/dm/movie-list-card.tsx
@@ -63,7 +63,7 @@ export function MovieListCard({ movie }: MovieListCardProps) {
             <span className="rounded-md bg-background/70 px-2 py-1.5">
               <span className="block font-mono text-[9px] uppercase">평점</span>
               <span className="font-semibold text-foreground">
-                {hasRating ? `★ ${rating.toFixed(1)}` : '평점 준비 중'}
+                {hasRating ? `★ ${rating.toFixed(1)}` : '첫 평점 남기기'}
               </span>
             </span>
             {audience > 0 && (


### PR DESCRIPTION
## Summary
홈 영화 카드의 무평점 상태 문구를 사용자 행동 유도형 CTA로 변경합니다.

## 원인
- `평점 준비 중`은 서비스가 아직 준비되지 않은 상태처럼 보여 사용자 참여를 유도하기 어렵습니다.

## 변경
- 평균 평점이 없는 영화는 `첫 평점 남기기`로 표시합니다.
- 실제 평균 평점이 있는 영화는 기존처럼 `★ n.n`을 유지합니다.

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: `movie-list-card.tsx` 87줄
- [x] `평점 준비 중` 잔여 미노출 확인
- [x] 로컬 브라우저 홈에서 `첫 평점 남기기` 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)