### PR TITLE
🚀 Release: 홈 평점 CTA 문구

### DIFF
--- a/src/components/dm/movie-list-card.tsx
+++ b/src/components/dm/movie-list-card.tsx
@@ -63,7 +63,7 @@ export function MovieListCard({ movie }: MovieListCardProps) {
             <span className="rounded-md bg-background/70 px-2 py-1.5">
               <span className="block font-mono text-[9px] uppercase">평점</span>
               <span className="font-semibold text-foreground">
-                {hasRating ? `★ ${rating.toFixed(1)}` : '평점 준비 중'}
+                {hasRating ? `★ ${rating.toFixed(1)}` : '첫 평점 남기기'}
               </span>
             </span>
             {audience > 0 && (


### PR DESCRIPTION
## Summary
홈 영화 카드 평점 CTA 문구 개선을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #358 — 무평점 영화 문구를 `첫 평점 남기기`로 변경

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: 87줄
- [x] 로컬 홈에서 `첫 평점 남기기` 노출 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 홈 문구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)