### PR TITLE
🚀 Release: 매칭 상세 비활성 CTA 제거

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -65,7 +65,7 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   const palette = paletteForMovie(matchPost.id, matchPost.movieTitle)
   const isFull = matchPost.currentParticipants >= matchPost.maxParticipants
   const isPast = getMatchScheduleStatus(matchPost.showTime).isPast
-  const ctaLabel = isPast ? '지난 일정' : isFull ? '모집 완료' : '신청하기'
+  const canApply = !isPast && !isFull
 
   useEffect(() => {
     if (handledApplyIntentRef.current) return
@@ -144,30 +144,32 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
         )}
       </div>
 
-      <div className="sticky bottom-0 z-40 mt-4 border-t border-border bg-background/95 px-4 pb-4 pt-3 backdrop-blur-md">
-        {myApplication ? (
-          <div className="flex flex-col items-center gap-2">
-            <ApplicationStatusBadge status={myApplication.status} />
-            {myApplication.status === 'accepted' && (
-              <Link
-                href={`/match/${matchPost.id}/chat/${matchPost.userno}`}
-                className="block w-full bg-primary py-3.5 text-center text-[15px] font-bold tracking-[-0.01em] text-white"
-              >
-                작성자와 채팅하기
-              </Link>
-            )}
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={handleApplyClick}
-            disabled={isFull || isPast}
-            className="w-full rounded-md bg-primary py-3.5 text-[15px] font-bold text-primary-foreground shadow-sm disabled:bg-secondary disabled:text-muted-foreground disabled:shadow-none"
-          >
-            {ctaLabel}
-          </button>
-        )}
-      </div>
+      {(myApplication || canApply) && (
+        <div className="sticky bottom-0 z-40 mt-4 border-t border-border bg-background/95 px-4 pb-4 pt-3 backdrop-blur-md">
+          {myApplication ? (
+            <div className="flex flex-col items-center gap-2">
+              <ApplicationStatusBadge status={myApplication.status} />
+              {myApplication.status === 'accepted' && (
+                <Link
+                  href={`/match/${matchPost.id}/chat/${matchPost.userno}`}
+                  className="block w-full bg-primary py-3.5 text-center text-[15px] font-bold tracking-[-0.01em] text-white"
+                >
+                  작성자와 채팅하기
+                </Link>
+              )}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={handleApplyClick}
+              disabled={!canApply}
+              className="w-full rounded-md bg-primary py-3.5 text-[15px] font-bold text-primary-foreground shadow-sm disabled:bg-secondary disabled:text-muted-foreground disabled:shadow-none"
+            >
+              신청하기
+            </button>
+          )}
+        </div>
+      )}
 
       <MatchApplyDialog
         isOpen={showApplyDialog}


### PR DESCRIPTION
## Summary
매칭 상세 모바일에서 지난 일정의 비활성 하단 CTA가 호스트 인사와 붙어 보이는 문제를 운영 배포합니다.

## 변경
- PR #378 — 지난 일정/모집 완료 상세에서는 하단 sticky CTA 숨김
- 신청 가능한 매칭 또는 내 신청 상태가 있는 경우에만 하단 액션 영역 표시

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인: `match-viewer-view.tsx` 184줄
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 모바일 상세 화면 확인

🤖 Generated with [Codex](https://openai.com/codex)