### PR TITLE
🐛 공개채팅 모바일 레이아웃 안정화

### DIFF
--- a/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
@@ -23,49 +23,11 @@ function formatDateTime(value: string) {
   })
 }
 
-function useMobileViewport() {
-  const [viewport, setViewport] = useState<{
-    height: number
-    top: number
-  } | null>(null)
-
-  useEffect(() => {
-    const updateViewport = () => {
-      if (!window.matchMedia('(max-width: 1023px)').matches) {
-        setViewport(null)
-        return
-      }
-
-      const visual = window.visualViewport
-      setViewport({
-        height: Math.round(visual?.height || window.innerHeight),
-        top: Math.round(visual?.offsetTop || 0),
-      })
-    }
-
-    updateViewport()
-    window.visualViewport?.addEventListener('resize', updateViewport)
-    window.visualViewport?.addEventListener('scroll', updateViewport)
-    window.addEventListener('resize', updateViewport)
-    window.addEventListener('orientationchange', updateViewport)
-
-    return () => {
-      window.visualViewport?.removeEventListener('resize', updateViewport)
-      window.visualViewport?.removeEventListener('scroll', updateViewport)
-      window.removeEventListener('resize', updateViewport)
-      window.removeEventListener('orientationchange', updateViewport)
-    }
-  }, [])
-
-  return viewport
-}
-
 export function PublicChatRoom() {
   const { data: session } = useSession()
   const [input, setInput] = useState('')
   const [guestName, setGuestName] = useState('')
   const bottomRef = useRef<HTMLDivElement>(null)
-  const viewport = useMobileViewport()
 
   useEffect(() => {
     const stored = window.localStorage.getItem('bollae.public-chat.nickname')
@@ -85,7 +47,6 @@ export function PublicChatRoom() {
   }
 
   useEffect(scrollToBottom, [messages])
-  useEffect(scrollToBottom, [viewport])
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -93,18 +54,8 @@ export function PublicChatRoom() {
     setInput('')
   }
 
-  const mobileStyle = viewport
-    ? {
-        height: `${viewport.height}px`,
-        top: `${viewport.top}px`,
-      }
-    : undefined
-
   return (
-    <div
-      className="fixed left-1/2 z-50 flex h-[100dvh] w-full max-w-[460px] -translate-x-1/2 flex-col bg-background text-foreground lg:static lg:min-h-[calc(100vh-9rem)] lg:max-w-none lg:translate-x-0"
-      style={mobileStyle}
-    >
+    <div className="flex h-[calc(100dvh-8rem-env(safe-area-inset-bottom))] min-h-[22rem] w-full flex-col overflow-hidden bg-background text-foreground lg:min-h-[calc(100vh-9rem)]">
       <div className="border-b border-border px-4 py-3">
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
@@ -155,7 +106,7 @@ export function PublicChatRoom() {
 
       <form
         onSubmit={handleSubmit}
-        className="sticky bottom-0 flex gap-2 border-t border-border bg-background/95 p-3 backdrop-blur"
+        className="flex shrink-0 gap-2 border-t border-border bg-background/95 p-3 backdrop-blur"
       >
         <input
           value={input}

--- a/src/components/dm/dm-app-footer.tsx
+++ b/src/components/dm/dm-app-footer.tsx
@@ -1,10 +1,16 @@
+'use client'
+
 import { Mail } from 'lucide-react'
+import { usePathname } from 'next/navigation'
 
 interface DmAppFooterProps {
   className?: string
 }
 
 export function DmAppFooter({ className }: DmAppFooterProps) {
+  const pathname = usePathname()
+  if (pathname === '/chat/public') return null
+
   return (
     <footer
       className={`mt-10 border-t border-border bg-background-deep px-6 py-8 text-muted-foreground ${className ?? ''}`}


### PR DESCRIPTION
## Summary
- `/chat/public`에서 모바일 fixed overlay와 visualViewport 실시간 보정을 제거해 UI 흔들림을 줄입니다.
- 공개채팅 화면을 앱바와 하단 탭 사이의 일반 레이아웃 안에 배치해 하단 메뉴가 보이도록 수정합니다.
- 공개채팅에서는 일반 앱 푸터를 숨겨 입력창과 하단 메뉴 사이에 푸터가 끼지 않도록 합니다.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 모바일 viewport 390x844 로컬 확인: 하단 탭 표시, 입력창과 하단 탭 미겹침, footer 없음
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with Codex