### PR TITLE
🐛 공개 채팅 히스토리 수신 추가

### DIFF
--- a/src/app/(root)/(routes)/chat/public/hooks/use-public-chat-socket.ts
+++ b/src/app/(root)/(routes)/chat/public/hooks/use-public-chat-socket.ts
@@ -12,6 +12,7 @@ export interface PublicChatMessage {
 }
 
 interface ServerPublicChatMessage {
+  id?: string
   clientId?: string
   nickName?: string
   nickname?: string
@@ -36,7 +37,7 @@ function normalizeMessage(
   if (!message) return null
 
   return {
-    id: data.clientId || createMessageId(),
+    id: data.id || data.clientId || createMessageId(),
     nickName: data.nickName || data.nickname || '익명',
     message,
     createdAt: data.createdAt || new Date().toISOString(),
@@ -62,6 +63,13 @@ export function usePublicChatSocket(nickName: string) {
     socketRef.current = socket
     socket.on('connect', () => setIsConnected(true))
     socket.on('disconnect', () => setIsConnected(false))
+    socket.on('history', (history: ServerPublicChatMessage[]) => {
+      const nextMessages = history
+        .map((message) => normalizeMessage(message))
+        .filter((message): message is PublicChatMessage => Boolean(message))
+
+      setMessages(nextMessages)
+    })
     socket.on('message', (data: ServerPublicChatMessage) => {
       const isMine = Boolean(
         data.clientId && sentIdsRef.current.has(data.clientId),


### PR DESCRIPTION
## Summary
공개 채팅 입장 시 서버 히스토리 이벤트를 받아 메시지 목록을 복원하도록 수정했습니다.

## 원인
공개 채팅은 실시간 message 이벤트만 수신하고 있었고, 새로고침/재입장 시 기존 메시지를 채우는 history 이벤트 처리가 없었습니다.

## 변경
- 공개 채팅 socket hook에 history 이벤트 수신 추가
- 서버 저장 메시지 id를 클라이언트 메시지 id로 사용

## Test plan
- [x] pnpm lint
- [x] pnpm build
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)