### PR TITLE
💄 공개채팅 아바타와 접속자 수 표시

### DIFF
--- a/src/app/(root)/(routes)/chat/public/components/public-chat-avatar.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-avatar.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { UserRound } from 'lucide-react'
+
+interface PublicChatAvatarProps {
+  image?: string
+  nickName: string
+  disabled?: boolean
+  onClick: () => void
+}
+
+export function PublicChatAvatar({
+  image,
+  nickName,
+  disabled,
+  onClick,
+}: PublicChatAvatarProps) {
+  const initial = nickName.trim().charAt(0).toUpperCase()
+
+  return (
+    <button
+      type="button"
+      aria-label={`${nickName}에게 1:1 채팅 보내기`}
+      disabled={disabled}
+      onClick={onClick}
+      className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-background text-[13px] font-semibold text-muted-foreground disabled:cursor-default disabled:opacity-70"
+    >
+      {image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={image} alt="" className="h-full w-full object-cover" />
+      ) : initial ? (
+        initial
+      ) : (
+        <UserRound className="h-4 w-4" />
+      )}
+    </button>
+  )
+}

--- a/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
@@ -3,6 +3,10 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { Send } from 'lucide-react'
 import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useAppToast } from '@/hooks/use-app-toast'
+import { PublicChatAvatar } from './public-chat-avatar'
+import type { PublicChatMessage } from '../hooks/use-public-chat-socket'
 import { usePublicChatSocket } from '../hooks/use-public-chat-socket'
 
 function createGuestName() {
@@ -21,6 +25,8 @@ function formatTime(value: string) {
 
 export function PublicChatRoom() {
   const { data: session } = useSession()
+  const router = useRouter()
+  const { showToast } = useAppToast()
   const [input, setInput] = useState('')
   const [guestName, setGuestName] = useState('')
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -36,7 +42,13 @@ export function PublicChatRoom() {
     () => session?.user?.nickname || session?.user?.name || guestName || '익명',
     [guestName, session?.user?.name, session?.user?.nickname],
   )
-  const { isConnected, messages, sendMessage } = usePublicChatSocket(nickName)
+  const currentUserId = session?.user?.id ? Number(session.user.id) : undefined
+  const { isConnected, messages, onlineCount, sendMessage } =
+    usePublicChatSocket({
+      nickName,
+      userId: currentUserId,
+      image: session?.user?.image,
+    })
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ block: 'end' })
@@ -46,6 +58,32 @@ export function PublicChatRoom() {
     event.preventDefault()
     sendMessage(input)
     setInput('')
+  }
+
+  const startDirectChat = async (message: PublicChatMessage) => {
+    if (!currentUserId) {
+      router.push('/login?callbackUrl=/chat/public')
+      return
+    }
+    if (!message.userId || message.userId === currentUserId) return
+
+    try {
+      const response = await fetch('/api/chat/direct', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          currentUserId,
+          targetUserId: message.userId,
+          targetUserName: message.nickName,
+        }),
+      })
+      const data = await response.json()
+      const chatRoomId = data?.chatRoom?.chatRoomId
+      if (!response.ok || !chatRoomId) throw new Error()
+      router.push(`/chat/${chatRoomId}`)
+    } catch {
+      showToast('1:1 채팅방을 열지 못했어요.')
+    }
   }
 
   return (
@@ -59,7 +97,7 @@ export function PublicChatRoom() {
             </p>
           </div>
           <span className="shrink-0 rounded-full border border-border px-3 py-1 text-[11px] text-muted-foreground">
-            {isConnected ? '접속 중' : '연결 중'}
+            {isConnected ? `${onlineCount}명 접속 중` : '연결 중'}
           </span>
         </div>
       </div>
@@ -74,8 +112,16 @@ export function PublicChatRoom() {
         {messages.map((message) => (
           <div
             key={message.id}
-            className={`flex ${message.mine ? 'justify-end' : 'justify-start'}`}
+            className={`flex items-start gap-2 ${message.mine ? 'justify-end' : 'justify-start'}`}
           >
+            {!message.mine && (
+              <PublicChatAvatar
+                image={message.image}
+                nickName={message.nickName}
+                disabled={!message.userId}
+                onClick={() => startDirectChat(message)}
+              />
+            )}
             <div
               className={`max-w-[82%] rounded-md border px-3 py-2 ${
                 message.mine

--- a/src/app/(root)/(routes)/chat/public/hooks/use-public-chat-socket.ts
+++ b/src/app/(root)/(routes)/chat/public/hooks/use-public-chat-socket.ts
@@ -5,7 +5,9 @@ import { io, Socket } from 'socket.io-client'
 
 export interface PublicChatMessage {
   id: string
+  userId?: number
   nickName: string
+  image?: string
   message: string
   createdAt: string
   mine?: boolean
@@ -14,11 +16,19 @@ export interface PublicChatMessage {
 interface ServerPublicChatMessage {
   id?: string
   clientId?: string
+  userId?: number
   nickName?: string
   nickname?: string
+  image?: string
   message?: string
   content?: string
   createdAt?: string
+}
+
+interface PublicChatUser {
+  nickName: string
+  userId?: number
+  image?: string
 }
 
 const PUBLIC_CHAT_CLIENT_ID_KEY = 'bollae-public-chat-client-id'
@@ -51,18 +61,21 @@ function normalizeMessage(
 
   return {
     id: data.id || data.clientId || createMessageId(),
+    userId: data.userId,
     nickName: data.nickName || data.nickname || '익명',
+    image: data.image,
     message,
     createdAt: data.createdAt || new Date().toISOString(),
     mine,
   }
 }
 
-export function usePublicChatSocket(nickName: string) {
+export function usePublicChatSocket(user: PublicChatUser) {
   const socketRef = useRef<Socket | null>(null)
   const clientIdRef = useRef<string | null>(null)
   const [messages, setMessages] = useState<PublicChatMessage[]>([])
   const [isConnected, setIsConnected] = useState(false)
+  const [onlineCount, setOnlineCount] = useState(0)
 
   useEffect(() => {
     const clientId = getPublicChatClientId()
@@ -77,7 +90,13 @@ export function usePublicChatSocket(nickName: string) {
 
     socketRef.current = socket
     socket.on('connect', () => setIsConnected(true))
-    socket.on('disconnect', () => setIsConnected(false))
+    socket.on('disconnect', () => {
+      setIsConnected(false)
+      setOnlineCount(0)
+    })
+    socket.on('onlineCount', (count: number) => {
+      setOnlineCount(Number.isFinite(Number(count)) ? Number(count) : 0)
+    })
     socket.on('history', (history: ServerPublicChatMessage[]) => {
       const nextMessages = history
         .map((message) =>
@@ -102,6 +121,7 @@ export function usePublicChatSocket(nickName: string) {
       socket.disconnect()
       socketRef.current = null
       setIsConnected(false)
+      setOnlineCount(0)
     }
   }, [])
 
@@ -112,13 +132,15 @@ export function usePublicChatSocket(nickName: string) {
 
       socketRef.current.emit('message', {
         clientId: clientIdRef.current || getPublicChatClientId(),
-        nickName: nickName.trim() || '익명',
+        userId: user.userId,
+        nickName: user.nickName.trim() || '익명',
+        image: user.image,
         message: content,
         createdAt: new Date().toISOString(),
       })
     },
-    [nickName],
+    [user.image, user.nickName, user.userId],
   )
 
-  return { isConnected, messages, sendMessage }
+  return { isConnected, messages, onlineCount, sendMessage }
 }


### PR DESCRIPTION
## Summary
공개채팅에서 상대방 아바타를 표시하고, 아바타 클릭 시 1:1 채팅방으로 이동할 수 있게 했습니다. 상단 배지는 접속 상태 문구 대신 공개채팅 접속자 수를 보여줍니다.

## 원인
공개채팅이 단순 텍스트 목록이라 상대 사용자를 식별하거나 바로 1:1 대화로 이어가기 어려웠습니다.

## 변경
- 공개채팅 메시지 타입에 userId/image/onlineCount 반영
- 내 메시지는 아바타를 숨기고 상대 메시지에만 아바타 표시
- 상대 아바타 클릭 시 /api/chat/direct 호출 후 채팅방 이동
- 상단 배지를 N명 접속 중으로 변경

## Test plan
- [x] pnpm lint
- [x] pnpm build
- [x] 모바일 390px 로컬 화면 확인: 가로 overflow 없음
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)