### PR TITLE
💄 매칭 상세 모바일 화면 개선

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -65,6 +65,7 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   const palette = paletteForMovie(matchPost.id, matchPost.movieTitle)
   const isFull = matchPost.currentParticipants >= matchPost.maxParticipants
   const isPast = getMatchScheduleStatus(matchPost.showTime).isPast
+  const ctaLabel = isPast ? '지난 일정' : isFull ? '모집 완료' : '신청하기'
 
   useEffect(() => {
     if (handledApplyIntentRef.current) return
@@ -87,20 +88,19 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   ])
 
   return (
-    <div className="relative min-h-page bg-background pb-[140px] lg:pb-6 text-foreground">
-      {/* 상단 컬러 그라디언트 */}
+    <div className="relative min-h-page bg-background pb-[140px] text-foreground lg:pb-6">
       <div
-        className="h-[80px] w-full"
+        className="h-[112px] w-full"
         style={{
           background: `linear-gradient(160deg, oklch(${palette.lt} ${palette.c} ${palette.h}) 0%, oklch(${palette.lb} ${palette.c * 0.5} ${palette.h}) 100%)`,
-          opacity: 0.6,
+          opacity: 0.7,
         }}
       />
-      <div className="flex items-center border-b border-border px-4 py-3.5 -mt-[80px] relative bg-background/70 backdrop-blur-sm">
+      <div className="relative -mt-[112px] flex items-center px-4 py-3.5">
         <button
           aria-label="뒤로"
           onClick={() => router.back()}
-          className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-white/[0.06] text-foreground"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur"
         >
           <svg width="8" height="14" viewBox="0 0 8 14">
             <path
@@ -113,43 +113,45 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
             />
           </svg>
         </button>
-        <div className="flex-1 text-center font-dm-display text-[17px] italic font-bold text-foreground">
+        <div className="flex-1 text-center text-[15px] font-semibold text-foreground">
           매칭 상세
         </div>
         <div className="w-[34px]" aria-hidden />
       </div>
 
-      <div className="flex gap-2.5 border-b border-border px-4 py-4">
-        <div className="w-[60px] flex-shrink-0">
-          <Poster title={matchPost.movieTitle} palette={palette} />
+      <section className="mx-4 mt-3 rounded-lg border border-border bg-card p-3.5 shadow-sm">
+        <div className="flex gap-3">
+          <div className="w-[72px] flex-shrink-0">
+            <Poster title={matchPost.movieTitle} palette={palette} rounded="md" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[12px] font-medium text-muted-foreground">
+              관람 예정 작품
+            </div>
+            <div className="mt-1 break-keep text-[20px] font-semibold leading-tight text-foreground">
+              {matchPost.movieTitle}
+            </div>
+            <div className="mt-2 break-keep text-[13px] leading-snug text-muted-foreground">
+              {matchPost.title}
+            </div>
+          </div>
         </div>
-        <div className="min-w-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.5px] text-muted-foreground">
-            관람 예정 작품
-          </div>
-          <div className="mt-0.5 font-dm-display text-[18px] italic text-foreground">
-            {matchPost.movieTitle}
-          </div>
-          <div className="mt-1 break-keep text-[11px] text-muted-foreground">
-            {matchPost.title}
-          </div>
-        </div>
-      </div>
+      </section>
 
-      <div className="px-4 pt-4">
+      <div className="px-4 pt-3">
         <DmMatchDetailCard match={matchPost} />
 
         {matchPost.content && (
           <div className="mt-4">
-            <SectionHead>호스트의 인사</SectionHead>
-            <div className="break-keep border border-border bg-secondary p-3.5 font-dm-display text-[14px] italic leading-[1.6] text-foreground">
-              &ldquo;{matchPost.content}&rdquo;
+            <SectionHead className="mt-0">호스트의 인사</SectionHead>
+            <div className="break-keep rounded-lg border border-border bg-card p-4 text-[14px] leading-[1.7] text-foreground">
+              {matchPost.content}
             </div>
           </div>
         )}
       </div>
 
-      <div className="fixed bottom-[calc(4rem+env(safe-area-inset-bottom)+0.5rem)] left-1/2 z-25 w-full max-w-[460px] -translate-x-1/2 border-t border-border bg-background/95 px-3 py-3 backdrop-blur-md lg:bottom-0">
+      <div className="fixed bottom-[calc(4rem+env(safe-area-inset-bottom)+0.5rem)] left-1/2 z-25 w-full max-w-[460px] -translate-x-1/2 border-t border-border bg-background/95 px-4 py-3 backdrop-blur-md lg:bottom-0">
         {myApplication ? (
           <div className="flex flex-col items-center gap-2">
             <ApplicationStatusBadge status={myApplication.status} />
@@ -167,9 +169,9 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
             type="button"
             onClick={handleApplyClick}
             disabled={isFull || isPast}
-            className="w-full rounded-md bg-primary py-3.5 text-[15px] font-bold tracking-[-0.01em] text-primary-foreground disabled:bg-secondary disabled:text-muted-foreground disabled:shadow-none"
+            className="w-full rounded-md bg-primary py-3.5 text-[15px] font-bold text-primary-foreground shadow-sm disabled:bg-secondary disabled:text-muted-foreground disabled:shadow-none"
           >
-            {isPast ? '지난 일정' : isFull ? '모집 완료' : '🎟  신청하기'}
+            {ctaLabel}
           </button>
         )}
       </div>

--- a/src/components/dm/dm-match-detail-card.tsx
+++ b/src/components/dm/dm-match-detail-card.tsx
@@ -1,6 +1,5 @@
 import { MatchPost } from '@/lib/type'
-import { getMatchScheduleStatus } from '@/lib/utils'
-import { Pill } from './pill'
+import { cn, getMatchScheduleStatus } from '@/lib/utils'
 
 interface DmMatchDetailCardProps {
   match: MatchPost
@@ -8,44 +7,34 @@ interface DmMatchDetailCardProps {
 
 const DOW = ['일', '월', '화', '수', '목', '금', '토']
 
-function FilmStrip({ position }: { position: 'top' | 'bottom' }) {
+function InfoRow({
+  label,
+  value,
+  sub,
+}: {
+  label: string
+  value: string
+  sub?: string
+}) {
   return (
-    <div
-      aria-hidden
-      className={`-mx-[18px] h-3 ${
-        position === 'top'
-          ? '-mt-[18px] mb-3.5 border-b border-border'
-          : 'mt-3.5 -mb-[18px] border-t border-border'
-      }`}
-      style={{
-        background:
-          'repeating-linear-gradient(90deg, #000 0 12px, transparent 12px 16px, #000 16px 28px, transparent 28px 32px)',
-      }}
-    />
-  )
-}
-
-function Label({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="font-mono text-[10px] uppercase tracking-[1px] text-muted-foreground">
-      {children}
+    <div className="rounded-md border border-border bg-background/55 px-3.5 py-3">
+      <div className="text-[11px] font-medium text-muted-foreground">{label}</div>
+      <div className="mt-1 break-keep text-[15px] font-semibold leading-snug text-foreground">
+        {value}
+      </div>
+      {sub && (
+        <div className="mt-0.5 break-keep text-[12px] leading-snug text-muted-foreground">
+          {sub}
+        </div>
+      )}
     </div>
-  )
-}
-
-function DashedDivider() {
-  return (
-    <div
-      className="my-3.5 border-t border-dashed border-border"
-      aria-hidden
-    />
   )
 }
 
 export function DmMatchDetailCard({ match }: DmMatchDetailCardProps) {
   const showTime = new Date(match.showTime)
-  const m = String(showTime.getMonth() + 1).padStart(2, '0')
-  const d = String(showTime.getDate()).padStart(2, '0')
+  const month = String(showTime.getMonth() + 1).padStart(2, '0')
+  const day = String(showTime.getDate()).padStart(2, '0')
   const dow = DOW[showTime.getDay()]
   const time = showTime.toLocaleTimeString('ko-KR', {
     hour: '2-digit',
@@ -53,73 +42,45 @@ export function DmMatchDetailCard({ match }: DmMatchDetailCardProps) {
     hour12: false,
   })
   const schedule = getMatchScheduleStatus(match.showTime)
-  const tags: string[] = []
-  if (match.gender === 'male') tags.push('남성만')
-  else if (match.gender === 'female') tags.push('여성만')
   const joined = match.currentParticipants
   const cap = match.maxParticipants
-  const emptyCount = Math.max(0, cap - joined)
+  const isFull = joined >= cap
+  const genderLabel =
+    match.gender === 'male' ? '남성만' : match.gender === 'female' ? '여성만' : '성별 무관'
 
   return (
-    <div className="relative border border-border bg-card p-[18px]" style={{ background: 'linear-gradient(160deg, hsl(var(--card)) 0%, hsl(var(--background)) 100%)' }}>
-      <FilmStrip position="top" />
-
-      <Label>WHEN</Label>
-      <div className="mt-1 font-dm-rank text-[28px] leading-none text-foreground">
-        {m}.{d} {dow}
-      </div>
-      <div className="mt-0.5 font-mono text-[14px] text-primary">
-        {time}{' '}
-        <span className="text-[11px] text-muted-foreground">
-          · {schedule.label}
+    <section className="rounded-lg border border-border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-[12px] font-medium text-muted-foreground">영화 약속</div>
+          <div className="mt-1 text-[18px] font-semibold leading-tight text-foreground">
+            {match.title || match.movieTitle}
+          </div>
+        </div>
+        <span
+          className={cn(
+            'shrink-0 rounded-full px-2.5 py-1 font-mono text-[11px] font-semibold',
+            schedule.isPast || isFull
+              ? 'bg-muted text-muted-foreground'
+              : 'bg-primary/10 text-primary',
+          )}
+        >
+          {schedule.label}
         </span>
       </div>
 
-      <DashedDivider />
-
-      <Label>WHERE</Label>
-      <div className="mt-1 text-[14px] text-foreground">{match.theaterName}</div>
-      <div className="mt-0.5 text-[11px] text-muted-foreground">
-        {match.location}
+      <div className="mt-4 grid gap-2">
+        <InfoRow label="일정" value={`${month}.${day}(${dow}) ${time}`} />
+        <InfoRow label="장소" value={match.theaterName} sub={match.location} />
+        <div className="grid grid-cols-2 gap-2">
+          <InfoRow
+            label="참여 인원"
+            value={`${joined}/${cap}명`}
+            sub={isFull ? '모집이 마감됐어요' : `${cap - joined}자리 남았어요`}
+          />
+          <InfoRow label="참여 조건" value={genderLabel} />
+        </div>
       </div>
-
-      <DashedDivider />
-
-      <Label>
-        WHO · <span className="text-primary">{joined}</span>/{cap}명
-      </Label>
-      <div className="mt-2 flex flex-wrap gap-1.5">
-        {Array.from({ length: joined }).map((_, i) => (
-          <span
-            key={`f-${i}`}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-secondary text-[13px] font-bold text-foreground"
-          >
-            {i === 0 ? match.author?.charAt(0).toUpperCase() ?? '?' : '·'}
-          </span>
-        ))}
-        {Array.from({ length: emptyCount }).map((_, i) => (
-          <span
-            key={`e-${i}`}
-            className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-border text-[13px] text-muted-foreground"
-          >
-            ?
-          </span>
-        ))}
-      </div>
-
-      {tags.length > 0 && (
-        <>
-          <DashedDivider />
-          <Label>조건</Label>
-          <div className="mt-1.5 flex gap-1">
-            {tags.map((t) => (
-              <Pill key={t}>{t}</Pill>
-            ))}
-          </div>
-        </>
-      )}
-
-      <FilmStrip position="bottom" />
-    </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
매칭 상세 화면의 모바일 정보 위계와 시각 밀도를 개선합니다.

## 원인
기존 상세 화면은 필름 티켓 장식과 영문 라벨이 정보보다 강하고, 영화/일정/장소/인원/CTA가 모바일에서 한눈에 연결되지 않았습니다.

## 변경
- 상단을 영화 약속 요약 카드로 재구성
- 일정/장소/인원/조건을 스캔 가능한 정보 행으로 변경
- 기존 `WHEN/WHERE/WHO` 라벨과 필름 스트립 장식 제거
- 호스트 메시지 스타일을 일반 카드로 정리
- 하단 CTA 문구와 패딩을 모바일에 맞게 정돈

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인: `match-viewer-view.tsx` 189줄, `dm-match-detail-card.tsx` 86줄
- [x] 운영 상세 URL 200 응답 확인
- [x] 로컬 상세 라우트 렌더링 확인: 개발 API에 해당 운영 id가 없어 에러 화면 표시
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 모바일 상세 화면 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)