### PR TITLE
🐛 이미지 업로드 인증 토큰 추출 수정

### DIFF
--- a/src/app/api/article/image/route.ts
+++ b/src/app/api/article/image/route.ts
@@ -1,4 +1,4 @@
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { NextRequest } from 'next/server'
 
 const base =
@@ -7,7 +7,7 @@ const base =
   'http://127.0.0.1:3030'
 
 export const POST = async (req: NextRequest) => {
-  const token = await getTokenFromCookie()
+  const token = await getAuthTokenFromRequest(req)
   if (!token) return new Response(null, { status: 401 })
 
   const form = await req.formData()

--- a/src/app/api/profile/image/route.ts
+++ b/src/app/api/profile/image/route.ts
@@ -1,11 +1,13 @@
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { UsersRepository } from '@/modules/users/users-repository'
 import { NextRequest } from 'next/server'
 
 export const POST = async (req: NextRequest) => {
   const form = await req.formData()
   const file = form.get('file') as File
-  const token = await getTokenFromCookie()
+  const token = await getAuthTokenFromRequest(req)
+  if (!token) return new Response(null, { status: 401 })
+
   try {
     const repo = new UsersRepository(token)
     const data = await repo.updateImage({ file })


### PR DESCRIPTION
## Summary
운영에서 아티클 이미지 업로드가 401로 실패하는 문제를 수정합니다.

## 원인
`/api/article/image`가 request 기반 NextAuth JWT 추출을 사용하지 않아, 운영의 secure NextAuth session cookie에서 백엔드 bearer token을 읽지 못했습니다.

## 변경
- 아티클 이미지 업로드 API를 `getAuthTokenFromRequest(req)` 기반으로 변경
- 프로필 이미지 업로드 API도 같은 방식으로 정리

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인
- [ ] 배포 후 로그인 세션에서 아티클 이미지 업로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
