### PR TITLE
🚀 Release: Google OAuth 닉네임 세션

### DIFF
--- a/src/app/api/auth/[...nextauth]/next-option.ts
+++ b/src/app/api/auth/[...nextauth]/next-option.ts
@@ -5,7 +5,6 @@ import { AppPath } from '@/config/app-path'
 import * as jose from 'jose'
 import { AppEnv } from '@/config/app-env'
 import GoogleProvider from 'next-auth/providers/google'
-import { assertProviderType } from '@/lib/utils/auth'
 
 export const authOptions: AuthOptions = {
   providers: [
@@ -76,14 +75,20 @@ export const authOptions: AuthOptions = {
       const repo = new UsersRepository()
       try {
         if (account && account?.provider !== 'credentials') {
-          const result = await repo.signInWithProvider({ id: user.id })
-          user.id = result.id ?? user.id
+          if (!user.email) {
+            return false
+          }
+
+          const result = await repo.signInWithProvider({ providerId: user.email })
+          user.id = result.id
+          user.email = result.email ?? user.email
           user.nickname = result.nickname ?? user.nickname
           user.image = result.image || user.image
           return true
         }
       } catch (error) {
         console.log(error)
+        return false
       }
 
       return true

--- a/src/app/api/user/nickname/route.ts
+++ b/src/app/api/user/nickname/route.ts
@@ -10,12 +10,18 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ success: false, message: '닉네임을 입력해주세요.' }, { status: 400 })
     }
 
+    const sessionToken = await getToken({
+      req,
+      secret: AppEnv.nextAuthSecret,
+    })
     const token = await getToken({
       req,
       secret: AppEnv.nextAuthSecret,
       raw: true,
     })
-    if (!token) {
+    const userId = Number(sessionToken?.userId)
+
+    if (!token || !Number.isInteger(userId) || userId <= 0 || userId > 2147483647) {
       return NextResponse.json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 })
     }
 

--- a/src/modules/users/users-datasource.ts
+++ b/src/modules/users/users-datasource.ts
@@ -53,7 +53,7 @@ export class UsersDatasource {
     return res.json()
   }
 
-  async signInWithProvider(params: { id: string }) {
+  async signInWithProvider(params: { providerId: string }) {
     const res = await fetch(AppBackEndApiEndpoint.oAuth(), {
       method: 'POST',
       headers: {
@@ -61,7 +61,7 @@ export class UsersDatasource {
       },
       body: JSON.stringify({
         provider: 'google',
-        accessToken: params.id,
+        accessToken: params.providerId,
       }),
       cache: 'no-cache',
     })

--- a/src/modules/users/users-repository.ts
+++ b/src/modules/users/users-repository.ts
@@ -29,8 +29,8 @@ export class UsersRepository {
     return await this.datasource.signUp({ userId, password, nickname, gender })
   }
 
-  async signInWithProvider(params: { id: string }) {
-    const result = await this.datasource.signInWithProvider({ id: params.id })
+  async signInWithProvider(params: { providerId: string }) {
+    const result = await this.datasource.signInWithProvider({ providerId: params.providerId })
     return this.convertToUserEntity(result)
   }
 


### PR DESCRIPTION
## Summary
Google OAuth 이후 `/setup-nickname` 닉네임 변경 실패 수정 사항을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #362 — Google OAuth 식별자를 이메일 기반으로 수정
- OAuth 연동 실패 시 잘못된 세션 생성을 중단
- `/api/user/nickname`에서 잘못된 JWT userId를 401로 방어

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 `/setup-nickname` Google OAuth 닉네임 설정 확인

🤖 Generated with [Codex](https://openai.com/codex)