### PR TITLE
✨ 매치 생성 단계형 UX 개선

### DIFF
--- a/src/app/(root)/(routes)/match/new/page.tsx
+++ b/src/app/(root)/(routes)/match/new/page.tsx
@@ -29,15 +29,8 @@ const Page: FunctionComponent<PageProps> = ({ searchParams }) => {
   const movieTitle = searchParams?.movieTitle?.trim() || undefined
 
   return (
-    <div className="min-h-page bg-background text-foreground">
-      <div className="flex items-center border-b border-border px-4 py-3.5">
-        <h1 className="font-dm-display text-[20px] italic font-bold text-foreground">
-          매치 만들기
-        </h1>
-      </div>
-      <div className="px-5 py-5">
-        <NewMatchContainer movieTitle={movieTitle} />
-      </div>
+    <div className="min-h-page bg-background px-5 py-5 text-foreground">
+      <NewMatchContainer movieTitle={movieTitle} />
     </div>
   )
 }

--- a/src/components/form/match/hooks/match-post-form-context.tsx
+++ b/src/components/form/match/hooks/match-post-form-context.tsx
@@ -6,18 +6,16 @@ import { createContext, useContext } from 'react'
 import * as z from 'zod'
 
 const formSchema = z.object({
-  title: z.string().min(2, {
+  title: z.string().min(1, {
     message: '제목은 최소 2자 이상 입력해주세요.',
   }),
-  content: z.string().min(5, {
+  content: z.string().min(1, {
     message: '내용은 최소 5자 이상 입력해주세요.',
   }),
   movieTitle: z.string().min(1, {
     message: '영화 제목을 입력해주세요.',
   }),
-  theaterName: z.string().min(1, {
-    message: '영화관 이름을 입력해주세요.',
-  }),
+  theaterName: z.string().min(1),
   showTime: z.string().min(1, {
     message: '상영 시간을 선택해주세요.',
   }),
@@ -39,10 +37,10 @@ const useMatchPostForm = () => {
     resolver: zodResolver(formSchema),
     mode: 'onTouched',
     defaultValues: {
-      title: '',
-      content: '',
+      title: '자동 생성',
+      content: '자동 생성',
       movieTitle: '',
-      theaterName: '',
+      theaterName: '상영관 미정',
       showTime: '',
       maxParticipants: 1,
       location: '',

--- a/src/components/form/match/match-post-form-utils.ts
+++ b/src/components/form/match/match-post-form-utils.ts
@@ -1,0 +1,27 @@
+import { CreateMatchPostRequest } from '@/lib/type'
+
+export function buildMatchPayload(
+  data: CreateMatchPostRequest,
+): CreateMatchPostRequest {
+  const movie = data.movieTitle.trim()
+  const place = data.location.trim()
+  const people = data.maxParticipants
+  return {
+    ...data,
+    title: `${movie} 같이 볼 사람 구해요`,
+    content: `${place}에서 ${people}명이 함께 볼 영화 약속입니다.`,
+    theaterName: place,
+  }
+}
+
+export function formatMatchDateTime(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}

--- a/src/components/form/match/match-post-form.tsx
+++ b/src/components/form/match/match-post-form.tsx
@@ -1,16 +1,11 @@
 'use client'
 
 import { Form } from '@/components/ui/form'
-import { FunctionComponent, useState } from 'react'
-import { useMatchPostFormContext } from './hooks/match-post-form-context'
-import { TitleInputField } from './fields/title-input-field'
-import { ContentInputField } from './fields/content-input-field'
-import { MovieTitleInputField } from './fields/movie-title-input-field'
-import { TheaterNameInputField } from './fields/theater-name-input-field'
-import { ShowTimeInputField } from './fields/show-time-input-field'
-import { MaxParticipantsInputField } from './fields/max-participants-input-field'
-import { LocationInputField } from './fields/location-input-field'
 import { CreateMatchPostRequest } from '@/lib/type'
+import { ArrowLeft, ArrowRight, Check } from 'lucide-react'
+import { FunctionComponent, useEffect, useMemo, useState } from 'react'
+import { useMatchPostFormContext } from './hooks/match-post-form-context'
+import { buildMatchPayload, formatMatchDateTime } from './match-post-form-utils'
 
 interface MatchPostFormProps {
   onSubmit: (_data: CreateMatchPostRequest) => Promise<void>
@@ -18,27 +13,60 @@ interface MatchPostFormProps {
   initialData?: Partial<CreateMatchPostRequest>
 }
 
+const steps = [
+  { field: 'movieTitle', label: '영화', title: '어떤 영화를 볼까요?' },
+  { field: 'showTime', label: '일정', title: '언제 볼까요?' },
+  { field: 'location', label: '장소', title: '어디서 만날까요?' },
+  { field: 'maxParticipants', label: '인원', title: '몇 명이 함께 볼까요?' },
+  { field: 'confirm', label: '확인', title: '이대로 매치를 만들까요?' },
+] as const
+
+const inputCls =
+  'w-full rounded-xl border border-border bg-secondary px-4 py-4 text-[18px] font-semibold text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none'
+
 const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
   onSubmit,
   onCancel,
   initialData,
 }) => {
   const { form } = useMatchPostFormContext()
+  const [step, setStep] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
 
-  // initialData가 있을 때 form 값 설정
-  if (initialData) {
+  useEffect(() => {
+    if (!initialData) return
     Object.entries(initialData).forEach(([key, value]) => {
       if (value !== undefined) {
         form.setValue(key as keyof CreateMatchPostRequest, value as any)
       }
     })
+  }, [form, initialData])
+
+  const values = form.watch()
+  const current = steps[step]
+  const isLast = step === steps.length - 1
+  const progress = ((step + 1) / steps.length) * 100
+
+  const summary = useMemo(
+    () => [
+      ['영화', values.movieTitle || '미정'],
+      ['일정', values.showTime ? formatMatchDateTime(values.showTime) : '미정'],
+      ['장소', values.location || '미정'],
+      ['인원', `${values.maxParticipants || 1}명`],
+    ],
+    [values],
+  )
+
+  const goNext = async () => {
+    if (current.field === 'confirm') return
+    const ok = await form.trigger(current.field)
+    if (ok) setStep((prev) => Math.min(prev + 1, steps.length - 1))
   }
 
-  const handleSubmit = form.handleSubmit(async (data) => {
+  const submit = form.handleSubmit(async (data) => {
     setIsLoading(true)
     try {
-      await onSubmit(data)
+      await onSubmit(buildMatchPayload(data))
     } finally {
       setIsLoading(false)
     }
@@ -46,37 +74,117 @@ const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
 
   return (
     <Form {...form}>
-      <form onSubmit={handleSubmit} className="min-w-0 space-y-4 pb-4 lg:pb-0">
-        <TitleInputField />
-        <ContentInputField />
-
-        <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
-          <MovieTitleInputField />
-          <TheaterNameInputField />
+      <form
+        onSubmit={submit}
+        className="mx-auto flex min-h-[calc(100dvh-220px)] max-w-[520px] flex-col"
+      >
+        <div className="mb-8 h-1.5 overflow-hidden rounded-full bg-secondary">
+          <div
+            className="h-full rounded-full bg-primary transition-all"
+            style={{ width: `${progress}%` }}
+          />
         </div>
 
-        <ShowTimeInputField />
-        <MaxParticipantsInputField />
-        <LocationInputField />
+        <p className="mb-3 text-[13px] font-semibold text-primary">
+          {step + 1} / {steps.length} · {current.label}
+        </p>
+        <h2 className="mb-8 text-[28px] font-bold leading-tight text-foreground">
+          {current.title}
+        </h2>
 
-        <div className="sticky bottom-0 z-10 flex gap-2 border-t border-border bg-background/95 py-3 backdrop-blur lg:static lg:border-t-0 lg:bg-transparent lg:py-0 lg:pt-2 lg:backdrop-blur-none">
+        <div className="flex-1">{renderStep(current.field, form, summary)}</div>
+
+        <div className="sticky bottom-0 flex gap-2 border-t border-border bg-background/95 py-3 backdrop-blur">
           <button
             type="button"
-            onClick={onCancel}
-            className="flex-1 border border-border py-3 font-mono text-[13px] text-muted-foreground hover:border-primary hover:text-primary"
+            onClick={step === 0 ? onCancel : () => setStep((prev) => prev - 1)}
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-border text-muted-foreground hover:border-primary hover:text-primary"
+            title={step === 0 ? '취소' : '이전'}
           >
-            취소
+            <ArrowLeft size={20} />
           </button>
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="flex-1 bg-primary py-3 font-mono text-[13px] text-white disabled:bg-secondary disabled:text-muted-foreground"
-          >
-            {isLoading ? '등록 중...' : '등록하기 →'}
-          </button>
+          {isLast ? (
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex h-12 flex-1 items-center justify-center gap-2 rounded-xl bg-primary text-[15px] font-bold text-white disabled:bg-secondary disabled:text-muted-foreground"
+            >
+              {isLoading ? '등록 중...' : '매치 만들기'} <Check size={18} />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={goNext}
+              className="flex h-12 flex-1 items-center justify-center gap-2 rounded-xl bg-primary text-[15px] font-bold text-white"
+            >
+              다음 <ArrowRight size={18} />
+            </button>
+          )}
         </div>
       </form>
     </Form>
+  )
+}
+
+function renderStep(field: (typeof steps)[number]['field'], form: any, summary: string[][]) {
+  if (field === 'confirm') {
+    return (
+      <div className="space-y-3">
+        {summary.map(([label, value]) => (
+          <div
+            key={label}
+            className="flex items-center justify-between rounded-xl bg-secondary px-4 py-4"
+          >
+            <span className="text-[13px] text-muted-foreground">{label}</span>
+            <span className="text-right text-[15px] font-bold text-foreground">{value}</span>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (field === 'maxParticipants') {
+    return (
+      <div className="grid grid-cols-2 gap-3">
+        {[1, 2, 3, 4, 5, 6].map((count) => {
+          const selected = form.watch('maxParticipants') === count
+          return (
+            <button
+              key={count}
+              type="button"
+              onClick={() =>
+                form.setValue('maxParticipants', count, { shouldValidate: true })
+              }
+              className={`rounded-xl border px-4 py-5 text-[18px] font-bold ${
+                selected
+                  ? 'border-primary bg-primary text-white'
+                  : 'border-border bg-secondary text-foreground'
+              }`}
+            >
+              {count}명
+            </button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  const type = field === 'showTime' ? 'datetime-local' : 'text'
+  const placeholder = field === 'movieTitle' ? '영화 제목' : '예: 강남, 홍대, 잠실'
+
+  return (
+    <div>
+      <input
+        type={type}
+        value={form.watch(field) as string}
+        onChange={(event) => form.setValue(field, event.target.value, { shouldValidate: true })}
+        placeholder={placeholder}
+        className={`${inputCls} ${field === 'showTime' ? '[color-scheme:dark]' : ''}`}
+      />
+      <p className="mt-3 text-[13px] text-destructive">
+        {form.formState.errors[field]?.message as string}
+      </p>
+    </div>
   )
 }
 

--- a/src/modules/match/match-post-repository.ts
+++ b/src/modules/match/match-post-repository.ts
@@ -63,11 +63,10 @@ export class MatchPostRepository {
       throw new Error('상영 시간을 입력해주세요.')
     }
 
-    const showTimeDate = new Date(data.showTime + 'T00:00:00')
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-    if (showTimeDate < today) {
-      throw new Error('상영 시간은 오늘 이후여야 합니다.')
+    const showTimeDate = new Date(data.showTime)
+    const now = new Date()
+    if (showTimeDate <= now) {
+      throw new Error('상영 시간은 현재 시간보다 미래여야 합니다.')
     }
 
     if (


### PR DESCRIPTION
## Summary
- /match/new 생성 폼을 한 번에 하나씩 입력하는 단계형 흐름으로 변경
- 사용자 입력에서 영화관/제목/내용을 제거하고 영화, 일정, 장소, 인원만 받도록 단순화
- 기존 API 계약 유지를 위해 제목/내용/theaterName은 제출 시 자동 생성
- 날짜 입력을 시간까지 받는 datetime-local로 변경하고 미래 시간 검증 보정

## Test plan
- [x] pnpm lint
- [x] pnpm build
- [x] 수정 파일 200줄 상한 확인

## Notes
- Chrome headless 모바일 캡처는 당시 Codex 사용량 제한으로 실행하지 못했습니다.