### PR TITLE
💄 매칭 상세 본문 푸터 겹침 수정

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -88,7 +88,7 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   ])
 
   return (
-    <div className="relative min-h-page bg-background pb-6 text-foreground">
+    <div className="relative shrink-0 bg-background pb-6 text-foreground">
       <div className="sticky top-0 z-30 flex items-center border-b border-border bg-background/95 px-4 py-3.5 backdrop-blur-md">
         <button
           aria-label="뒤로"


### PR DESCRIPTION
## Summary
- 매칭 상세 본문 루트의 `min-h-page`를 제거하고 `shrink-0`으로 콘텐츠 높이만큼 유지되게 수정합니다.
- 실제 모바일에서 호스트 인사 영역이 footer와 겹쳐 보이는 문제를 해결합니다.

## Cause
- 운영 모바일 측정 결과 상세 루트가 `min-h-page` 때문에 630px 높이로 잡혔고, 내부 호스트 블록은 745px까지 overflow되었습니다.
- footer가 상세 루트의 계산된 끝인 691px부터 시작하면서 호스트 영역과 약 54px 겹쳤습니다.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인: `match-viewer-view.tsx` 184줄
- [x] 운영 현재 상태에서 host/footer overlap 원인 측정
- [ ] 배포 후 운영 모바일 상세에서 host/footer overlap 0px 확인

🤖 Generated with [Codex](https://openai.com/codex)