### PR TITLE
✨ 영화 관람등급을 카드와 상세에 노출

### DIFF
--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -26,8 +26,17 @@ export function DmMovieDetail({
   const rating = averageScore ?? movie.averageScore ?? 0
   const reviews = scoreCount ?? movie.scoreCount ?? 0
   const matchHref = `/match?movieTitle=${encodeURIComponent(movie.title)}`
-  const genres = movie.genre?.split(/[,/·]/).map((g) => g.trim()).filter(Boolean) ?? []
-  const releaseYear = movie.openedAt ? new Date(movie.openedAt).getFullYear() : undefined
+  const genres =
+    movie.genre
+      ?.split(/[,/·]/)
+      .map((g) => g.trim())
+      .filter(Boolean) ?? []
+  const releaseYear = movie.openedAt
+    ? new Date(movie.openedAt).getFullYear()
+    : undefined
+  const metadata = [...genres.slice(0, 2), movie.ratting?.trim(), releaseYear]
+    .filter(Boolean)
+    .join(' · ')
 
   return (
     <div className="pb-5">
@@ -42,7 +51,11 @@ export function DmMovieDetail({
       <div className="relative -mt-[70px] px-4">
         <div className="flex items-end gap-3.5">
           <div className="w-[106px] shrink-0">
-            <Poster title={movie.title} palette={palette} imageUrl={movie.poster} />
+            <Poster
+              title={movie.title}
+              palette={palette}
+              imageUrl={movie.poster}
+            />
           </div>
           <div className="pb-1">
             {movie.rank && (
@@ -54,8 +67,7 @@ export function DmMovieDetail({
               {movie.title}
             </h1>
             <div className="mt-1 font-mono text-[11px] text-muted-foreground">
-              {genres.slice(0, 2).join(' · ')}
-              {releaseYear && ` · ${releaseYear}`}
+              {metadata}
             </div>
           </div>
         </div>
@@ -63,7 +75,9 @@ export function DmMovieDetail({
         {/* 평점 */}
         <div className="mt-4 flex items-center gap-3 rounded-lg border border-border bg-card p-3">
           <div className="text-center">
-            <div className="text-[32px] font-bold text-foreground">{rating.toFixed(1)}</div>
+            <div className="text-[32px] font-bold text-foreground">
+              {rating.toFixed(1)}
+            </div>
             <Stars value={rating} size={10} />
             <div className="mt-0.5 font-mono text-[10px] text-muted-foreground">
               {reviews.toLocaleString()}명

--- a/src/components/dm/movie-list-card.tsx
+++ b/src/components/dm/movie-list-card.tsx
@@ -13,11 +13,20 @@ export function MovieListCard({ movie }: MovieListCardProps) {
   const hasRating = rating > 0
   const rankInten = movie.rankInten ?? 0
   const audience = movie.audience ?? 0
-  const genres = movie.genre?.split(/[,/·]/).map((g) => g.trim()).filter(Boolean) ?? []
+  const genres =
+    movie.genre
+      ?.split(/[,/·]/)
+      .map((g) => g.trim())
+      .filter(Boolean) ?? []
   const director = movie.director?.trim()
+  const contentRating = movie.ratting?.trim()
 
   const intenColor =
-    rankInten > 0 ? 'text-green-400' : rankInten < 0 ? 'text-primary' : 'text-muted-foreground'
+    rankInten > 0
+      ? 'text-green-400'
+      : rankInten < 0
+        ? 'text-primary'
+        : 'text-muted-foreground'
   const intenLabel =
     rankInten > 0 ? `▲${rankInten}` : rankInten < 0 ? `▼${-rankInten}` : '—'
 
@@ -32,7 +41,7 @@ export function MovieListCard({ movie }: MovieListCardProps) {
             className="shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
             rounded="md"
           />
-          <span className="absolute left-2 top-2 inline-flex h-7 min-w-7 items-center justify-center rounded-full bg-primary px-2 font-mono text-[11px] font-semibold text-primary-foreground shadow">
+          <span className="min-w-7 absolute left-2 top-2 inline-flex h-7 items-center justify-center rounded-full bg-primary px-2 font-mono text-[11px] font-semibold text-primary-foreground shadow">
             {movie.rank}
           </span>
         </div>
@@ -51,6 +60,11 @@ export function MovieListCard({ movie }: MovieListCardProps) {
               {movie.rankOldAndNew === 'NEW' && (
                 <span className="rounded-full bg-foreground px-2 py-0.5 font-mono text-[10px] text-background">
                   NEW
+                </span>
+              )}
+              {contentRating && (
+                <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
+                  {contentRating}
                 </span>
               )}
             </div>
@@ -74,7 +88,9 @@ export function MovieListCard({ movie }: MovieListCardProps) {
             </span>
             {audience > 0 && (
               <span className="rounded-md bg-background/70 px-2 py-1.5">
-                <span className="block font-mono text-[9px] uppercase">관객</span>
+                <span className="block font-mono text-[9px] uppercase">
+                  관객
+                </span>
                 <span className="font-semibold text-foreground">
                   {(audience / 10000).toFixed(0)}만명
                 </span>


### PR DESCRIPTION
## Summary
- 홈 영화 카드의 장르/NEW 칩 영역에 관람등급 badge 노출
- 영화 상세 상단 메타 정보에 장르, 관람등급, 개봉연도 순으로 표시

## Test plan
- [x] `pnpm prettier --write src/components/dm/movie-list-card.tsx src/components/dm/dm-movie-detail.tsx`
- [x] `pnpm lint` (기존 경고만 존재)
- [x] `pnpm build` (기존 DynamicServerUsage 로그만 존재)
- [x] 수정 파일 200줄 상한 확인 (`movie-list-card.tsx` 109줄, `dm-movie-detail.tsx` 123줄)
- [ ] 인앱 브라우저 모바일 시각 확인: 현재 iab 연결 unavailable로 미수행

🤖 Generated with Codex