### PR TITLE
🐛 회원가입 자동 로그인 및 공개채팅 모바일 개선

### DIFF
--- a/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
@@ -9,14 +9,49 @@ function createGuestName() {
   return `익명${Math.floor(1000 + Math.random() * 9000)}`
 }
 
-function formatTime(value: string) {
+const MOBILE_CHROME_OFFSET = 126
+
+function formatDateTime(value: string) {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return ''
 
-  return date.toLocaleTimeString('ko-KR', {
+  return date.toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
+    hour12: false,
   })
+}
+
+function useVisibleViewportHeight() {
+  const [height, setHeight] = useState<number | null>(null)
+
+  useEffect(() => {
+    const updateHeight = () => {
+      if (!window.matchMedia('(max-width: 1023px)').matches) {
+        setHeight(null)
+        return
+      }
+
+      const visualHeight = window.visualViewport?.height || window.innerHeight
+      setHeight(Math.round(visualHeight))
+    }
+
+    updateHeight()
+    window.visualViewport?.addEventListener('resize', updateHeight)
+    window.visualViewport?.addEventListener('scroll', updateHeight)
+    window.addEventListener('resize', updateHeight)
+
+    return () => {
+      window.visualViewport?.removeEventListener('resize', updateHeight)
+      window.visualViewport?.removeEventListener('scroll', updateHeight)
+      window.removeEventListener('resize', updateHeight)
+    }
+  }, [])
+
+  return height
 }
 
 export function PublicChatRoom() {
@@ -24,6 +59,7 @@ export function PublicChatRoom() {
   const [input, setInput] = useState('')
   const [guestName, setGuestName] = useState('')
   const bottomRef = useRef<HTMLDivElement>(null)
+  const viewportHeight = useVisibleViewportHeight()
 
   useEffect(() => {
     const stored = window.localStorage.getItem('bollae.public-chat.nickname')
@@ -48,8 +84,15 @@ export function PublicChatRoom() {
     setInput('')
   }
 
+  const mobileHeight = viewportHeight
+    ? `${Math.max(viewportHeight - MOBILE_CHROME_OFFSET, 360)}px`
+    : undefined
+
   return (
-    <div className="flex min-h-[calc(100vh-9rem)] flex-col bg-background text-foreground">
+    <div
+      className="flex min-h-0 flex-col bg-background text-foreground lg:min-h-[calc(100vh-9rem)]"
+      style={mobileHeight ? { height: mobileHeight } : undefined}
+    >
       <div className="border-b border-border px-4 py-3">
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
@@ -87,7 +130,7 @@ export function PublicChatRoom() {
                 <span className="max-w-[8rem] truncate">
                   {message.nickName}
                 </span>
-                <span>{formatTime(message.createdAt)}</span>
+                <span className="shrink-0">{formatDateTime(message.createdAt)}</span>
               </div>
               <p className="whitespace-pre-wrap break-words text-[14px] leading-5">
                 {message.message}

--- a/src/components/form/auth/register/hook/register-form-context.tsx
+++ b/src/components/form/auth/register/hook/register-form-context.tsx
@@ -65,7 +65,7 @@ const useRegisterForm = () => {
 
   const onSubmit = async (
     values: z.infer<typeof formSchema>,
-    onSuccess: () => void,
+    onSuccess: () => void | Promise<void>,
     onError: (error: string) => void,
   ) => {
     try {
@@ -79,7 +79,7 @@ const useRegisterForm = () => {
       })
 
       if (result.success) {
-        onSuccess()
+        await onSuccess()
       } else {
         onError(result.message || '회원가입에 실패했습니다.')
       }

--- a/src/components/form/auth/register/multi-step-register-form.tsx
+++ b/src/components/form/auth/register/multi-step-register-form.tsx
@@ -2,6 +2,7 @@
 
 import { Form } from '@/components/ui/form'
 import { useAppToast } from '@/hooks/use-app-toast'
+import { signIn } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { FunctionComponent, useMemo, useState } from 'react'
 import { useRegister } from './hook/use-register'
@@ -107,10 +108,22 @@ const MultiStepRegisterForm: FunctionComponent = () => {
     const data = form.getValues()
     await onSubmit(
       data,
-      () => {
+      async () => {
         showToast('회원가입이 완료되었습니다!', 3000)
+        const result = await signIn('credentials', {
+          userId: data.userId,
+          password: data.password,
+          redirect: false,
+          callbackUrl: '/',
+        })
+
+        if (result?.error) {
+          router.push('/login')
+          return
+        }
+
         form.reset()
-        setTimeout(() => router.push('/login'), 1200)
+        window.location.href = result?.url || '/'
       },
       (err: string) => showToast(err, 3000),
     )


### PR DESCRIPTION
## Summary
회원가입 완료 후 바로 로그인 세션을 생성하고, 공개채팅 모바일 입력창/날짜 표시 UX를 개선합니다.

## 원인
- 회원가입 성공 후 `/login`으로 이동만 해서 사용자가 다시 로그인해야 했습니다.
- 공개채팅은 고정 viewport 높이만 사용해 실제 모바일 키보드가 올라올 때 입력 영역이 가려질 수 있었습니다.
- 메시지 메타가 시간만 보여 같은 시간대 이전 메시지의 날짜 맥락을 알기 어려웠습니다.

## 변경
- 회원가입 성공 후 NextAuth credentials `signIn`을 호출해 즉시 세션 생성
- 공개채팅 메시지 날짜를 `YYYY. MM. DD. HH:mm` 형태로 표시
- 모바일에서 `visualViewport.height` 기반으로 채팅 영역 높이를 보정

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인
- [x] 로컬 모바일 폭에서 `/chat/public` 입력창 위치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)