### PR TITLE
💄 모바일 푸터 하단 내비 겹침 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -141,7 +141,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                   </div>
                   <main className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain lg:min-h-page lg:overflow-visible">
                     {children}
-                    <DmAppFooter className="mt-auto pb-4 lg:pb-8" />
+                    <DmAppFooter className="mt-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-8" />
                   </main>
                   <div className="lg:hidden">
                     <DmBottomNav />


### PR DESCRIPTION
## Summary
- 모바일 앱 쉘에서 footer가 하단 내비게이션과 겹치는 문제를 수정합니다.
- footer 하단 padding을 모바일 하단 nav 높이와 safe-area 기준으로 확보합니다.
- 데스크톱 footer 여백은 기존 `lg:pb-8`을 유지합니다.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인: `layout.tsx` 160줄
- [x] 로컬 모바일 `/match` footer/nav visible overlap 0px 확인
- [x] 로컬 모바일 `/match/cmovjhnc00003az1xltp0ii4q` footer/nav visible overlap 0px 확인
- [ ] 배포 후 운영 모바일 화면 확인

🤖 Generated with [Codex](https://openai.com/codex)