### PR TITLE
🚀 Release: 매칭 상세 본문 푸터 겹침 수정

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-viewer-view.tsx
@@ -88,7 +88,7 @@ const MatchViewerView = ({ matchPost, onApply }: MatchViewerViewProps) => {
   ])
 
   return (
-    <div className="relative min-h-page bg-background pb-6 text-foreground">
+    <div className="relative shrink-0 bg-background pb-6 text-foreground">
       <div className="sticky top-0 z-30 flex items-center border-b border-border bg-background/95 px-4 py-3.5 backdrop-blur-md">
         <button
           aria-label="뒤로"


### PR DESCRIPTION
## Summary
실제 모바일 기기에서 매칭 상세의 호스트 인사와 footer가 겹쳐 보이는 문제를 운영 배포합니다.

## 변경
- PR #382 — 상세 본문 루트의 `min-h-page` 제거 및 `shrink-0` 적용

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인: `match-viewer-view.tsx` 184줄
- [x] 운영 현재 상태에서 host/footer overlap 원인 측정
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 모바일 상세에서 host/footer overlap 0px 확인

🤖 Generated with [Codex](https://openai.com/codex)