### PR TITLE
✨ 공개채팅 프로필 메뉴와 프로필 화면 추가

### DIFF
--- a/src/app/(root)/(routes)/chat/public/components/public-chat-avatar.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-avatar.tsx
@@ -5,14 +5,12 @@ import { UserRound } from 'lucide-react'
 interface PublicChatAvatarProps {
   image?: string
   nickName: string
-  disabled?: boolean
   onClick?: () => void
 }
 
 export function PublicChatAvatar({
   image,
   nickName,
-  disabled,
   onClick,
 }: PublicChatAvatarProps) {
   const initial = nickName.trim().charAt(0).toUpperCase()
@@ -21,9 +19,8 @@ export function PublicChatAvatar({
     <button
       type="button"
       aria-label={`${nickName} 프로필 메뉴 열기`}
-      disabled={disabled}
       onClick={onClick}
-      className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-background text-[13px] font-semibold text-muted-foreground disabled:cursor-default disabled:opacity-70"
+      className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-background text-[13px] font-semibold text-muted-foreground"
     >
       {image ? (
         // eslint-disable-next-line @next/next/no-img-element

--- a/src/app/(root)/(routes)/chat/public/components/public-chat-profile-menu.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-profile-menu.tsx
@@ -12,7 +12,8 @@ import { PublicChatAvatar } from './public-chat-avatar'
 interface PublicChatProfileMenuProps {
   image?: string
   nickName: string
-  disabled?: boolean
+  canOpenDirectChat: boolean
+  canViewProfile: boolean
   onDirectChat: () => void
   onProfileView: () => void
 }
@@ -20,7 +21,8 @@ interface PublicChatProfileMenuProps {
 export function PublicChatProfileMenu({
   image,
   nickName,
-  disabled,
+  canOpenDirectChat,
+  canViewProfile,
   onDirectChat,
   onProfileView,
 }: PublicChatProfileMenuProps) {
@@ -42,7 +44,6 @@ export function PublicChatProfileMenu({
         <PublicChatAvatar
           image={image}
           nickName={nickName}
-          disabled={disabled}
         />
       </PopoverTrigger>
       <PopoverContent
@@ -57,7 +58,8 @@ export function PublicChatProfileMenu({
         <button
           type="button"
           onClick={handleDirectChat}
-          className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-[13px] hover:bg-secondary"
+          disabled={!canOpenDirectChat}
+          className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-[13px] hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-45"
         >
           <MessageCircle className="h-4 w-4" />
           1:1 채팅하기
@@ -65,7 +67,8 @@ export function PublicChatProfileMenu({
         <button
           type="button"
           onClick={handleProfileView}
-          className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-[13px] hover:bg-secondary"
+          disabled={!canViewProfile}
+          className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-[13px] hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-45"
         >
           <UserRound className="h-4 w-4" />
           프로필 보기

--- a/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
@@ -67,11 +67,15 @@ export function PublicChatRoom() {
   }
 
   const startDirectChat = async (message: PublicChatMessage) => {
+    if (!message.userId) {
+      showToast('회원 프로필이 있는 메시지만 1:1 채팅을 열 수 있어요.')
+      return
+    }
     if (!currentUserId) {
       router.push('/login?callbackUrl=/chat/public')
       return
     }
-    if (!message.userId || message.userId === currentUserId) return
+    if (message.userId === currentUserId) return
 
     try {
       const response = await fetch('/api/chat/direct', {
@@ -93,7 +97,11 @@ export function PublicChatRoom() {
   }
 
   const showProfile = (message: PublicChatMessage) => {
-    showToast(`${message.nickName} 프로필`)
+    if (!message.userId) {
+      showToast('회원 프로필이 없는 메시지예요.')
+      return
+    }
+    router.push(`/profile/${message.userId}`)
   }
 
   return (
@@ -128,7 +136,8 @@ export function PublicChatRoom() {
               <PublicChatProfileMenu
                 image={message.image}
                 nickName={message.nickName}
-                disabled={!message.userId}
+                canOpenDirectChat={Boolean(message.userId)}
+                canViewProfile={Boolean(message.userId)}
                 onDirectChat={() => startDirectChat(message)}
                 onProfileView={() => showProfile(message)}
               />

--- a/src/app/(root)/(routes)/profile/[id]/page.tsx
+++ b/src/app/(root)/(routes)/profile/[id]/page.tsx
@@ -1,0 +1,61 @@
+import { UserRound } from 'lucide-react'
+import { notFound } from 'next/navigation'
+import { UsersRepository } from '@/modules/users/users-repository'
+
+interface ProfilePageProps {
+  params: { id: string }
+}
+
+interface PublicProfile {
+  id: number
+  nickname: string
+  image?: string
+}
+
+async function getProfile(id: string): Promise<PublicProfile | null> {
+  const userId = Number(id)
+  if (!Number.isInteger(userId) || userId <= 0) return null
+
+  try {
+    const user = await new UsersRepository().getUser(userId)
+    return {
+      id: user.id,
+      nickname: user.nickname,
+      image: user.image,
+    }
+  } catch {
+    return null
+  }
+}
+
+export default async function ProfilePage({ params }: ProfilePageProps) {
+  const profile = await getProfile(params.id)
+  if (!profile) notFound()
+
+  const initial = profile.nickname.trim().charAt(0).toUpperCase()
+
+  return (
+    <main className="mx-auto flex min-h-[calc(100dvh-10rem)] w-full max-w-[42rem] flex-col px-5 py-8">
+      <section className="flex flex-1 flex-col items-center justify-center text-center">
+        <div className="flex h-28 w-28 items-center justify-center overflow-hidden rounded-full border border-border bg-secondary text-3xl font-bold text-muted-foreground">
+          {profile.image ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={profile.image}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : initial ? (
+            initial
+          ) : (
+            <UserRound className="h-10 w-10" />
+          )}
+        </div>
+        <h1 className="mt-5 text-2xl font-bold">{profile.nickname}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          볼래에서 같이 영화 볼 사람을 찾고 있어요.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/src/app/api/user/[id]/route.ts
+++ b/src/app/api/user/[id]/route.ts
@@ -1,0 +1,34 @@
+import { UsersRepository } from '@/modules/users/users-repository'
+import { NextRequest, NextResponse } from 'next/server'
+
+interface RouteParams {
+  params: { id: string }
+}
+
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const userId = Number(params.id)
+    if (!Number.isInteger(userId) || userId <= 0) {
+      return NextResponse.json(
+        { success: false, message: '사용자 정보가 올바르지 않습니다.' },
+        { status: 400 },
+      )
+    }
+
+    const user = await new UsersRepository().getUser(userId)
+    return NextResponse.json({
+      success: true,
+      data: {
+        id: user.id,
+        nickname: user.nickname,
+        image: user.image,
+      },
+    })
+  } catch (error) {
+    console.error('user GET error:', error)
+    return NextResponse.json(
+      { success: false, message: '프로필을 불러오지 못했습니다.' },
+      { status: 404 },
+    )
+  }
+}

--- a/src/modules/users/users-datasource.ts
+++ b/src/modules/users/users-datasource.ts
@@ -126,6 +126,16 @@ export class UsersDatasource {
     return res.json()
   }
 
+  async getUser(id: number) {
+    const res = await fetch(`${serverApi}/user/${id}`, {
+      cache: 'no-cache',
+    })
+    if (!res.ok) {
+      throw new Error(`[${res.status}] ${res.statusText}`)
+    }
+    return res.json()
+  }
+
   async deleteAccount() {
     const res = await fetch(`${serverApi}/user`, {
       method: 'DELETE',

--- a/src/modules/users/users-repository.ts
+++ b/src/modules/users/users-repository.ts
@@ -64,6 +64,11 @@ export class UsersRepository {
     return await this.datasource.updateImage({ file })
   }
 
+  async getUser(id: number) {
+    const result = await this.datasource.getUser(id)
+    return this.convertToUserEntity(result)
+  }
+
   async deleteAccount() {
     return await this.datasource.deleteAccount()
   }


### PR DESCRIPTION
## Summary
공개채팅 아바타 클릭 메뉴와 공개 프로필 화면을 추가합니다.

## 원인
userId가 없는 메시지의 아바타 버튼이 disabled 처리되어 클릭해도 아무 반응이 없어 보였습니다.

## 변경
- 공개채팅 아바타는 항상 메뉴를 열도록 수정
- 메뉴에 1:1 채팅하기, 프로필 보기 버튼 제공
- 프로필 보기 라우트 /profile/:id 추가
- 사용자 공개 조회 API 프록시 /api/user/:id 추가

## Test plan
- [x] pnpm lint 통과
- [x] pnpm build 1회 통과
- [x] 수정 파일 200줄 상한 확인
- [ ] 두 번째 build는 worktree symlink 의존성 문제로 실패. 코드 빌드는 최초 통과 결과 기준

Generated with Claude Code