### PR TITLE
🚀 Release: 공개 채팅 화면 추가

### DIFF
--- a/src/app/(root)/(routes)/chat/components/chat-room-list.tsx
+++ b/src/app/(root)/(routes)/chat/components/chat-room-list.tsx
@@ -2,7 +2,6 @@
 
 import { ChatRoomEntity } from '@/modules/chat'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import useSWR from 'swr'
 
@@ -49,9 +48,10 @@ function RoomRow({
     parseRoom(room, currentUserId)
   // matchId가 있으면 매치 컨텍스트가 있는 채팅 페이지로,
   // 없으면(레거시 룸) chatRoomId 직접 진입 페이지로 폴백
-  const href = matchId && targetUserId
-    ? `/match/${matchId}/chat/${targetUserId}`
-    : `/chat/${room.chatRoomId}`
+  const href =
+    matchId && targetUserId
+      ? `/match/${matchId}/chat/${targetUserId}`
+      : `/chat/${room.chatRoomId}`
   const avatarLabel = targetProfile?.nickname || title || room.roomName
   const initial = avatarLabel.charAt(0).toUpperCase()
   const avatarStyle = targetProfile?.image
@@ -88,7 +88,9 @@ function RoomRow({
         </div>
         <div className="mt-0.5 flex items-center gap-1.5 text-[12px] text-muted-foreground">
           {targetProfile?.nickname && (
-            <span className="max-w-[34%] truncate">{targetProfile.nickname}</span>
+            <span className="max-w-[34%] truncate">
+              {targetProfile.nickname}
+            </span>
           )}
           {targetProfile?.nickname && <span aria-hidden="true">·</span>}
           <span className="truncate">{preview}</span>
@@ -100,7 +102,6 @@ function RoomRow({
 
 export function ChatRoomList() {
   const { data: session, status } = useSession()
-  const router = useRouter()
   const userId = session?.user?.id ? Number(session.user.id) : null
 
   const { data, isLoading } = useSWR(
@@ -117,8 +118,19 @@ export function ChatRoomList() {
     )
 
   if (status === 'unauthenticated') {
-    router.push('/login')
-    return null
+    return (
+      <div className="mx-4 mt-4 rounded-md border border-border px-4 py-5 text-center">
+        <div className="text-[14px] font-semibold text-foreground">
+          로그인하면 매칭 채팅을 볼 수 있어요
+        </div>
+        <Link
+          href="/login?callbackUrl=%2Fchat"
+          className="mt-3 inline-flex rounded-md border border-border px-4 py-2 text-[12px] text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          로그인
+        </Link>
+      </div>
+    )
   }
 
   const rooms: ChatRoomEntity[] = data?.chatRooms ?? []

--- a/src/app/(root)/(routes)/chat/page.tsx
+++ b/src/app/(root)/(routes)/chat/page.tsx
@@ -1,13 +1,39 @@
 import { FunctionComponent, Suspense } from 'react'
+import Link from 'next/link'
 import { ChatRoomList } from './components/chat-room-list'
 
 const Page: FunctionComponent = () => {
   return (
     <div className="min-h-page bg-background text-foreground">
       <div className="flex items-center border-b border-border px-4 py-3.5">
-        <h1 className="font-dm-display text-[20px] italic font-bold text-foreground">
+        <h1 className="font-dm-display text-[20px] font-bold italic text-foreground">
           채팅
         </h1>
+      </div>
+      <section className="border-b border-border px-4 py-4">
+        <Link
+          href="/chat/public"
+          className="block rounded-md border border-border bg-secondary px-4 py-4 hover:border-primary"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="truncate text-[16px] font-bold text-foreground">
+                공개 채팅
+              </h2>
+              <p className="mt-1 truncate text-[12px] text-muted-foreground">
+                지금 접속한 사람들과 이야기하기
+              </p>
+            </div>
+            <span className="shrink-0 text-[18px]" aria-hidden="true">
+              →
+            </span>
+          </div>
+        </Link>
+      </section>
+      <div className="px-4 pt-4">
+        <h2 className="text-[13px] font-semibold text-muted-foreground">
+          내 매칭 채팅
+        </h2>
       </div>
       <Suspense
         fallback={

--- a/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import { Send } from 'lucide-react'
+import { useSession } from 'next-auth/react'
+import { usePublicChatSocket } from '../hooks/use-public-chat-socket'
+
+function createGuestName() {
+  return `익명${Math.floor(1000 + Math.random() * 9000)}`
+}
+
+function formatTime(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+
+  return date.toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function PublicChatRoom() {
+  const { data: session } = useSession()
+  const [input, setInput] = useState('')
+  const [guestName, setGuestName] = useState('')
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('bollae.public-chat.nickname')
+    const nextName = stored || createGuestName()
+    window.localStorage.setItem('bollae.public-chat.nickname', nextName)
+    setGuestName(nextName)
+  }, [])
+
+  const nickName = useMemo(
+    () => session?.user?.nickname || session?.user?.name || guestName || '익명',
+    [guestName, session?.user?.name, session?.user?.nickname],
+  )
+  const { isConnected, messages, sendMessage } = usePublicChatSocket(nickName)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: 'end' })
+  }, [messages])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    sendMessage(input)
+    setInput('')
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-9rem)] flex-col bg-background text-foreground">
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="truncate text-[18px] font-bold">공개 채팅</h1>
+            <p className="mt-0.5 truncate text-[12px] text-muted-foreground">
+              {nickName}
+            </p>
+          </div>
+          <span className="shrink-0 rounded-full border border-border px-3 py-1 text-[11px] text-muted-foreground">
+            {isConnected ? '접속 중' : '연결 중'}
+          </span>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4">
+        {messages.length === 0 && (
+          <div className="flex min-h-[40vh] items-center justify-center text-center text-[13px] text-muted-foreground">
+            첫 메시지를 남겨보세요.
+          </div>
+        )}
+
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={`flex ${message.mine ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`max-w-[82%] rounded-md border px-3 py-2 ${
+                message.mine
+                  ? 'border-primary bg-primary text-white'
+                  : 'border-border bg-secondary text-foreground'
+              }`}
+            >
+              <div className="mb-1 flex items-center gap-2 text-[11px] opacity-80">
+                <span className="max-w-[8rem] truncate">
+                  {message.nickName}
+                </span>
+                <span>{formatTime(message.createdAt)}</span>
+              </div>
+              <p className="whitespace-pre-wrap break-words text-[14px] leading-5">
+                {message.message}
+              </p>
+            </div>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="sticky bottom-0 flex gap-2 border-t border-border bg-background/95 p-3 backdrop-blur"
+      >
+        <input
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder="메시지 입력"
+          className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-3 text-[14px] outline-none focus:border-primary"
+        />
+        <button
+          type="submit"
+          aria-label="보내기"
+          disabled={!input.trim()}
+          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-primary text-white disabled:bg-secondary disabled:text-muted-foreground"
+        >
+          <Send className="h-4 w-4" />
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/(root)/(routes)/chat/public/hooks/use-public-chat-socket.ts
+++ b/src/app/(root)/(routes)/chat/public/hooks/use-public-chat-socket.ts
@@ -1,0 +1,103 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { io, Socket } from 'socket.io-client'
+
+export interface PublicChatMessage {
+  id: string
+  nickName: string
+  message: string
+  createdAt: string
+  mine?: boolean
+}
+
+interface ServerPublicChatMessage {
+  clientId?: string
+  nickName?: string
+  nickname?: string
+  message?: string
+  content?: string
+  createdAt?: string
+}
+
+function createMessageId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function normalizeMessage(
+  data: ServerPublicChatMessage,
+  mine = false,
+): PublicChatMessage | null {
+  const message = (data.message || data.content || '').trim()
+  if (!message) return null
+
+  return {
+    id: data.clientId || createMessageId(),
+    nickName: data.nickName || data.nickname || '익명',
+    message,
+    createdAt: data.createdAt || new Date().toISOString(),
+    mine,
+  }
+}
+
+export function usePublicChatSocket(nickName: string) {
+  const socketRef = useRef<Socket | null>(null)
+  const sentIdsRef = useRef(new Set<string>())
+  const [messages, setMessages] = useState<PublicChatMessage[]>([])
+  const [isConnected, setIsConnected] = useState(false)
+
+  useEffect(() => {
+    const base =
+      typeof window !== 'undefined' && window.location.origin
+        ? window.location.origin
+        : process.env.NEXT_PUBLIC_CHAT_SERVER_API
+    const socket = io(`${base}/ws-public`, {
+      transports: ['websocket', 'polling'],
+    })
+
+    socketRef.current = socket
+    socket.on('connect', () => setIsConnected(true))
+    socket.on('disconnect', () => setIsConnected(false))
+    socket.on('message', (data: ServerPublicChatMessage) => {
+      const isMine = Boolean(
+        data.clientId && sentIdsRef.current.has(data.clientId),
+      )
+      const nextMessage = normalizeMessage(data, isMine)
+      if (!nextMessage) return
+
+      setMessages((prev) => {
+        if (prev.some((message) => message.id === nextMessage.id)) return prev
+        return [...prev, nextMessage].slice(-80)
+      })
+    })
+
+    return () => {
+      socket.disconnect()
+      socketRef.current = null
+      setIsConnected(false)
+    }
+  }, [])
+
+  const sendMessage = useCallback(
+    (message: string) => {
+      const content = message.trim()
+      if (!content || !socketRef.current) return
+
+      const clientId = createMessageId()
+      sentIdsRef.current.add(clientId)
+      socketRef.current.emit('message', {
+        clientId,
+        nickName: nickName.trim() || '익명',
+        message: content,
+        createdAt: new Date().toISOString(),
+      })
+    },
+    [nickName],
+  )
+
+  return { isConnected, messages, sendMessage }
+}

--- a/src/app/(root)/(routes)/chat/public/page.tsx
+++ b/src/app/(root)/(routes)/chat/public/page.tsx
@@ -1,0 +1,5 @@
+import { PublicChatRoom } from './components/public-chat-room'
+
+export default function Page() {
+  return <PublicChatRoom />
+}

--- a/src/components/form/match/match-post-form.tsx
+++ b/src/components/form/match/match-post-form.tsx
@@ -46,11 +46,11 @@ const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
 
   return (
     <Form {...form}>
-      <form onSubmit={handleSubmit} className="space-y-4 pb-4 lg:pb-0">
+      <form onSubmit={handleSubmit} className="min-w-0 space-y-4 pb-4 lg:pb-0">
         <TitleInputField />
         <ContentInputField />
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
           <MovieTitleInputField />
           <TheaterNameInputField />
         </div>


### PR DESCRIPTION
## Summary
- PR #392 — 공개 채팅 화면 추가 및 /match/new 모바일 가로 스크롤 방지

## 원인
- 비로그인 사용자가 채팅 탭에서 바로 로그인으로 이동해 공개 채팅 진입점이 없었음
- /match/new 모바일 입력 그리드가 고정 2열이라 실제 디바이스 폭에서 overflow 가능성이 있었음

## 변경
- /chat 공개 채팅 CTA 추가
- /chat/public 공개 채팅 화면 추가
- 비로그인 매칭 채팅 목록을 로그인 안내로 변경
- 매칭 작성 폼 모바일 입력 그리드 1열화

## Test plan
- [x] pnpm lint
- [x] pnpm build
- [x] 수정 파일 200줄 상한 확인
- [x] 로컬 모바일 390px overflow 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)