### PR TITLE
🐛 모바일 푸터 콘텐츠 겹침 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -140,7 +140,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     <DmAppBar />
                   </div>
                   <main className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain lg:min-h-page lg:overflow-visible">
-                    {children}
+                    <div className="shrink-0">{children}</div>
                     <DmAppFooter className="mt-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-8" />
                   </main>
                   <div className="lg:hidden">


### PR DESCRIPTION
## Summary
모바일 레이아웃에서 공통 푸터가 페이지 콘텐츠 중간에 끼어 보이는 문제를 수정합니다.

## 원인
모바일 main이 flex column이고 페이지 children이 직접 flex item으로 들어가면서, 긴 페이지에서 children이 shrink되어 내부 콘텐츠가 footer 뒤로 overflow될 수 있었습니다.

## 변경
- 공통 layout의 children을 shrink-0 래퍼로 감싸 페이지 콘텐츠의 자연 높이를 보존
- footer는 짧은 페이지에서는 하단으로 밀리고, 긴 페이지에서는 콘텐츠 뒤에 위치하도록 유지

## Test plan
- [x] pnpm lint
- [x] pnpm build
- [x] 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)