### PR TITLE
✨ 매칭 작성자 관리 기능 추가

### DIFF
--- a/src/app/(root)/(routes)/match/[id]/components/match-author-view.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-author-view.tsx
@@ -1,19 +1,22 @@
 'use client'
 
 import { DmMatchDetailCard } from '@/components/dm'
-import { MatchApplication, MatchPost } from '@/lib/type'
+import { CreateMatchPostRequest, MatchApplication, MatchPost } from '@/lib/type'
 import { useRouter } from 'next/navigation'
-import { FunctionComponent } from 'react'
+import { FunctionComponent, useState } from 'react'
+import { MatchFormSection } from '../../sections/match-form-section'
 import { MatchApplicationRow } from './match-application-row'
 
 interface MatchAuthorViewProps {
   matchPost: MatchPost
   applications: MatchApplication[]
   isDeleting: boolean
+  isUpdating: boolean
+  onUpdate: (_data: CreateMatchPostRequest) => Promise<void>
   onDelete: () => Promise<void>
   onApplicationStatusChange: (
-    applicationId: string,
-    status: 'accepted' | 'rejected',
+    _applicationId: string,
+    _status: 'accepted' | 'rejected',
   ) => Promise<void>
   mutateApplications: () => void
 }
@@ -22,14 +25,32 @@ const MatchAuthorView: FunctionComponent<MatchAuthorViewProps> = ({
   matchPost,
   applications,
   isDeleting,
+  isUpdating,
+  onUpdate,
   onDelete,
   onApplicationStatusChange,
 }) => {
   const router = useRouter()
+  const [isEditing, setIsEditing] = useState(false)
 
   const handleDelete = async () => {
     if (!window.confirm('정말로 이 매치를 삭제하시겠습니까?')) return
     await onDelete()
+  }
+
+  const handleUpdate = async (data: CreateMatchPostRequest) => {
+    await onUpdate(data)
+    setIsEditing(false)
+  }
+
+  const initialData = {
+    title: matchPost.title,
+    content: matchPost.content,
+    movieTitle: matchPost.movieTitle,
+    theaterName: matchPost.theaterName,
+    showTime: toDatetimeLocalValue(matchPost.showTime),
+    maxParticipants: matchPost.maxParticipants,
+    location: matchPost.location,
   }
 
   return (
@@ -45,15 +66,32 @@ const MatchAuthorView: FunctionComponent<MatchAuthorViewProps> = ({
           HOST VIEW
         </span>
         <button
+          onClick={() => setIsEditing((prev) => !prev)}
+          disabled={isUpdating}
+          className="ml-auto border border-border px-2.5 py-1 font-mono text-[11px] text-muted-foreground hover:border-primary hover:text-primary disabled:opacity-50"
+        >
+          {isEditing ? '닫기' : '수정'}
+        </button>
+        <button
           onClick={handleDelete}
           disabled={isDeleting}
-          className="ml-auto border border-primary/50 px-2.5 py-1 font-mono text-[11px] text-primary hover:bg-primary/10 disabled:opacity-50"
+          className="border border-primary/50 px-2.5 py-1 font-mono text-[11px] text-primary hover:bg-primary/10 disabled:opacity-50"
         >
           {isDeleting ? '삭제 중...' : '삭제'}
         </button>
       </div>
 
-      <DmMatchDetailCard match={matchPost} />
+      {isEditing ? (
+        <div className="px-4 py-5">
+          <MatchFormSection
+            initialData={initialData}
+            onSubmit={handleUpdate}
+            onCancel={() => setIsEditing(false)}
+          />
+        </div>
+      ) : (
+        <DmMatchDetailCard match={matchPost} />
+      )}
 
       <div className="mt-4 border-t border-border">
         <div className="flex items-center justify-between px-5 py-3.5">
@@ -87,6 +125,13 @@ const MatchAuthorView: FunctionComponent<MatchAuthorViewProps> = ({
       </div>
     </div>
   )
+}
+
+function toDatetimeLocalValue(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  const offset = date.getTimezoneOffset() * 60000
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16)
 }
 
 export { MatchAuthorView }

--- a/src/app/(root)/(routes)/match/[id]/components/match-detail-container.tsx
+++ b/src/app/(root)/(routes)/match/[id]/components/match-detail-container.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useAppToast } from '@/hooks/use-app-toast'
+import { CreateMatchPostRequest } from '@/lib/type'
 import { useSession } from 'next-auth/react'
 import { useParams, useRouter } from 'next/navigation'
 import {
@@ -8,6 +9,7 @@ import {
   useDeleteMatch,
   useMatchApplications,
   useMatchPost,
+  useUpdateMatch,
 } from '../../hooks'
 import { MatchAuthorView } from './match-author-view'
 import { MatchViewerView } from './match-viewer-view'
@@ -19,10 +21,18 @@ const MatchDetailContainer = () => {
   const { showToast } = useAppToast()
   const matchId = params?.id as string
 
-  const { matchPost, isLoading: isMatchLoading, error: matchError } = useMatchPost(matchId)
+  const {
+    matchPost,
+    isLoading: isMatchLoading,
+    error: matchError,
+    mutate: mutateMatch,
+  } = useMatchPost(matchId)
   const { applyToMatch } = useApplyMatch(matchId)
   const { deleteMatch, isDeleting } = useDeleteMatch(matchId)
-  const isAuthor = matchPost?.userno === session?.user?.id
+  const { updateMatch, isUpdating } = useUpdateMatch(matchId)
+  const sessionUserId = session?.user?.id ? Number(session.user.id) : null
+  const isAuthor =
+    !!matchPost && !!sessionUserId && matchPost.userno === sessionUserId
   const { applications, mutate: mutateApplications } = useMatchApplications(
     isAuthor ? matchId : '',
   )
@@ -71,6 +81,17 @@ const MatchDetailContainer = () => {
     }
   }
 
+  const handleUpdate = async (data: CreateMatchPostRequest) => {
+    try {
+      await updateMatch(data)
+      await mutateMatch()
+      showToast('매치가 수정되었습니다.')
+    } catch {
+      showToast('매치 수정에 실패했습니다.')
+      throw new Error('Failed to update match')
+    }
+  }
+
   if (status === 'loading' || isMatchLoading)
     return (
       <div className="flex min-h-page items-center justify-center bg-background font-mono text-[12px] text-muted-foreground">
@@ -98,6 +119,8 @@ const MatchDetailContainer = () => {
         matchPost={matchPost}
         applications={applications}
         isDeleting={isDeleting}
+        isUpdating={isUpdating}
+        onUpdate={handleUpdate}
         onDelete={handleDelete}
         onApplicationStatusChange={handleApplicationStatus}
         mutateApplications={mutateApplications}

--- a/src/app/api/match/[id]/applications/[applicationId]/route.ts
+++ b/src/app/api/match/[id]/applications/[applicationId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MatchApplicationRepository } from '@/modules/match/match-application-repository'
 
 // PUT /api/match/[id]/applications/[applicationId] - 신청 상태 변경 (승인/거절)
@@ -8,7 +8,7 @@ export async function PUT(
   { params }: { params: { id: string; applicationId: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/match/[id]/applications/route.ts
+++ b/src/app/api/match/[id]/applications/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MatchApplicationRepository } from '@/modules/match/match-application-repository'
 
 // GET /api/match/[id]/applications - match 신청 목록 조회
@@ -8,7 +8,7 @@ export async function GET(
   { params }: { params: { id: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/match/[id]/apply/route.ts
+++ b/src/app/api/match/[id]/apply/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MatchApplicationRepository } from '@/modules/match/match-application-repository'
 
 // POST /api/match/[id]/apply - match 신청
@@ -8,7 +8,7 @@ export async function POST(
   { params }: { params: { id: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/match/[id]/my-application/route.ts
+++ b/src/app/api/match/[id]/my-application/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MatchApplicationRepository } from '@/modules/match/match-application-repository'
 
 // GET /api/match/[id]/my-application - 내 신청 상태 조회
@@ -8,7 +8,7 @@ export async function GET(
   { params }: { params: { id: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/match/[id]/route.ts
+++ b/src/app/api/match/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import {
+  getAuthTokenFromRequest,
+} from '@/lib/utils/getToken'
 import { MatchPostRepository } from '@/modules/match/match-post-repository'
 
 // GET /api/match/[id] - match 상세 조회
@@ -9,7 +11,7 @@ export async function GET(
 ) {
   try {
     const { id } = params
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     const matchRepository = new MatchPostRepository(token)
 
     const data = await matchRepository.getMatchPost(id)
@@ -29,7 +31,7 @@ export async function PUT(
   { params }: { params: { id: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
@@ -55,7 +57,7 @@ export async function DELETE(
   { params }: { params: { id: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/match/applications/[applicationId]/route.ts
+++ b/src/app/api/match/applications/[applicationId]/route.ts
@@ -1,13 +1,13 @@
-import { NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MatchApplicationRepository } from '@/modules/match/match-application-repository'
 
 export async function DELETE(
-  _request: Request,
+  request: NextRequest,
   { params }: { params: { applicationId: string } },
 ) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/match/my-applications/route.ts
+++ b/src/app/api/match/my-applications/route.ts
@@ -1,10 +1,12 @@
-import { NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MatchApplicationRepository } from '@/modules/match/match-application-repository'
 
-export async function GET() {
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/app/api/match/my-posts/route.ts
+++ b/src/app/api/match/my-posts/route.ts
@@ -1,10 +1,12 @@
-import { NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MatchPostRepository } from '@/modules/match/match-post-repository'
 
-export async function GET() {
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
   try {
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }

--- a/src/modules/match/match-post-repository.ts
+++ b/src/modules/match/match-post-repository.ts
@@ -117,9 +117,9 @@ export class MatchPostRepository {
 
     if (
       data.maxParticipants !== undefined &&
-      (data.maxParticipants < 2 || data.maxParticipants > 10)
+      (data.maxParticipants < 1 || data.maxParticipants > 10)
     ) {
-      throw new Error('최대 인원은 2-10명 사이여야 합니다.')
+      throw new Error('최대 인원은 1-10명 사이여야 합니다.')
     }
 
     return await this.dataSource.updateMatchPost(matchId, data)


### PR DESCRIPTION
## Summary
- 매칭 상세에서 작성자 판정을 숫자 비교로 보정해 본인 매칭이면 작성자 관리 화면을 보여줍니다.
- 작성자 화면에 매칭 수정 폼과 삭제 액션을 제공합니다.
- 매칭 신청 목록/승인/신청/수정/삭제 API route에서 request 기반 NextAuth 토큰 추출을 사용하도록 보강합니다.
- 내 매칭/내 신청 API route를 dynamic으로 명시합니다.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with Codex