### PR TITLE
🐛 닉네임 API userid claim 허용

### DIFF
--- a/src/app/api/user/nickname/route.ts
+++ b/src/app/api/user/nickname/route.ts
@@ -19,7 +19,8 @@ export async function PATCH(req: NextRequest) {
       secret: AppEnv.nextAuthSecret,
       raw: true,
     })
-    const userId = Number(sessionToken?.userId)
+    const decodedToken = sessionToken as { userId?: unknown; userid?: unknown } | null
+    const userId = Number(decodedToken?.userId ?? decodedToken?.userid)
 
     if (!token || !Number.isInteger(userId) || userId <= 0 || userId > 2147483647) {
       return NextResponse.json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 })


### PR DESCRIPTION
## Summary
Google OAuth 통과 후 `/api/user/nickname` PATCH가 401로 응답하는 문제를 수정합니다.

## 원인
- NextAuth custom JWT encode에는 백엔드 호환용 `userid` claim이 포함됩니다.
- 닉네임 API의 방어 로직은 decoded token의 `userId`만 확인하고 있어, 운영 토큰에서 `userid`만 확인 가능한 경우 로그인 상태를 401로 판단할 수 있었습니다.

## 변경
- 닉네임 API에서 `userId`와 `userid` claim을 모두 허용
- raw JWT는 기존처럼 백엔드 Authorization에 전달

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인: 36줄

🤖 Generated with [Codex](https://openai.com/codex)