### PR TITLE
🐛 공개채팅 아바타 클릭 이벤트 전달

### DIFF
--- a/src/app/(root)/(routes)/chat/public/components/public-chat-avatar.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-avatar.tsx
@@ -1,26 +1,37 @@
 'use client'
 
+import { forwardRef } from 'react'
+import type { ButtonHTMLAttributes } from 'react'
 import { UserRound } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
-interface PublicChatAvatarProps {
+interface PublicChatAvatarProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
   image?: string
   nickName: string
-  onClick?: () => void
 }
 
-export function PublicChatAvatar({
+export const PublicChatAvatar = forwardRef<
+  HTMLButtonElement,
+  PublicChatAvatarProps
+>(function PublicChatAvatar({
   image,
   nickName,
-  onClick,
-}: PublicChatAvatarProps) {
+  className,
+  ...props
+}, ref) {
   const initial = nickName.trim().charAt(0).toUpperCase()
 
   return (
     <button
+      ref={ref}
       type="button"
       aria-label={`${nickName} 프로필 메뉴 열기`}
-      onClick={onClick}
-      className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-background text-[13px] font-semibold text-muted-foreground"
+      className={cn(
+        'mt-1 flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-background text-[13px] font-semibold text-muted-foreground',
+        className
+      )}
+      {...props}
     >
       {image ? (
         // eslint-disable-next-line @next/next/no-img-element
@@ -32,4 +43,4 @@ export function PublicChatAvatar({
       )}
     </button>
   )
-}
+})


### PR DESCRIPTION
## Summary
- PublicChatAvatar를 forwardRef 기반 버튼 컴포넌트로 변경
- ContextMenuTrigger가 주입하는 ref/click/aria props가 실제 버튼까지 전달되도록 수정

## Test plan
- [x] `git diff --check`
- [x] 수정 파일 200줄 상한 확인
- [ ] 로컬 `pnpm lint`는 node_modules 내 next 실행 파일 부재로 실행 불가
- [ ] GitHub Actions production build 확인

🤖 Generated with Codex