### PR TITLE
🐛 1대1 채팅 상대 프로필 표시

### DIFF
--- a/src/app/(root)/(routes)/chat/[chatRoomId]/page.tsx
+++ b/src/app/(root)/(routes)/chat/[chatRoomId]/page.tsx
@@ -27,7 +27,9 @@ export default function ChatRoomPage({ params: { chatRoomId } }: PageProps) {
     fetcher,
   )
   const { data: messageData, isLoading: msgLoading, mutate } = useSWR(
-    myUserId ? `/api/chat/rooms/${chatRoomId}/messages?userId=${myUserId}&pageSize=200` : null,
+    myUserId
+      ? `/api/chat/rooms/${chatRoomId}/messages?userId=${myUserId}&pageSize=200`
+      : null,
     fetcher,
   )
 
@@ -42,7 +44,9 @@ export default function ChatRoomPage({ params: { chatRoomId } }: PageProps) {
     }),
   )
   const messages = [...serverMessages, ...localMessages]
-  const targetUserId = room?.memberIds.find((id: number) => id !== myUserId) ?? null
+  const targetProfile = room?.memberProfiles?.find(
+    (profile: { userId: number }) => profile.userId !== myUserId,
+  )
 
   const { sendMessage, isConnected } = useChatSocket({
     namespace: 'ws-home',
@@ -91,7 +95,8 @@ export default function ChatRoomPage({ params: { chatRoomId } }: PageProps) {
     )
   }
 
-  const targetName = targetUserId ? `상대방 #${targetUserId}` : room.name
+  const targetName = targetProfile?.nickname || room.name
+  const targetImage = targetProfile?.image || ''
   const initial = targetName.charAt(0).toUpperCase()
 
   return (
@@ -102,16 +107,39 @@ export default function ChatRoomPage({ params: { chatRoomId } }: PageProps) {
           onClick={() => router.push('/chat')}
           className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-white/[0.06] text-foreground"
         >
-          <svg width="8" height="14" viewBox="0 0 8 14">
-            <path d="M7 1L1 7l6 6" stroke="currentColor" strokeWidth="1.8" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+          <svg width="8" height="14" viewBox="0 0 8 14" aria-hidden>
+            <path
+              d="M7 1L1 7l6 6"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
         </button>
-        <span aria-hidden className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-secondary text-[14px] font-bold text-foreground">
-          {initial}
+        <span
+          aria-hidden
+          className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-full border border-border bg-secondary text-[14px] font-bold text-foreground"
+        >
+          {targetImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={targetImage}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            initial
+          )}
         </span>
         <div className="min-w-0 flex-1">
           <div className="text-[14px] font-semibold text-foreground">{targetName}</div>
-          <div className={`text-[10px] ${isConnected ? 'text-[#6fc96f]' : 'text-muted-foreground'}`}>
+          <div
+            className={`text-[10px] ${
+              isConnected ? 'text-[#6fc96f]' : 'text-muted-foreground'
+            }`}
+          >
             ● {isConnected ? 'online' : '연결 중...'}
           </div>
         </div>
@@ -136,6 +164,7 @@ export default function ChatRoomPage({ params: { chatRoomId } }: PageProps) {
                 createdAt={message.createdAt}
                 showAvatar={showAvatar}
                 avatarInitial={initial}
+                avatarImage={targetImage}
               />
             )
           })

--- a/src/components/dm/dm-chat-bubble.tsx
+++ b/src/components/dm/dm-chat-bubble.tsx
@@ -7,6 +7,7 @@ interface DmChatBubbleProps {
   createdAt?: string | Date
   showAvatar?: boolean
   avatarInitial?: string
+  avatarImage?: string
 }
 
 function formatTime(input?: string | Date): string {
@@ -27,6 +28,7 @@ export function DmChatBubble({
   createdAt,
   showAvatar = true,
   avatarInitial,
+  avatarImage,
 }: DmChatBubbleProps) {
   const time = formatTime(createdAt)
   return (
@@ -44,7 +46,16 @@ export function DmChatBubble({
             !showAvatar && 'opacity-0',
           )}
         >
-          {avatarInitial ?? senderName?.charAt(0).toUpperCase() ?? '?'}
+          {avatarImage && showAvatar ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={avatarImage}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            avatarInitial ?? senderName?.charAt(0).toUpperCase() ?? '?'
+          )}
         </span>
       )}
       <div className="flex max-w-[72%] flex-col gap-0.5">


### PR DESCRIPTION
## Summary
- /chat/:chatRoomId 상세 화면에서 상대방 #id 대신 memberProfiles의 상대 닉네임을 표시
- 헤더 아바타와 상대 메시지 아바타에 상대 프로필 이미지를 표시
- DmChatBubble에 avatarImage prop 추가

## Test plan
- [x] `git diff --check`
- [x] 수정 파일 200줄 상한 확인
- [ ] 로컬 `pnpm lint`는 node_modules 내 next 실행 파일 부재로 실행 불가
- [ ] GitHub Actions production build 확인

🤖 Generated with Codex