### PR TITLE
🚀 Release: 닉네임 설정 로그아웃 버튼

### DIFF
--- a/src/app/(root)/(routes)/setup-nickname/page.tsx
+++ b/src/app/(root)/(routes)/setup-nickname/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { useSession } from 'next-auth/react'
+import { Button } from '@/components/ui/button'
+import { X } from 'lucide-react'
+import { signOut, useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
@@ -10,6 +12,10 @@ export default function SetupNicknamePage() {
   const [nickname, setNickname] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+
+  const handleSignOut = () => {
+    signOut({ callbackUrl: '/login' })
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -42,10 +48,21 @@ export default function SetupNicknamePage() {
 
   return (
     <main className="flex min-h-page flex-col px-6 py-10">
-      <div className="mb-8">
+      <div className="mb-8 flex items-start justify-between gap-4">
         <div className="text-[22px] font-bold tracking-tight text-foreground">
           볼래
         </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="로그아웃"
+          title="로그아웃"
+          onClick={handleSignOut}
+          className="-mr-2 -mt-2 text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </Button>
       </div>
 
       <h2 className="mb-1.5 text-[22px] font-semibold tracking-tight text-foreground">


### PR DESCRIPTION
## Summary
닉네임 설정 실패 상태에서 사용자가 세션을 끊고 다시 로그인할 수 있도록 운영 배포합니다.

## 변경
- PR #370 — `/setup-nickname` 상단 X 로그아웃 버튼 추가

## Test plan
- [x] `pnpm lint`
- [x] 수정 파일 200줄 상한 확인: 117줄
- [x] 로컬 `/setup-nickname`에서 로그아웃 버튼 1개와 페이지 제목 렌더링 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 `/setup-nickname` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)