### PR TITLE
🐛 채팅 API 인증 토큰 조회 수정

### DIFF
--- a/src/app/api/chat/direct/route.ts
+++ b/src/app/api/chat/direct/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { ChatRepository } from '@/modules/chat/chat-repository'
 
 // POST /api/chat/direct - 1:1 채팅방 찾기 또는 생성
 export async function POST(request: NextRequest) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/chat/rooms/[roomId]/messages/route.ts
+++ b/src/app/api/chat/rooms/[roomId]/messages/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { ChatRepository } from '@/modules/chat/chat-repository'
 
 // GET /api/chat/rooms/[roomId]/messages - 특정 채팅방의 메시지 조회
@@ -8,7 +8,7 @@ export async function GET(
   { params }: { params: { roomId: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
@@ -47,7 +47,7 @@ export async function POST(
   { params }: { params: { roomId: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/chat/rooms/[roomId]/route.ts
+++ b/src/app/api/chat/rooms/[roomId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { ChatRepository } from '@/modules/chat/chat-repository'
 
 // GET /api/chat/rooms/[roomId] - 특정 채팅방 조회
@@ -8,7 +8,7 @@ export async function GET(
   { params }: { params: { roomId: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/chat/rooms/route.ts
+++ b/src/app/api/chat/rooms/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { ChatRepository } from '@/modules/chat/chat-repository'
 import { MatchPostRepository } from '@/modules/match/match-post-repository'
 import type { ChatRoomsResponseEntity } from '@/modules/chat/chat.entity'
@@ -42,7 +42,7 @@ async function addMatchTitles(
 // POST /api/chat/rooms - 채팅방 생성
 export async function POST(request: NextRequest) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
@@ -64,7 +64,7 @@ export async function POST(request: NextRequest) {
 // GET /api/chat/rooms - 채팅방 목록 조회
 export async function GET(request: NextRequest) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/lib/utils/getToken.ts
+++ b/src/lib/utils/getToken.ts
@@ -1,10 +1,22 @@
 import { AppEnv } from '@/config/app-env'
 import { cookies } from 'next/dist/client/components/headers'
+import { getToken } from 'next-auth/jwt'
+import type { NextRequest } from 'next/server'
 
 export const getTokenFromCookie = () => {
   const cookieStore = cookies()
   const token = cookieStore.get(AppEnv.cookieTokenKey)?.value
   return token
+}
+
+export const getAuthTokenFromRequest = async (req: NextRequest) => {
+  const nextAuthToken = await getToken({
+    req,
+    secret: AppEnv.nextAuthSecret,
+    raw: true,
+  })
+
+  return nextAuthToken ?? getTokenFromCookie()
 }
 
 // // 클라이언트 사이드에서 쿠키에서 토큰을 가져오는 함수


### PR DESCRIPTION
## Summary
채팅 BFF API가 NextAuth secure session 쿠키에서도 raw JWT를 읽도록 수정합니다.

## 원인
/api/chat/rooms 계열 라우트가 COOKIE_TOKEN_KEY 쿠키만 직접 조회해, Google OAuth/HTTPS 환경에서 NextAuth 세션 토큰을 못 읽으면 401을 반환했습니다.

## 변경
- NextAuth getToken(raw) 기반 공통 토큰 헬퍼 추가
- chat rooms/direct/messages 라우트가 새 헬퍼를 사용하도록 변경
- 기존 COOKIE_TOKEN_KEY 직접 조회는 폴백으로 유지

## Test plan
- [x] pnpm lint
- [x] pnpm build
- [x] 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)