### PR TITLE
🐛 지난 매칭 일정 상태 표시 수정

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -8,6 +8,7 @@ import {
   SectionHead,
 } from '@/components/dm'
 import { MatchPost } from '@/lib/type'
+import { getMatchScheduleStatus } from '@/lib/utils'
 import { useSession } from 'next-auth/react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -63,18 +64,20 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   }
   const palette = paletteForMovie(matchPost.id, matchPost.movieTitle)
   const isFull = matchPost.currentParticipants >= matchPost.maxParticipants
+  const isPast = getMatchScheduleStatus(matchPost.showTime).isPast
 
   useEffect(() => {
     if (handledApplyIntentRef.current) return
     if (searchParams?.get('intent') !== 'apply') return
     if (status !== 'authenticated' || isMyApplicationLoading) return
-    if (isFull || myApplication) return
+    if (isFull || isPast || myApplication) return
 
     handledApplyIntentRef.current = true
     setShowApplyDialog(true)
     router.replace(`/match/${matchPost.id}`)
   }, [
     isFull,
+    isPast,
     isMyApplicationLoading,
     matchPost.id,
     myApplication,
@@ -163,10 +166,10 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
           <button
             type="button"
             onClick={handleApplyClick}
-            disabled={isFull}
+            disabled={isFull || isPast}
             className="w-full rounded-md bg-primary py-3.5 text-[15px] font-bold tracking-[-0.01em] text-primary-foreground disabled:bg-secondary disabled:text-muted-foreground disabled:shadow-none"
           >
-            {isFull ? '모집 완료' : '🎟  신청하기'}
+            {isPast ? '지난 일정' : isFull ? '모집 완료' : '🎟  신청하기'}
           </button>
         )}
       </div>

--- a/src/app/(root)/(routes)/match/sections/match-list-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-list-section.tsx
@@ -3,7 +3,7 @@
 import { FunctionComponent, useEffect, useRef, useCallback } from 'react'
 import { DmMatchTicket } from '@/components/dm'
 import { MatchApplyDialog } from '@/components/app/match-apply-dialog'
-import { cn } from '@/lib/utils'
+import { cn, getMatchScheduleStatus } from '@/lib/utils'
 import type { MatchPostFilter } from '../hooks'
 
 interface MatchListSectionProps {
@@ -77,6 +77,14 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
   }
 
   const { title: emptyTitle, sub: emptySub } = emptyMessages[filter]
+  const getApplyState = (match: any) => {
+    const isPast = getMatchScheduleStatus(match.showTime).isPast
+    const isFull = match.currentParticipants >= match.maxParticipants
+    return {
+      disabled: isPast || isFull,
+      label: isPast ? '지난 일정' : isFull ? '모집완료' : '신청하기',
+    }
+  }
 
   return (
     <>
@@ -107,19 +115,22 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
         </div>
       ) : (
         <div className="flex flex-col gap-3 px-4 py-2">
-          {list.map((match) => (
-            <div key={match.id}>
-              <DmMatchTicket match={match} />
-              <button
-                type="button"
-                onClick={() => onApply(match.id)}
-                disabled={match.currentParticipants >= match.maxParticipants}
-                className="mt-2 h-9 w-full rounded-md border border-border text-[13px] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {match.currentParticipants >= match.maxParticipants ? '모집완료' : '신청하기'}
-              </button>
-            </div>
-          ))}
+          {list.map((match) => {
+            const applyState = getApplyState(match)
+            return (
+              <div key={match.id}>
+                <DmMatchTicket match={match} />
+                <button
+                  type="button"
+                  onClick={() => onApply(match.id)}
+                  disabled={applyState.disabled}
+                  className="mt-2 h-9 w-full rounded-md border border-border text-[13px] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {applyState.label}
+                </button>
+              </div>
+            )
+          })}
         </div>
       )}
 

