### PR TITLE
🐛 매치 생성 인증 및 영화 추천 개선

### DIFF
--- a/src/app/api/match/route.ts
+++ b/src/app/api/match/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import {
+  getAuthTokenFromRequest,
+  getTokenFromCookie,
+} from '@/lib/utils/getToken'
 import { MatchPostRepository } from '@/modules/match/match-post-repository'
 
 // GET /api/match - match 목록 조회
@@ -33,7 +36,7 @@ export async function GET(request: NextRequest) {
 // POST /api/match - match 생성
 export async function POST(request: NextRequest) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/movie/route.ts
+++ b/src/app/api/movie/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { MovieRepository } from '@/modules/movie/movie-repository'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const pageSize = Number(searchParams.get('pageSize') || '8')
+    const movies = await new MovieRepository().getMovie()
+
+    return NextResponse.json({
+      movies: movies.slice(0, Math.min(Math.max(pageSize, 1), 12)),
+    })
+  } catch (error) {
+    console.error('Movie list API error:', error)
+    return NextResponse.json(
+      { error: '영화 목록을 불러오지 못했습니다.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/form/match/match-post-form.tsx
+++ b/src/components/form/match/match-post-form.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, ArrowRight, Check } from 'lucide-react'
 import { FunctionComponent, useEffect, useMemo, useState } from 'react'
 import { useMatchPostFormContext } from './hooks/match-post-form-context'
 import { buildMatchPayload, formatMatchDateTime } from './match-post-form-utils'
+import { MovieSuggestionChips } from './movie-suggestion-chips'
 
 interface MatchPostFormProps {
   onSubmit: (_data: CreateMatchPostRequest) => Promise<void>
@@ -184,6 +185,14 @@ function renderStep(field: (typeof steps)[number]['field'], form: any, summary: 
       <p className="mt-3 text-[13px] text-destructive">
         {form.formState.errors[field]?.message as string}
       </p>
+      {field === 'movieTitle' && (
+        <MovieSuggestionChips
+          selectedTitle={form.watch('movieTitle') as string}
+          onSelect={(title) =>
+            form.setValue('movieTitle', title, { shouldValidate: true })
+          }
+        />
+      )}
     </div>
   )
 }

--- a/src/components/form/match/movie-suggestion-chips.tsx
+++ b/src/components/form/match/movie-suggestion-chips.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import type { Movie } from '@/modules/movie'
+import { useEffect, useState } from 'react'
+
+interface MovieSuggestionChipsProps {
+  selectedTitle?: string
+  onSelect: (_title: string) => void
+}
+
+export function MovieSuggestionChips({
+  selectedTitle,
+  onSelect,
+}: MovieSuggestionChipsProps) {
+  const [movies, setMovies] = useState<Movie[]>([])
+
+  useEffect(() => {
+    let mounted = true
+    fetch('/api/movie?pageSize=8')
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data) => {
+        if (mounted) setMovies(data?.movies ?? [])
+      })
+      .catch(() => {
+        if (mounted) setMovies([])
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  if (movies.length === 0) return null
+
+  return (
+    <div className="mt-4">
+      <p className="mb-2 text-[13px] font-semibold text-muted-foreground">
+        요즘 많이 보는 영화
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {movies.map((movie) => {
+          const selected = selectedTitle === movie.title
+          return (
+            <button
+              key={movie.id}
+              type="button"
+              onClick={() => onSelect(movie.title)}
+              className={`rounded-2xl rounded-tl-md border px-3 py-2 text-left text-[13px] font-semibold transition ${
+                selected
+                  ? 'border-primary bg-primary text-white'
+                  : 'border-border bg-secondary text-foreground hover:border-primary'
+              }`}
+            >
+              {movie.title}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `/api/match` 생성 요청에서 request 기반 NextAuth 토큰을 사용해 운영 secure cookie 환경의 401을 수정합니다.
- `/match/new` 첫 단계에 최근 상위 영화 추천 말풍선 칩을 추가합니다.
- 추천 칩용 `/api/movie` BFF 라우트를 추가합니다.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with Codex