### PR TITLE
🐛 닉네임 설정 토큰 추출 수정

### DIFF
--- a/src/app/api/user/nickname/route.ts
+++ b/src/app/api/user/nickname/route.ts
@@ -1,5 +1,6 @@
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { AppEnv } from '@/config/app-env'
 import { UsersRepository } from '@/modules/users/users-repository'
+import { getToken } from 'next-auth/jwt'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function PATCH(req: NextRequest) {
@@ -9,11 +10,20 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ success: false, message: '닉네임을 입력해주세요.' }, { status: 400 })
     }
 
-    const token = await getTokenFromCookie()
+    const token = await getToken({
+      req,
+      secret: AppEnv.nextAuthSecret,
+      raw: true,
+    })
+    if (!token) {
+      return NextResponse.json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 })
+    }
+
     const repo = new UsersRepository(token)
     const data = await repo.updateProfile({ nickname: nickname.trim() })
     return NextResponse.json({ success: true, data })
-  } catch {
+  } catch (error) {
+    console.error('user/nickname PATCH error:', error)
     return NextResponse.json({ success: false, message: '닉네임 변경에 실패했습니다.' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
OAuth 이후 `/setup-nickname`에서 닉네임 저장 시 500이 발생하는 문제를 수정합니다.

## 원인
- `/api/user/nickname` BFF가 NextAuth 세션 토큰을 표준 방식으로 읽지 않고 `COOKIE_TOKEN_KEY` raw cookie만 직접 조회했습니다.
- OAuth/운영 secure cookie 환경에서 토큰을 못 찾으면 백엔드에 잘못된 Bearer 값이 전달되고, BFF는 이를 500으로 뭉갰습니다.

## 변경
- `next-auth/jwt`의 `getToken({ raw: true })`로 현재 요청의 JWT를 추출합니다.
- 토큰이 없으면 `401 로그인이 필요합니다.`로 명확히 응답합니다.
- 실패 원인 추적을 위해 route 에러 로그를 추가했습니다.

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: `route.ts` 29줄
- [x] 로컬 미인증 PATCH `/api/user/nickname` → 401 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 미인증 PATCH 401 확인
- [ ] 사용자 OAuth 세션에서 `/setup-nickname` 닉네임 저장 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)