### PR TITLE
🚀 Release: 닉네임 API raw 토큰 인증

### DIFF
--- a/src/app/api/user/nickname/route.ts
+++ b/src/app/api/user/nickname/route.ts
@@ -10,19 +10,13 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ success: false, message: '닉네임을 입력해주세요.' }, { status: 400 })
     }
 
-    const sessionToken = await getToken({
-      req,
-      secret: AppEnv.nextAuthSecret,
-    })
     const token = await getToken({
       req,
       secret: AppEnv.nextAuthSecret,
       raw: true,
     })
-    const decodedToken = sessionToken as { userId?: unknown; userid?: unknown } | null
-    const userId = Number(decodedToken?.userId ?? decodedToken?.userid)
 
-    if (!token || !Number.isInteger(userId) || userId <= 0 || userId > 2147483647) {
+    if (!token) {
       return NextResponse.json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 })
     }
 


### PR DESCRIPTION
## Summary
Google OAuth 후 닉네임 설정 PATCH가 401로 응답하는 문제를 해결하기 위해 BFF 인증 판정을 raw JWT 존재 여부로 단순화합니다.

## 변경
- PR #368 — `/api/user/nickname`의 decoded userId 중복 검증 제거
- raw JWT를 백엔드 Authorization에 전달하고 최종 인증은 백엔드 JwtAuthGuard에 위임

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 Google OAuth 닉네임 저장 재시도 확인

🤖 Generated with [Codex](https://openai.com/codex)