### PR TITLE
💄 홈 영화 카드에 감독 정보 추가

### DIFF
--- a/src/components/dm/movie-list-card.tsx
+++ b/src/components/dm/movie-list-card.tsx
@@ -14,6 +14,7 @@ export function MovieListCard({ movie }: MovieListCardProps) {
   const rankInten = movie.rankInten ?? 0
   const audience = movie.audience ?? 0
   const genres = movie.genre?.split(/[,/·]/).map((g) => g.trim()).filter(Boolean) ?? []
+  const director = movie.director?.trim()
 
   const intenColor =
     rankInten > 0 ? 'text-green-400' : rankInten < 0 ? 'text-primary' : 'text-muted-foreground'
@@ -57,6 +58,11 @@ export function MovieListCard({ movie }: MovieListCardProps) {
             <h3 className="mt-2 line-clamp-2 break-keep text-[19px] font-bold leading-tight text-foreground group-hover:text-primary sm:text-[21px]">
               {movie.title}
             </h3>
+            {director && (
+              <p className="mt-1 truncate text-[12px] font-medium text-muted-foreground">
+                감독 {director}
+              </p>
+            )}
           </div>
 
           <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
홈 박스오피스 영화 카드에 감독 정보를 추가했습니다.

## 원인
영화 데이터에는 `director`가 이미 포함되어 있지만, 홈 카드 UI에서 노출하지 않아 사용자가 감독 정보를 확인할 수 없었습니다.

## 변경
- 영화 카드 제목 아래에 `감독 {director}` 라인을 추가
- 감독 정보가 비어있으면 라인을 숨김
- 긴 감독명은 한 줄 말줄임 처리

## Test plan
- [x] `pnpm lint` 통과 (기존 경고만 존재)
- [x] `pnpm build` 통과 (기존 DynamicServerUsage 로그만 존재)
- [x] 수정 파일 200줄 상한 확인: `movie-list-card.tsx` 93줄