### PR TITLE
🐛 공개채팅 아바타 메뉴를 ContextMenu로 변경

### DIFF
--- a/src/app/(root)/(routes)/chat/public/components/public-chat-profile-menu.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-profile-menu.tsx
@@ -3,10 +3,13 @@
 import { useState } from 'react'
 import { MessageCircle, UserRound } from 'lucide-react'
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { PublicChatAvatar } from './public-chat-avatar'
 
 interface PublicChatProfileMenuProps {
@@ -39,41 +42,38 @@ export function PublicChatProfileMenu({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
+    <ContextMenu open={open} onOpenChange={setOpen}>
+      <ContextMenuTrigger asChild>
         <PublicChatAvatar
           image={image}
           nickName={nickName}
         />
-      </PopoverTrigger>
-      <PopoverContent
+      </ContextMenuTrigger>
+      <ContextMenuContent
         side="right"
         align="start"
-        className="w-44 p-2"
+        className="w-44"
         sideOffset={8}
       >
-        <div className="mb-1 truncate px-2 py-1 text-[12px] font-semibold">
+        <ContextMenuLabel className="truncate text-[12px]">
           {nickName}
-        </div>
-        <button
-          type="button"
-          onClick={handleDirectChat}
+        </ContextMenuLabel>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          onSelect={handleDirectChat}
           disabled={!canOpenDirectChat}
-          className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-[13px] hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-45"
         >
-          <MessageCircle className="h-4 w-4" />
+          <MessageCircle className="mr-2 h-4 w-4" />
           1:1 채팅하기
-        </button>
-        <button
-          type="button"
-          onClick={handleProfileView}
+        </ContextMenuItem>
+        <ContextMenuItem
+          onSelect={handleProfileView}
           disabled={!canViewProfile}
-          className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-[13px] hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-45"
         >
-          <UserRound className="h-4 w-4" />
+          <UserRound className="mr-2 h-4 w-4" />
           프로필 보기
-        </button>
-      </PopoverContent>
-    </Popover>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./dropdown-menu"
+
+const ContextMenu = DropdownMenu
+const ContextMenuTrigger = DropdownMenuTrigger
+const ContextMenuContent = DropdownMenuContent
+const ContextMenuItem = DropdownMenuItem
+const ContextMenuLabel = DropdownMenuLabel
+const ContextMenuSeparator = DropdownMenuSeparator
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+}


### PR DESCRIPTION
## Summary
공개채팅 아바타 클릭 메뉴를 ContextMenu 기반으로 변경합니다.

## 원인
기존 Popover 메뉴가 운영 공개채팅에서 클릭 반응이 없다는 제보가 있었습니다.

## 변경
- shadcn 스타일 ContextMenu facade 추가
- 공개채팅 아바타 메뉴를 ContextMenu로 교체
- 메뉴 항목은 1:1 채팅하기, 프로필 보기 유지

## Test plan
- [x] 수정 파일 200줄 상한 확인
- [ ] 로컬 pnpm lint/build는 현재 원본 node_modules가 비어 있어 실행 불가
- [ ] GitHub Actions 빌드로 검증

Generated with Claude Code