### PR TITLE
🚀 Release: 공개 채팅 히스토리 수신 추가

### DIFF
--- a/src/app/(root)/(routes)/chat/public/hooks/use-public-chat-socket.ts
+++ b/src/app/(root)/(routes)/chat/public/hooks/use-public-chat-socket.ts
@@ -12,6 +12,7 @@ export interface PublicChatMessage {
 }
 
 interface ServerPublicChatMessage {
+  id?: string
   clientId?: string
   nickName?: string
   nickname?: string
@@ -36,7 +37,7 @@ function normalizeMessage(
   if (!message) return null
 
   return {
-    id: data.clientId || createMessageId(),
+    id: data.id || data.clientId || createMessageId(),
     nickName: data.nickName || data.nickname || '익명',
     message,
     createdAt: data.createdAt || new Date().toISOString(),
@@ -62,6 +63,13 @@ export function usePublicChatSocket(nickName: string) {
     socketRef.current = socket
     socket.on('connect', () => setIsConnected(true))
     socket.on('disconnect', () => setIsConnected(false))
+    socket.on('history', (history: ServerPublicChatMessage[]) => {
+      const nextMessages = history
+        .map((message) => normalizeMessage(message))
+        .filter((message): message is PublicChatMessage => Boolean(message))
+
+      setMessages(nextMessages)
+    })
     socket.on('message', (data: ServerPublicChatMessage) => {
       const isMine = Boolean(
         data.clientId && sentIdsRef.current.has(data.clientId),


### PR DESCRIPTION
## Summary
- PR #394 — 공개 채팅 히스토리 이벤트 수신 추가

## 원인
- 공개 채팅 화면이 서버 히스토리 이벤트를 처리하지 않아 새로고침 후 메시지를 복원하지 못했음

## 변경
- history 이벤트 수신
- 저장 메시지 id 기반 dedupe 처리

## Test plan
- [x] pnpm lint
- [x] pnpm build
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)