### PR TITLE
🐛 공개채팅 프로필 조회와 1대1 채팅 보강

### DIFF
--- a/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-room.tsx
@@ -67,15 +67,16 @@ export function PublicChatRoom() {
   }
 
   const startDirectChat = async (message: PublicChatMessage) => {
-    if (!message.userId) {
+    const targetUserId = Number(message.userId)
+    if (!Number.isInteger(targetUserId) || targetUserId <= 0) {
       showToast('회원 프로필이 있는 메시지만 1:1 채팅을 열 수 있어요.')
       return
     }
-    if (!currentUserId) {
+    if (!currentUserId || !Number.isInteger(currentUserId)) {
       router.push('/login?callbackUrl=/chat/public')
       return
     }
-    if (message.userId === currentUserId) return
+    if (targetUserId === currentUserId) return
 
     try {
       const response = await fetch('/api/chat/direct', {
@@ -83,7 +84,7 @@ export function PublicChatRoom() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           currentUserId,
-          targetUserId: message.userId,
+          targetUserId,
           targetUserName: message.nickName,
         }),
       })
@@ -97,11 +98,12 @@ export function PublicChatRoom() {
   }
 
   const showProfile = (message: PublicChatMessage) => {
-    if (!message.userId) {
+    const nickname = message.nickName.trim()
+    if (!nickname || nickname === '익명') {
       showToast('회원 프로필이 없는 메시지예요.')
       return
     }
-    router.push(`/profile/${message.userId}`)
+    router.push(`/profile/${encodeURIComponent(nickname)}`)
   }
 
   return (

--- a/src/app/(root)/(routes)/profile/[nickname]/page.tsx
+++ b/src/app/(root)/(routes)/profile/[nickname]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation'
 import { UsersRepository } from '@/modules/users/users-repository'
 
 interface ProfilePageProps {
-  params: { id: string }
+  params: { nickname: string }
 }
 
 interface PublicProfile {
@@ -12,12 +12,12 @@ interface PublicProfile {
   image?: string
 }
 
-async function getProfile(id: string): Promise<PublicProfile | null> {
-  const userId = Number(id)
-  if (!Number.isInteger(userId) || userId <= 0) return null
+async function getProfile(nickname: string): Promise<PublicProfile | null> {
+  const decodedNickname = decodeURIComponent(nickname).trim()
+  if (!decodedNickname) return null
 
   try {
-    const user = await new UsersRepository().getUser(userId)
+    const user = await new UsersRepository().getUserByNickname(decodedNickname)
     return {
       id: user.id,
       nickname: user.nickname,
@@ -29,7 +29,7 @@ async function getProfile(id: string): Promise<PublicProfile | null> {
 }
 
 export default async function ProfilePage({ params }: ProfilePageProps) {
-  const profile = await getProfile(params.id)
+  const profile = await getProfile(params.nickname)
   if (!profile) notFound()
 
   const initial = profile.nickname.trim().charAt(0).toUpperCase()

--- a/src/app/api/chat/direct/route.ts
+++ b/src/app/api/chat/direct/route.ts
@@ -12,8 +12,15 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json()
     const { currentUserId, targetUserId, targetUserName } = body
+    const currentId = Number(currentUserId)
+    const targetId = Number(targetUserId)
 
-    if (!currentUserId || !targetUserId) {
+    if (
+      !Number.isInteger(currentId) ||
+      !Number.isInteger(targetId) ||
+      currentId <= 0 ||
+      targetId <= 0
+    ) {
       return NextResponse.json(
         { error: 'currentUserId and targetUserId are required' },
         { status: 400 },
@@ -23,8 +30,8 @@ export async function POST(request: NextRequest) {
     const chatRepository = new ChatRepository(token)
 
     const data = await chatRepository.findOrCreateDirectChatRoom(
-      currentUserId,
-      targetUserId,
+      currentId,
+      targetId,
       targetUserName,
     )
     return NextResponse.json({ chatRoom: data })

--- a/src/app/api/user/nickname/[nickname]/route.ts
+++ b/src/app/api/user/nickname/[nickname]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { UsersRepository } from '@/modules/users/users-repository'
+
+interface RouteParams {
+  params: { nickname: string }
+}
+
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const nickname = decodeURIComponent(params.nickname).trim()
+    if (!nickname) {
+      return NextResponse.json(
+        { success: false, message: '닉네임 정보가 올바르지 않습니다.' },
+        { status: 400 },
+      )
+    }
+
+    const user = await new UsersRepository().getUserByNickname(nickname)
+    return NextResponse.json({
+      success: true,
+      data: {
+        id: user.id,
+        nickname: user.nickname,
+        image: user.image,
+      },
+    })
+  } catch (error) {
+    console.error('user nickname GET error:', error)
+    return NextResponse.json(
+      { success: false, message: '프로필을 불러오지 못했습니다.' },
+      { status: 404 },
+    )
+  }
+}

--- a/src/config/app-backend-api-endpoint.ts
+++ b/src/config/app-backend-api-endpoint.ts
@@ -88,6 +88,9 @@ const AppBackEndApiEndpoint = {
   updateProfileImage: () => {
     return `${_base}/user/image`
   },
+  getUserByNickname: (nickname: string) => {
+    return `${_base}/user/nickname/${encodeURIComponent(nickname)}`
+  },
   updateScore: (id: number) => {
     return `${_base}/movie/score/${id}`
   },

--- a/src/modules/users/users-datasource.ts
+++ b/src/modules/users/users-datasource.ts
@@ -136,6 +136,16 @@ export class UsersDatasource {
     return res.json()
   }
 
+  async getUserByNickname(nickname: string) {
+    const res = await fetch(AppBackEndApiEndpoint.getUserByNickname(nickname), {
+      cache: 'no-cache',
+    })
+    if (!res.ok) {
+      throw new Error(`[${res.status}] ${res.statusText}`)
+    }
+    return res.json()
+  }
+
   async deleteAccount() {
     const res = await fetch(`${serverApi}/user`, {
       method: 'DELETE',

--- a/src/modules/users/users-repository.ts
+++ b/src/modules/users/users-repository.ts
@@ -69,6 +69,11 @@ export class UsersRepository {
     return this.convertToUserEntity(result)
   }
 
+  async getUserByNickname(nickname: string) {
+    const result = await this.datasource.getUserByNickname(nickname)
+    return this.convertToUserEntity(result)
+  }
+
   async deleteAccount() {
     return await this.datasource.deleteAccount()
   }


### PR DESCRIPTION
## Summary
- 공개채팅 프로필 보기를 /profile/:nickname 기반으로 변경
- 공개 프로필 조회를 nickname 기반 backend API로 연결
- 프로필 이미지가 응답에서 누락되지 않도록 user repository 조회 경로 보강
- /api/chat/direct payload 숫자 검증 강화

## Test plan
- [x] `git diff --check`
- [x] 수정 파일 200줄 상한 확인
- [ ] 로컬 `pnpm lint`는 node_modules 내 next 실행 파일 부재로 실행 불가
- [ ] GitHub Actions production build 확인

🤖 Generated with Codex