### PR TITLE
✨ 아티클 마크다운 에디터 추가

### DIFF
--- a/src/app/(root)/(routes)/articles/[id]/sections/article-data-section.tsx
+++ b/src/app/(root)/(routes)/articles/[id]/sections/article-data-section.tsx
@@ -2,6 +2,7 @@
 
 import { Article } from '@/lib/type'
 import { useAppToast } from '@/hooks/use-app-toast'
+import { MarkdownContent } from '@/components/app/markdown-content'
 import { useSession } from 'next-auth/react'
 import { FunctionComponent } from 'react'
 import { Pencil, Trash2 } from 'lucide-react'
@@ -78,8 +79,8 @@ const ArticleDataSection: FunctionComponent<ArticleDataSectionProps> = ({
         <span>{dateStr}</span>
       </div>
 
-      <div className="mt-5 border-t border-border pt-5 text-[14px] leading-relaxed text-muted-foreground whitespace-pre-wrap">
-        {data.content}
+      <div className="mt-5 border-t border-border pt-5">
+        <MarkdownContent content={data.content} />
       </div>
     </section>
   )

--- a/src/app/(root)/(routes)/articles/new/components/create-article-form.tsx
+++ b/src/app/(root)/(routes)/articles/new/components/create-article-form.tsx
@@ -7,7 +7,7 @@ import { FunctionComponent } from 'react'
 import { Form } from '@/components/ui/form'
 import { useCreateArticleFormContext } from '../hooks/create-article-form-context'
 import { useCreateArticle } from '../hooks/use-create-article'
-import { ContentInputField } from './content-input-field'
+import { MarkdownEditorField } from './markdown-editor-field'
 import { TitleInputField } from './title-input-field'
 
 const CreateArticleForm: FunctionComponent = () => {
@@ -49,7 +49,7 @@ const CreateArticleForm: FunctionComponent = () => {
     <Form {...form}>
       <form onSubmit={handleSubmit} className="space-y-3">
         <TitleInputField />
-        <ContentInputField />
+        <MarkdownEditorField />
         <button
           type="submit"
           disabled={isCreating}

--- a/src/app/(root)/(routes)/articles/new/components/markdown-editor-field.tsx
+++ b/src/app/(root)/(routes)/articles/new/components/markdown-editor-field.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { FormControl, FormField, FormItem } from '@/components/ui/form'
+import { MarkdownContent } from '@/components/app/markdown-content'
+import { useAppToast } from '@/hooks/use-app-toast'
+import { Bold, Eye, ImagePlus, Italic, List, Pencil } from 'lucide-react'
+import { useRef, useState } from 'react'
+import { useCreateArticleFormContext } from '../hooks/create-article-form-context'
+
+type Mode = 'write' | 'preview'
+
+export function MarkdownEditorField() {
+  const { form } = useCreateArticleFormContext()
+  const { showToast } = useAppToast()
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [mode, setMode] = useState<Mode>('write')
+  const [uploading, setUploading] = useState(false)
+
+  const insertText = (text: string) => {
+    const current = form.getValues('content') ?? ''
+    const target = textareaRef.current
+    const start = target?.selectionStart ?? current.length
+    const end = target?.selectionEnd ?? current.length
+    const next = `${current.slice(0, start)}${text}${current.slice(end)}`
+    form.setValue('content', next, { shouldDirty: true, shouldValidate: true })
+    requestAnimationFrame(() => {
+      target?.focus()
+      target?.setSelectionRange(start + text.length, start + text.length)
+    })
+  }
+
+  const uploadImage = async (file: File) => {
+    const body = new FormData()
+    body.append('file', file)
+    const res = await fetch('/api/article/image', { method: 'POST', body })
+    const data = await res.json().catch(() => null)
+    if (!res.ok || !data?.url) throw new Error('이미지 업로드에 실패했습니다.')
+    insertText(`\n\n![${file.name}](${data.url})\n`)
+  }
+
+  return (
+    <FormField
+      control={form.control}
+      name="content"
+      render={({ field }) => (
+        <FormItem className="w-full">
+          <div className="rounded-md border border-border bg-secondary">
+            <div className="flex items-center gap-1 border-b border-border p-2">
+              <button
+                type="button"
+                title="작성"
+                onClick={() => setMode('write')}
+                className={toolClass(mode === 'write')}
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                title="미리보기"
+                onClick={() => setMode('preview')}
+                className={toolClass(mode === 'preview')}
+              >
+                <Eye className="h-4 w-4" />
+              </button>
+              <span className="mx-1 h-5 w-px bg-border" />
+              <button
+                type="button"
+                title="굵게"
+                onClick={() => insertText('**텍스트**')}
+                className={toolClass(false)}
+              >
+                <Bold className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                title="기울임"
+                onClick={() => insertText('*텍스트*')}
+                className={toolClass(false)}
+              >
+                <Italic className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                title="목록"
+                onClick={() => insertText('\n- 항목')}
+                className={toolClass(false)}
+              >
+                <List className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                title="이미지"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                className={toolClass(false)}
+              >
+                <ImagePlus className="h-4 w-4" />
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={async (event) => {
+                  const file = event.target.files?.[0]
+                  event.target.value = ''
+                  if (!file) return
+                  try {
+                    setUploading(true)
+                    await uploadImage(file)
+                    showToast('이미지를 추가했습니다.')
+                  } catch {
+                    showToast('이미지 업로드에 실패했습니다.')
+                  } finally {
+                    setUploading(false)
+                  }
+                }}
+              />
+            </div>
+            <FormControl>
+              {mode === 'write' ? (
+                <textarea
+                  {...field}
+                  ref={(element) => {
+                    field.ref(element)
+                    textareaRef.current = element
+                  }}
+                  rows={14}
+                  placeholder="내용을 입력해주세요."
+                  className="min-h-[360px] w-full resize-none bg-transparent px-3.5 py-3 text-[14px] text-foreground placeholder:text-muted-foreground focus:outline-none"
+                />
+              ) : (
+                <div className="min-h-[360px] px-3.5 py-3">
+                  <MarkdownContent content={field.value || ''} />
+                </div>
+              )}
+            </FormControl>
+          </div>
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function toolClass(active: boolean) {
+  return `flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50 ${
+    active ? 'bg-background text-foreground' : 'bg-transparent'
+  }`
+}

--- a/src/app/api/article/image/route.ts
+++ b/src/app/api/article/image/route.ts
@@ -1,0 +1,38 @@
+import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NextRequest } from 'next/server'
+
+const base =
+  process.env.SERVER_API ||
+  process.env.NEXT_PUBLIC_SERVER_API ||
+  'http://127.0.0.1:3030'
+
+export const POST = async (req: NextRequest) => {
+  const token = await getTokenFromCookie()
+  if (!token) return new Response(null, { status: 401 })
+
+  const form = await req.formData()
+  const file = form.get('file')
+  if (!(file instanceof File)) {
+    return json({ message: '파일이 없습니다.' }, 400)
+  }
+
+  const body = new FormData()
+  body.append('file', file)
+
+  const res = await fetch(`${base}/article/image`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body,
+    cache: 'no-cache',
+  })
+
+  const data = await res.json().catch(() => null)
+  return json(data ?? {}, res.status)
+}
+
+function json(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/components/app/markdown-content.tsx
+++ b/src/components/app/markdown-content.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+interface MarkdownContentProps {
+  content: string
+}
+
+export function MarkdownContent({ content }: MarkdownContentProps) {
+  return (
+    <div className="space-y-3 break-words text-[14px] leading-relaxed text-muted-foreground">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: ({ children }) => (
+            <h2 className="text-[22px] font-bold text-foreground">
+              {children}
+            </h2>
+          ),
+          h2: ({ children }) => (
+            <h3 className="text-[18px] font-semibold text-foreground">
+              {children}
+            </h3>
+          ),
+          h3: ({ children }) => (
+            <h4 className="text-[16px] font-semibold text-foreground">
+              {children}
+            </h4>
+          ),
+          p: ({ children }) => (
+            <p className="whitespace-pre-wrap">{children}</p>
+          ),
+          a: ({ href, children }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary underline-offset-4 hover:underline"
+            >
+              {children}
+            </a>
+          ),
+          img: ({ src, alt }) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={src ?? ''}
+              alt={alt ?? ''}
+              className="max-h-[520px] w-full rounded-md border border-border object-contain"
+            />
+          ),
+          ul: ({ children }) => (
+            <ul className="list-disc space-y-1 pl-5">{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="list-decimal space-y-1 pl-5">{children}</ol>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-2 border-primary pl-3 text-foreground">
+              {children}
+            </blockquote>
+          ),
+          code: ({ children }) => (
+            <code className="rounded bg-secondary px-1 py-0.5 font-mono text-[12px] text-foreground">
+              {children}
+            </code>
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
커뮤니티 글 작성 화면에 마크다운 에디터와 이미지 삽입 기능을 추가합니다.

## 변경
- `articles/new` 작성 폼을 마크다운 에디터로 교체
- `POST /api/article/image` BFF route 추가
- 업로드 성공 시 `![filename](url)` 마크다운을 현재 커서 위치에 삽입
- 아티클 상세 본문을 `react-markdown` + GFM으로 렌더링

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 모바일 390px에서 `/articles/new` 가로 overflow 없음 확인
- [x] 수정 파일 200줄 상한 확인
- [ ] 백엔드 S3 env 설정 후 이미지 업로드 운영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
