### PR TITLE
🚀 Release: 닉네임 API userid claim

### DIFF
--- a/src/app/api/user/nickname/route.ts
+++ b/src/app/api/user/nickname/route.ts
@@ -19,7 +19,8 @@ export async function PATCH(req: NextRequest) {
       secret: AppEnv.nextAuthSecret,
       raw: true,
     })
-    const userId = Number(sessionToken?.userId)
+    const decodedToken = sessionToken as { userId?: unknown; userid?: unknown } | null
+    const userId = Number(decodedToken?.userId ?? decodedToken?.userid)
 
     if (!token || !Number.isInteger(userId) || userId <= 0 || userId > 2147483647) {
       return NextResponse.json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 })


### PR DESCRIPTION
## Summary
Google OAuth 후 닉네임 설정 PATCH가 401로 응답하는 수정 사항을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #366 — `/api/user/nickname`에서 `userId`, `userid` JWT claim 모두 허용

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 Google OAuth 닉네임 저장 재시도 확인

🤖 Generated with [Codex](https://openai.com/codex)