### PR TITLE
✨ 계정 회원탈퇴 UI 추가

### DIFF
--- a/src/app/(root)/account/sections/account-section.tsx
+++ b/src/app/(root)/account/sections/account-section.tsx
@@ -1,9 +1,20 @@
 'use client'
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { AppPath } from '@/config/app-path'
 import { signOut } from 'next-auth/react'
 import Link from 'next/link'
-import { FunctionComponent } from 'react'
-import { AppPath } from '@/config/app-path'
+import { FunctionComponent, useState } from 'react'
 
 interface MenuItem {
   label: string
@@ -35,11 +46,31 @@ function MenuRow({ item, isLast }: { item: MenuItem; isLast: boolean }) {
 }
 
 const AccountSection: FunctionComponent = () => {
+  const [isDeleting, setIsDeleting] = useState(false)
   const items: MenuItem[] = [
     { label: '내 매칭', href: '/match/my-matches' },
     { label: '알림 설정', href: AppPath.settings() },
     { label: '로그아웃', onClick: () => signOut({ callbackUrl: '/' }), destructive: true },
   ]
+
+  const handleDeleteAccount = async () => {
+    if (isDeleting) return
+    setIsDeleting(true)
+    try {
+      const res = await fetch('/api/user', {
+        method: 'DELETE',
+      })
+      if (!res.ok) {
+        throw new Error('Failed to delete account')
+      }
+      await signOut({ callbackUrl: '/' })
+    } catch (error) {
+      console.error('Delete account error:', error)
+      setIsDeleting(false)
+      window.alert('회원탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.')
+    }
+  }
+
   return (
     <section>
       <div className="flex items-center border-b border-border px-4 py-3.5">
@@ -52,6 +83,43 @@ const AccountSection: FunctionComponent = () => {
           {items.map((it, i) => (
             <MenuRow key={it.label} item={it} isLast={i === items.length - 1} />
           ))}
+        </div>
+      </div>
+
+      <div className="px-4 pt-4">
+        <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">계정 관리</p>
+        <div className="rounded-lg border border-border bg-card overflow-hidden">
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <button
+                type="button"
+                className="flex w-full items-center px-4 py-3.5 text-left transition-colors hover:bg-accent"
+              >
+                <span className="text-[14px] text-destructive">회원탈퇴</span>
+              </button>
+            </AlertDialogTrigger>
+            <AlertDialogContent className="max-w-[calc(100vw-2rem)] rounded-lg sm:max-w-md">
+              <AlertDialogHeader>
+                <AlertDialogTitle>정말 탈퇴하시겠습니까?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  탈퇴하면 계정이 비활성화되고 다시 로그인할 수 없습니다.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isDeleting}>취소</AlertDialogCancel>
+                <AlertDialogAction
+                  disabled={isDeleting}
+                  onClick={(event) => {
+                    event.preventDefault()
+                    handleDeleteAccount()
+                  }}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                >
+                  {isDeleting ? '탈퇴 처리 중...' : '탈퇴하기'}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
     </section>

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,25 @@
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
+import { UsersRepository } from '@/modules/users/users-repository'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const token = await getAuthTokenFromRequest(req)
+    if (!token) {
+      return NextResponse.json(
+        { success: false, message: '로그인이 필요합니다.' },
+        { status: 401 },
+      )
+    }
+
+    const repo = new UsersRepository(token)
+    const data = await repo.deleteAccount()
+    return NextResponse.json({ success: true, data })
+  } catch (error) {
+    console.error('user DELETE error:', error)
+    return NextResponse.json(
+      { success: false, message: '회원탈퇴에 실패했습니다.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/modules/users/users-datasource.ts
+++ b/src/modules/users/users-datasource.ts
@@ -1,5 +1,10 @@
 import { AppBackEndApiEndpoint } from '@/config/app-backend-api-endpoint'
 
+const serverApi =
+  process.env.SERVER_API ||
+  process.env.NEXT_PUBLIC_SERVER_API ||
+  'http://127.0.0.1:3030'
+
 export class UsersDatasource {
   private token?: string
   constructor(token?: string) {
@@ -110,6 +115,20 @@ export class UsersDatasource {
     const res = await fetch(AppBackEndApiEndpoint.updateProfileImage(), {
       method: 'PATCH',
       body: formData,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+      },
+      cache: 'no-cache',
+    })
+    if (!res.ok) {
+      throw new Error(`[${res.status}] ${res.statusText}`)
+    }
+    return res.json()
+  }
+
+  async deleteAccount() {
+    const res = await fetch(`${serverApi}/user`, {
+      method: 'DELETE',
       headers: {
         Authorization: `Bearer ${this.token}`,
       },

--- a/src/modules/users/users-repository.ts
+++ b/src/modules/users/users-repository.ts
@@ -63,4 +63,8 @@ export class UsersRepository {
   async updateImage({ file }: { file: File }) {
     return await this.datasource.updateImage({ file })
   }
+
+  async deleteAccount() {
+    return await this.datasource.deleteAccount()
+  }
 }


### PR DESCRIPTION
## Summary
계정 화면에서 회원탈퇴를 실행할 수 있는 버튼과 확인 다이얼로그를 추가합니다.

## 원인
`/account` 화면에 회원탈퇴 진입점이 없어 사용자가 계정을 비활성화할 수 없었습니다.

## 변경
- 계정 관리 섹션에 회원탈퇴 버튼 추가
- 확인 다이얼로그에서 `DELETE /api/user` 호출
- BFF 라우트가 NextAuth raw token으로 백엔드 `DELETE /user` 프록시
- 탈퇴 완료 후 `signOut`으로 세션 정리

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)