--- a/src/components/dm/dm-chat-ticket-pin.tsx
+++ b/src/components/dm/dm-chat-ticket-pin.tsx
@@ -1,11 +1,9 @@
+import { getMatchScheduleStatus } from '@/lib/utils'
+
 interface DmChatTicketPinProps {
   movieTitle: string
   showTime: string | Date
   venue?: string
-}
-
-function dDay(target: Date): number {
-  return Math.ceil((target.getTime() - Date.now()) / (1000 * 60 * 60 * 24))
 }
 
 export function DmChatTicketPin({
@@ -22,7 +20,7 @@ export function DmChatTicketPin({
     minute: '2-digit',
     hour12: false,
   })
-  const dd = dDay(date)
+  const schedule = getMatchScheduleStatus(date)
   const venueShort = venue?.split(' ')[0]
 
   return (
@@ -46,7 +44,7 @@ export function DmChatTicketPin({
         </div>
       </div>
       <span className="font-mono text-[14px] font-bold leading-none text-primary">
-        D-{dd >= 0 ? dd : 0}
+        {schedule.label}
       </span>
     </div>
   )

--- a/src/components/dm/dm-desktop-right-sidebar.tsx
+++ b/src/components/dm/dm-desktop-right-sidebar.tsx
@@ -1,20 +1,14 @@
 'use client'
 
 import { MatchPost } from '@/lib/type'
+import { getMatchScheduleStatus } from '@/lib/utils'
 import Link from 'next/link'
 import useSWR from 'swr'
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
-function dDay(showTime: string) {
-  const diff = Math.ceil(
-    (new Date(showTime).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
-  )
-  return diff >= 0 ? `D-${diff}` : '마감'
-}
-
 function MatchCard({ match }: { match: MatchPost }) {
-  const dd = dDay(match.showTime)
+  const schedule = getMatchScheduleStatus(match.showTime)
   const dateStr = new Date(match.showTime).toLocaleDateString('ko-KR', {
     month: 'numeric',
     day: 'numeric',
@@ -23,14 +17,14 @@ function MatchCard({ match }: { match: MatchPost }) {
   return (
     <Link
       href={`/match/${match.id}`}
-      className="block border-b border-border px-4 py-3 hover:bg-accent"
+      className={`block border-b border-border px-4 py-3 hover:bg-accent ${schedule.isPast ? 'opacity-70' : ''}`}
     >
       <div className="flex items-baseline gap-1.5">
         <span className="text-[14px] font-semibold text-foreground">
           {dateStr}
         </span>
-        <span className="ml-auto font-mono text-[10px] text-primary">
-          {dd}
+        <span className={`ml-auto font-mono text-[10px] ${schedule.isPast ? 'text-muted-foreground' : 'text-primary'}`}>
+          {schedule.label}
         </span>
       </div>
       <div className="mt-0.5 truncate text-[13px] font-semibold text-foreground">

--- a/src/components/dm/dm-match-detail-card.tsx
+++ b/src/components/dm/dm-match-detail-card.tsx
@@ -1,4 +1,5 @@
 import { MatchPost } from '@/lib/type'
+import { getMatchScheduleStatus } from '@/lib/utils'
 import { Pill } from './pill'
 
 interface DmMatchDetailCardProps {
@@ -6,11 +7,6 @@ interface DmMatchDetailCardProps {
 }
 
 const DOW = ['일', '월', '화', '수', '목', '금', '토']
-
-function dDay(showTime: string): number {
-  const target = new Date(showTime).getTime()
-  return Math.ceil((target - Date.now()) / (1000 * 60 * 60 * 24))
-}
 
 function FilmStrip({ position }: { position: 'top' | 'bottom' }) {
   return (
@@ -56,7 +52,7 @@ export function DmMatchDetailCard({ match }: DmMatchDetailCardProps) {
     minute: '2-digit',
     hour12: false,
   })
-  const dd = dDay(match.showTime)
+  const schedule = getMatchScheduleStatus(match.showTime)
   const tags: string[] = []
   if (match.gender === 'male') tags.push('남성만')
   else if (match.gender === 'female') tags.push('여성만')
@@ -75,7 +71,7 @@ export function DmMatchDetailCard({ match }: DmMatchDetailCardProps) {
       <div className="mt-0.5 font-mono text-[14px] text-primary">
         {time}{' '}
         <span className="text-[11px] text-muted-foreground">
-          · D-{dd >= 0 ? dd : 0}
+          · {schedule.label}
         </span>
       </div>
 

--- a/src/components/dm/dm-match-ticket.tsx
+++ b/src/components/dm/dm-match-ticket.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { MatchPost } from '@/lib/type'
+import { cn, getMatchScheduleStatus } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
 import { Poster } from './poster'
 import { paletteForMovie } from './poster-palette'
@@ -10,12 +11,6 @@ interface DmMatchTicketProps {
 }
 
 const DOW = ['일', '월', '화', '수', '목', '금', '토']
-
-function dDay(showTime: string): number {
-  const target = new Date(showTime).getTime()
-  const now = Date.now()
-  return Math.ceil((target - now) / (1000 * 60 * 60 * 24))
-}
 
 export function DmMatchTicket({ match }: DmMatchTicketProps) {
   const router = useRouter()
@@ -28,7 +23,7 @@ export function DmMatchTicket({ match }: DmMatchTicketProps) {
     minute: '2-digit',
     hour12: false,
   })
-  const dd = dDay(match.showTime)
+  const schedule = getMatchScheduleStatus(match.showTime)
   const initial = match.author?.trim().charAt(0).toUpperCase() ?? '?'
   const isFull = match.currentParticipants >= match.maxParticipants
   const palette = paletteForMovie(match.id, match.movieTitle)
@@ -37,7 +32,10 @@ export function DmMatchTicket({ match }: DmMatchTicketProps) {
     <button
       type="button"
       onClick={() => router.push(`/match/${match.id}`)}
-      className="w-full cursor-pointer rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-accent"
+      className={cn(
+        'w-full cursor-pointer rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-accent',
+        schedule.isPast && 'opacity-70',
+      )}
     >
       <div className="flex gap-3">
         {/* movie poster */}
@@ -47,13 +45,18 @@ export function DmMatchTicket({ match }: DmMatchTicketProps) {
 
         {/* body */}
         <div className="min-w-0 flex-1">
-          {/* date + time + D-day */}
+          {/* date + time + schedule status */}
           <div className="flex items-center gap-1.5">
             <span className="font-mono text-[11px] text-muted-foreground">
               {month}.{day}({dow}) {time}
             </span>
-            <span className={`ml-auto shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px] font-medium ${isFull ? 'bg-muted text-muted-foreground' : 'border border-border text-muted-foreground'}`}>
-              {dd <= 0 ? 'D-day' : `D-${dd}`}
+            <span className={cn(
+              'ml-auto shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px] font-medium',
+              schedule.isPast || isFull
+                ? 'bg-muted text-muted-foreground'
+                : 'border border-primary/30 text-primary',
+            )}>
+              {schedule.label}
             </span>
           </div>
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 import { cn } from './cn'
 import { assertValue, assertNever } from './assertions'
 import { generateRandomNumber } from './utils'
-export { cn, assertValue, assertNever, generateRandomNumber }
+import { getMatchScheduleStatus } from './match-schedule'
+export { cn, assertValue, assertNever, generateRandomNumber, getMatchScheduleStatus }

--- a/src/lib/utils/match-schedule.ts
+++ b/src/lib/utils/match-schedule.ts
@@ -1,0 +1,19 @@
+const DAY_MS = 1000 * 60 * 60 * 24
+
+function startOfDay(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+export function getMatchScheduleStatus(
+  showTime: string | Date,
+  now = new Date(),
+) {
+  const target = typeof showTime === 'string' ? new Date(showTime) : showTime
+  const daysUntil = Math.ceil(
+    (startOfDay(target).getTime() - startOfDay(now).getTime()) / DAY_MS,
+  )
+  const isPast = target.getTime() < now.getTime()
+  const label = isPast ? '지난 일정' : daysUntil === 0 ? '오늘' : `D-${daysUntil}`
+
+  return { daysUntil, isPast, label }
+}


### PR DESCRIPTION
## Summary
지난 매칭 일정이 `/match`에서 `D-day`와 `신청하기`로 보이는 문제를 수정합니다.

## 원인
D-day 계산에서 과거 날짜를 0 이하로 묶어 `D-day`/`D-0`처럼 표시했고, 신청 버튼은 인원 마감 여부만 확인했습니다.

## 변경
- 매칭 일정 상태 공통 유틸 추가: 미래 `D-n`, 당일 `오늘`, 과거 `지난 일정`
- `/match` 목록 카드의 지난 일정 배지를 muted 처리
- 지난 일정의 신청 버튼 비활성화 및 문구 `지난 일정`으로 변경
- 상세/채팅 핀/우측 사이드바의 D-day 표시도 같은 기준으로 통일
- 상세 페이지 `intent=apply` 자동 모달도 지난 일정에서는 열리지 않도록 차단

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인
- [x] 운영 `/match`에서 2026-05 지난 글이 `D-day`/`신청하기`로 보이는 문제 재현 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 `/match`에서 지난 글이 `지난 일정`으로 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)