### PR TITLE
🚀 Release: 닉네임 설정 토큰 수정

### DIFF
--- a/src/app/api/user/nickname/route.ts
+++ b/src/app/api/user/nickname/route.ts
@@ -1,5 +1,6 @@
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { AppEnv } from '@/config/app-env'
 import { UsersRepository } from '@/modules/users/users-repository'
+import { getToken } from 'next-auth/jwt'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function PATCH(req: NextRequest) {
@@ -9,11 +10,20 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ success: false, message: '닉네임을 입력해주세요.' }, { status: 400 })
     }
 
-    const token = await getTokenFromCookie()
+    const token = await getToken({
+      req,
+      secret: AppEnv.nextAuthSecret,
+      raw: true,
+    })
+    if (!token) {
+      return NextResponse.json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 })
+    }
+
     const repo = new UsersRepository(token)
     const data = await repo.updateProfile({ nickname: nickname.trim() })
     return NextResponse.json({ success: true, data })
-  } catch {
+  } catch (error) {
+    console.error('user/nickname PATCH error:', error)
     return NextResponse.json({ success: false, message: '닉네임 변경에 실패했습니다.' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
OAuth 이후 닉네임 설정 API 500 수정 사항을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #360 — `/api/user/nickname`에서 NextAuth `getToken({ raw: true })`로 JWT 추출
- 토큰 없음은 500 대신 401로 응답

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: 29줄
- [x] 로컬 미인증 PATCH `/api/user/nickname` → 401 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 미인증 PATCH 401 확인
- [ ] 사용자 OAuth 세션에서 `/setup-nickname` 닉네임 저장 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)