### PR TITLE
🐛 OAuth 빈 닉네임 AccessDenied 수정

### DIFF
--- a/src/modules/users/users.entity.ts
+++ b/src/modules/users/users.entity.ts
@@ -9,7 +9,12 @@ export interface UserEntity {
 }
 
 export function isUserEntity(arg: any): arg is UserEntity {
-  return arg && arg.id && arg.provider && arg.nickname
+  return (
+    arg &&
+    Number.isInteger(Number(arg.id)) &&
+    typeof arg.provider === 'string' &&
+    typeof arg.nickname === 'string'
+  )
 }
 
 export function assertUserEntity(arg: any): asserts arg is UserEntity {


### PR DESCRIPTION
## Summary
Google OAuth 후 `AccessDenied`가 발생하는 사용자 엔티티 검증을 수정합니다.

## 원인
- `/setup-nickname` 플로우는 닉네임이 아직 비어 있을 수 있습니다.
- 그런데 프론트 `UserEntity` 검증이 `nickname`을 truthy 필수값으로 보고 있어, OAuth 백엔드 응답에 빈 닉네임이 있으면 `Invalid user`로 처리되고 NextAuth signIn이 AccessDenied를 반환했습니다.

## 변경
- 사용자 엔티티 검증에서 `nickname`은 문자열 타입이면 허용
- `id`는 숫자로 해석 가능한 값인지 명시 검증

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인: 24줄

🤖 Generated with [Codex](https://openai.com/codex)