### PR TITLE
🐛 닉네임 API raw 토큰 인증 사용

### DIFF
--- a/src/app/api/user/nickname/route.ts
+++ b/src/app/api/user/nickname/route.ts
@@ -10,19 +10,13 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ success: false, message: '닉네임을 입력해주세요.' }, { status: 400 })
     }
 
-    const sessionToken = await getToken({
-      req,
-      secret: AppEnv.nextAuthSecret,
-    })
     const token = await getToken({
       req,
       secret: AppEnv.nextAuthSecret,
       raw: true,
     })
-    const decodedToken = sessionToken as { userId?: unknown; userid?: unknown } | null
-    const userId = Number(decodedToken?.userId ?? decodedToken?.userid)
 
-    if (!token || !Number.isInteger(userId) || userId <= 0 || userId > 2147483647) {
+    if (!token) {
       return NextResponse.json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 })
     }
 


### PR DESCRIPTION
## Summary
Google OAuth 사용자가 `/setup-nickname`에서 닉네임 저장 시 401이 나는 문제를 수정합니다.

## 원인
- `/api/user/nickname` BFF 라우트가 raw JWT 존재 여부 외에 decoded `userId` 숫자 검증까지 수행했습니다.
- 실제 인증 판정은 백엔드 JwtAuthGuard가 raw bearer JWT로 수행하므로, 프론트 BFF의 중복 검증이 OAuth 세션을 과하게 차단할 수 있었습니다.

## 변경
- BFF에서는 `getToken({ raw: true })`로 raw JWT 존재만 확인
- raw JWT를 그대로 백엔드 Authorization에 전달
- userId claim 검증은 백엔드 JwtAuthGuard에 위임

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인: 30줄

🤖 Generated with [Codex](https://openai.com/codex)