### PR TITLE
🚀 Release: 홈 모집 중 매칭 카운트 수정

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -4,6 +4,7 @@ import { MatchHeroBanner, MovieListCard } from '@/components/dm'
 import { Movie } from '@/modules/movie/movie.entity'
 import { MovieRepository } from '@/modules/movie/movie-repository'
 import { MatchPostRepository } from '@/modules/match/match-post-repository'
+import { getMatchScheduleStatus } from '@/lib/utils'
 import { Metadata } from 'next'
 import { FunctionComponent } from 'react'
 
@@ -23,7 +24,9 @@ const getMatchLiveCount = async (): Promise<number> => {
     const repo = new MatchPostRepository()
     const data = await repo.getMatchPosts(1, 100)
     return data.matchPosts.filter(
-      (m) => m.currentParticipants < m.maxParticipants,
+      (m) =>
+        m.currentParticipants < m.maxParticipants &&
+        !getMatchScheduleStatus(m.showTime).isPast,
     ).length
   } catch {
     return 0

--- a/src/components/dm/dm-desktop-right-sidebar.tsx
+++ b/src/components/dm/dm-desktop-right-sidebar.tsx
@@ -43,7 +43,13 @@ export function DmDesktopRightSidebar() {
     fetcher,
     { refreshInterval: 60_000 },
   )
-  const posts = data?.matchPosts?.slice(0, 5) ?? []
+  const posts = data?.matchPosts
+    ?.filter(
+      (match) =>
+        match.currentParticipants < match.maxParticipants &&
+        !getMatchScheduleStatus(match.showTime).isPast,
+    )
+    ?.slice(0, 5) ?? []
 
   return (
     <aside className="hidden lg:sticky lg:top-0 lg:flex lg:h-screen lg:w-[320px] lg:shrink-0 lg:flex-col lg:overflow-y-auto lg:border-l lg:border-border lg:bg-background">


### PR DESCRIPTION
## Summary
홈 화면에서 지난 일정만 남았는데도 `모집 1개`로 표시되는 문제를 운영 배포합니다.

## 변경
- PR #384 — 홈 모집 카운트와 우측 모집 중 목록에서 지난 일정/마감 글 제외

## Test plan
- [x] 운영 API 데이터가 모두 지난 일정임을 확인
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인
- [x] 로컬 홈에서 `모집 1개` 텍스트 미노출 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 운영 홈에서 `모집 1개` 미노출 확인

🤖 Generated with [Codex](https://openai.com/codex)