### PR TITLE
💄 채팅 목록 메타 정보 개선

### DIFF
--- a/src/app/(root)/(routes)/chat/components/chat-room-list.tsx
+++ b/src/app/(root)/(routes)/chat/components/chat-room-list.tsx
@@ -8,6 +8,19 @@ import useSWR from 'swr'
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
+function formatRoomTime(value?: string) {
+  if (!value) return ''
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+
+  const now = new Date()
+  const isToday = date.toDateString() === now.toDateString()
+  return isToday
+    ? date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+    : date.toLocaleDateString('ko-KR', { month: 'numeric', day: 'numeric' })
+}
+
 function parseRoom(room: ChatRoomEntity, currentUserId: number) {
   // 우선순위: matchPostId 필드(신규) → roomName 파싱(레거시)
   let matchId: string | null = room.matchPostId ?? null
@@ -15,13 +28,14 @@ function parseRoom(room: ChatRoomEntity, currentUserId: number) {
     matchId = room.roomName.replace('Match Chat - ', '')
   }
   const targetUserId = room.memberIds.find((id) => id !== currentUserId) ?? null
-  const date = new Date(room.updatedAt)
-  const now = new Date()
-  const isToday = date.toDateString() === now.toDateString()
-  const timeStr = isToday
-    ? date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
-    : date.toLocaleDateString('ko-KR', { month: 'numeric', day: 'numeric' })
-  return { matchId, targetUserId, timeStr }
+  const targetProfile = room.memberProfiles?.find(
+    (profile) => profile.userId !== currentUserId,
+  )
+  const timeStr = formatRoomTime(room.lastMessageAt || room.updatedAt)
+  const title = room.matchTitle || (matchId ? '매칭 채팅' : room.roomName)
+  const preview = room.lastMessage || '아직 주고받은 메시지가 없어요'
+
+  return { matchId, targetUserId, targetProfile, timeStr, title, preview }
 }
 
 function RoomRow({
@@ -31,41 +45,53 @@ function RoomRow({
   room: ChatRoomEntity
   currentUserId: number
 }) {
-  const { matchId, targetUserId, timeStr } = parseRoom(room, currentUserId)
+  const { matchId, targetUserId, targetProfile, timeStr, title, preview } =
+    parseRoom(room, currentUserId)
   // matchId가 있으면 매치 컨텍스트가 있는 채팅 페이지로,
   // 없으면(레거시 룸) chatRoomId 직접 진입 페이지로 폴백
   const href = matchId && targetUserId
     ? `/match/${matchId}/chat/${targetUserId}`
     : `/chat/${room.chatRoomId}`
-  const initial = (targetUserId ? `${targetUserId}` : room.roomName)
-    .charAt(0)
-    .toUpperCase()
+  const avatarLabel = targetProfile?.nickname || title || room.roomName
+  const initial = avatarLabel.charAt(0).toUpperCase()
+  const avatarStyle = targetProfile?.image
+    ? {
+        backgroundImage: `url("${targetProfile.image}")`,
+        backgroundPosition: 'center',
+        backgroundSize: 'cover',
+      }
+    : undefined
 
   return (
     <Link
       href={href}
       className="flex items-center gap-3 border-b border-border px-4 py-3.5 hover:bg-secondary"
     >
-      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-border bg-secondary text-[17px] font-bold text-foreground">
-        {initial}
+      <div
+        className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-border bg-secondary text-[17px] font-bold text-foreground"
+        style={avatarStyle}
+        aria-label={avatarLabel}
+      >
+        {!targetProfile?.image && initial}
       </div>
 
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate text-[14px] font-semibold text-foreground">
-            {targetUserId ? `상대방 #${targetUserId}` : room.roomName}
+            {title}
           </span>
-          <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
-            {timeStr}
-          </span>
+          {timeStr && (
+            <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+              마지막 {timeStr}
+            </span>
+          )}
         </div>
-        {matchId && (
-          <div className="mt-0.5 font-mono text-[9px] tracking-[0.5px] text-primary">
-            🎟 {matchId}
-          </div>
-        )}
-        <div className="mt-0.5 text-[12px] text-muted-foreground">
-          채팅방 열기 →
+        <div className="mt-0.5 flex items-center gap-1.5 text-[12px] text-muted-foreground">
+          {targetProfile?.nickname && (
+            <span className="max-w-[34%] truncate">{targetProfile.nickname}</span>
+          )}
+          {targetProfile?.nickname && <span aria-hidden="true">·</span>}
+          <span className="truncate">{preview}</span>
         </div>
       </div>
     </Link>

--- a/src/app/api/chat/rooms/route.ts
+++ b/src/app/api/chat/rooms/route.ts
@@ -1,6 +1,43 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getTokenFromCookie } from '@/lib/utils/getToken'
 import { ChatRepository } from '@/modules/chat/chat-repository'
+import { MatchPostRepository } from '@/modules/match/match-post-repository'
+import type { ChatRoomsResponseEntity } from '@/modules/chat/chat.entity'
+
+async function addMatchTitles(
+  data: ChatRoomsResponseEntity,
+  token: string,
+): Promise<ChatRoomsResponseEntity> {
+  const matchIds = Array.from(
+    new Set(data.chatRooms.map((room) => room.matchPostId).filter(Boolean)),
+  ) as string[]
+
+  if (matchIds.length === 0) return data
+
+  const matchRepository = new MatchPostRepository(token)
+  const entries = await Promise.all(
+    matchIds.map(async (matchId) => {
+      try {
+        const match = await matchRepository.getMatchPost(matchId)
+        return [matchId, match.title || match.movieTitle] as const
+      } catch (error) {
+        console.warn(`Match title fetch skipped (${matchId}):`, error)
+        return [matchId, ''] as const
+      }
+    }),
+  )
+  const titleMap = new Map(entries.filter(([, title]) => Boolean(title)))
+
+  return {
+    ...data,
+    chatRooms: data.chatRooms.map((room) => ({
+      ...room,
+      matchTitle: room.matchPostId
+        ? titleMap.get(room.matchPostId) || room.matchTitle
+        : room.matchTitle,
+    })),
+  }
+}
 
 // POST /api/chat/rooms - 채팅방 생성
 export async function POST(request: NextRequest) {
@@ -48,7 +85,7 @@ export async function GET(request: NextRequest) {
       page,
       pageSize,
     })
-    return NextResponse.json(data)
+    return NextResponse.json(await addMatchTitles(data, token))
   } catch (error) {
     console.error('Chat rooms list API error:', error)
     return NextResponse.json(

--- a/src/modules/chat/chat-mapper.ts
+++ b/src/modules/chat/chat-mapper.ts
@@ -11,6 +11,10 @@ export function convertApiResponseToChatRoomEntity(
     createdAt: apiResponse.createdAt,
     updatedAt: apiResponse.updatedAt,
     matchPostId: apiResponse.matchPostId || undefined,
+    matchTitle: apiResponse.matchTitle || undefined,
+    memberProfiles: apiResponse.memberProfiles || undefined,
+    lastMessage: apiResponse.lastMessage || undefined,
+    lastMessageAt: apiResponse.lastMessageAt || undefined,
   }
 }
 

--- a/src/modules/chat/chat.entity.ts
+++ b/src/modules/chat/chat.entity.ts
@@ -1,4 +1,10 @@
 // 채팅방 엔티티
+export interface ChatRoomMemberProfileEntity {
+  userId: number
+  nickname: string
+  image: string
+}
+
 export interface ChatRoomEntity {
   chatRoomId: string
   roomName: string
@@ -7,6 +13,10 @@ export interface ChatRoomEntity {
   createdAt: string
   updatedAt: string
   matchPostId?: string
+  matchTitle?: string
+  memberProfiles?: ChatRoomMemberProfileEntity[]
+  lastMessage?: string
+  lastMessageAt?: string
 }
 
 // 채팅 메시지 엔티티


### PR DESCRIPTION
## Summary
채팅 목록에서 매칭 제목, 마지막 메시지 시간, 상대 프로필 이미지를 보여주도록 개선합니다.

## 원인
기존 목록은 상대방 ID를 제목처럼 보여주고, 아바타도 숫자 이니셜로 표시되어 채팅방을 구분하기 어려웠습니다.

## 변경
- /api/chat/rooms 응답에 매칭 제목 병합
- 채팅 목록 제목을 상대방 번호 대신 매칭 제목으로 표시
- 상대 프로필 이미지와 마지막 메시지 시간/프리뷰 표시

## Test plan
- [x] pnpm lint
- [x] pnpm build
- [x] 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)