### PR TITLE
✨ 영화 상세 감독 필모그래피 추가

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/hooks/use-director-filmography.ts
+++ b/src/app/(root)/(routes)/movie/[id]/hooks/use-director-filmography.ts
@@ -1,0 +1,39 @@
+'use client'
+
+import { MovieClientApiEndpoint } from '@/config/movie-api-endpoint'
+import { Movie } from '@/modules/movie/movie.entity'
+import useSWR from 'swr'
+
+const fetcher = async (url: string): Promise<Movie[]> => {
+  const response = await fetch(url)
+  const result = await response.json()
+  if (!response.ok) {
+    throw new Error(result.error || '감독 필모그래피를 불러오지 못했습니다.')
+  }
+  return result.movies ?? []
+}
+
+const pickFirstDirector = (director?: string) => {
+  return (
+    director
+      ?.split(/[,/·]/)
+      .map((name) => name.trim())
+      .filter(Boolean)[0] ?? ''
+  )
+}
+
+export const useDirectorFilmography = (movie?: Movie) => {
+  const director = pickFirstDirector(movie?.director)
+  const key =
+    movie && director
+      ? MovieClientApiEndpoint.getMoviesByDirector(director, movie.id, 12)
+      : null
+
+  const { data, ...state } = useSWR<Movie[]>(key, fetcher)
+
+  return {
+    director,
+    movies: data ?? [],
+    ...state,
+  }
+}

--- a/src/app/(root)/(routes)/movie/[id]/hooks/use-get-movie-detail.ts
+++ b/src/app/(root)/(routes)/movie/[id]/hooks/use-get-movie-detail.ts
@@ -1,4 +1,4 @@
-import { AppClientApiEndpoint } from '@/config/app-client-api-endpoint'
+import { MovieClientApiEndpoint } from '@/config/movie-api-endpoint'
 import useSWR from 'swr'
 
 const fetcher = async (url: string) => {
@@ -16,7 +16,7 @@ const fetcher = async (url: string) => {
 }
 
 const getKey = (movieCd: string) => {
-  return AppClientApiEndpoint.getMovieDetail(movieCd)
+  return MovieClientApiEndpoint.getMovieDetail(movieCd)
 }
 
 export const useGetMovieDetail = (movieCd: string) => {

--- a/src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
@@ -5,6 +5,7 @@ import { FunctionComponent } from 'react'
 import MovieVodModal from '../components/movie-vod-modal'
 import { useGetMovieDetail } from '../hooks/use-get-movie-detail'
 import { useVodModalContext } from '../hooks/use-vod-modal-context'
+import { DirectorFilmographySection } from './director-filmography-section'
 
 interface DescriptionSectionProps {
   id: string
@@ -36,6 +37,7 @@ const DescriptionSection: FunctionComponent<DescriptionSectionProps> = ({
     <>
       <MovieVodModal />
       <DmMovieDetail movie={data} onVodClick={handleVodClick} />
+      <DirectorFilmographySection movie={data} />
     </>
   )
 }

--- a/src/app/(root)/(routes)/movie/[id]/sections/director-filmography-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/director-filmography-section.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { Movie } from '@/modules/movie/movie.entity'
+import Link from 'next/link'
+import { Poster } from '@/components/dm/poster'
+import { paletteForMovie } from '@/components/dm/poster-palette'
+import { SectionHead } from '@/components/dm/section-head'
+import { useDirectorFilmography } from '../hooks/use-director-filmography'
+
+interface DirectorFilmographySectionProps {
+  movie: Movie
+}
+
+function FilmographyCard({ movie }: { movie: Movie }) {
+  const palette = paletteForMovie(movie.id, movie.title)
+  const releaseYear = movie.openedAt
+    ? new Date(movie.openedAt).getFullYear()
+    : undefined
+  const genre =
+    movie.genre
+      ?.split(/[,/·]/)
+      .map((item) => item.trim())
+      .filter(Boolean)[0] ?? ''
+  const rating = movie.averageScore ?? 0
+
+  return (
+    <Link
+      href={`/movie/${movie.id}`}
+      className="block w-[132px] shrink-0 rounded-lg border border-border bg-card p-2 transition-colors hover:bg-accent"
+    >
+      <Poster
+        title={movie.title}
+        palette={palette}
+        imageUrl={movie.poster}
+        rounded="md"
+      />
+      <h3 className="mt-2 line-clamp-2 min-h-[34px] text-[13px] font-semibold leading-[1.3] text-foreground">
+        {movie.title}
+      </h3>
+      <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+        {[releaseYear, genre].filter(Boolean).join(' · ')}
+      </p>
+      {rating > 0 && (
+        <p className="mt-1 font-mono text-[10px] font-semibold text-primary">
+          ★ {rating.toFixed(1)}
+        </p>
+      )}
+    </Link>
+  )
+}
+
+export function DirectorFilmographySection({
+  movie,
+}: DirectorFilmographySectionProps) {
+  const { director, movies, isLoading, error } = useDirectorFilmography(movie)
+
+  if (!director || error || (!isLoading && movies.length === 0)) return null
+
+  return (
+    <section className="px-4 pb-5">
+      <SectionHead>{director} 감독 필모그래피</SectionHead>
+      {isLoading ? (
+        <div className="flex gap-3 overflow-hidden">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-[244px] w-[132px] shrink-0 animate-pulse rounded-lg bg-muted"
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="-mx-4 overflow-x-auto px-4 pb-1">
+          <div className="flex w-max gap-3 pr-4">
+            {movies.map((item) => (
+              <FilmographyCard key={item.id} movie={item} />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/app/api/movie/director/route.ts
+++ b/src/app/api/movie/director/route.ts
@@ -1,0 +1,31 @@
+import { MovieRepository } from '@/modules/movie/movie-repository'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const name = searchParams.get('name') || ''
+    const excludeMovieCd = Number(searchParams.get('excludeMovieCd') || '0')
+    const limit = Number(searchParams.get('limit') || '12')
+
+    if (!name.trim()) {
+      return NextResponse.json({ movies: [] })
+    }
+
+    const movies = await new MovieRepository().getMoviesByDirector(
+      name,
+      Number.isFinite(excludeMovieCd) ? excludeMovieCd : 0,
+      Number.isFinite(limit) ? limit : 12,
+    )
+
+    return NextResponse.json({ movies })
+  } catch (error) {
+    console.error('Director filmography API error:', error)
+    return NextResponse.json(
+      { error: '감독 필모그래피를 불러오지 못했습니다.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/config/movie-api-endpoint.ts
+++ b/src/config/movie-api-endpoint.ts
@@ -1,0 +1,55 @@
+import queryString from 'query-string'
+
+const serverBase =
+  process.env.SERVER_API ||
+  process.env.NEXT_PUBLIC_SERVER_API ||
+  'http://127.0.0.1:3030'
+
+export const MovieBackEndApiEndpoint = {
+  getMovie: () => `${serverBase}/movie`,
+  getMovieDetail: (movieCd: string) => `${serverBase}/movie/${movieCd}`,
+  getMoviesByDirector: (
+    name: string,
+    excludeMovieCd: number,
+    limit: number,
+  ) =>
+    queryString.stringifyUrl(
+      {
+        url: `${serverBase}/movie/director`,
+        query: { name, excludeMovieCd, limit },
+      },
+      { skipEmptyString: true, skipNull: true },
+    ),
+  updateScore: (id: number) => `${serverBase}/movie/score/${id}`,
+  getScore: (id: string) => `${serverBase}/movie/score/${id}`,
+  getAverageScore: (id: string) => `${serverBase}/movie/score/average/${id}`,
+  getMovieTheaterList: () => `${serverBase}/movie/cgv/theaters`,
+  getMovieTheaterDetail: (id: number) => `${serverBase}/movie-theater/${id}`,
+  getMoviesByTheaterId: (theaterId: number) =>
+    `${serverBase}/movie-theater/${theaterId}/movies`,
+  getMovieDetailByTheater: (movieCd: string) =>
+    `${serverBase}/movie-theater/movie/${movieCd}`,
+}
+
+export const MovieClientApiEndpoint = {
+  getMovieDetail: (movieCd: string) =>
+    queryString.stringifyUrl(
+      {
+        url: `/api/movie/${movieCd}`,
+        query: { movieCd },
+      },
+      { skipEmptyString: true, skipNull: true },
+    ),
+  getMoviesByDirector: (
+    name: string,
+    excludeMovieCd: number,
+    limit: number,
+  ) =>
+    queryString.stringifyUrl(
+      {
+        url: '/api/movie/director',
+        query: { name, excludeMovieCd, limit },
+      },
+      { skipEmptyString: true, skipNull: true },
+    ),
+}

--- a/src/modules/movie/movie-datasource.ts
+++ b/src/modules/movie/movie-datasource.ts
@@ -1,4 +1,4 @@
-import { AppBackEndApiEndpoint } from '@/config/app-backend-api-endpoint'
+import { MovieBackEndApiEndpoint } from '@/config/movie-api-endpoint'
 
 export class MovieDatasource {
   private token?: string
@@ -6,7 +6,7 @@ export class MovieDatasource {
     this.token = token
   }
   async getMovie() {
-    const res = await fetch(AppBackEndApiEndpoint.getMovie(), {
+    const res = await fetch(MovieBackEndApiEndpoint.getMovie(), {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -21,7 +21,7 @@ export class MovieDatasource {
   }
 
   async getMovieDetail(movieCd: string) {
-    const res = await fetch(AppBackEndApiEndpoint.getMovieDetail(movieCd), {
+    const res = await fetch(MovieBackEndApiEndpoint.getMovieDetail(movieCd), {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -34,8 +34,30 @@ export class MovieDatasource {
     }
     return res.json()
   }
+
+  async getMoviesByDirector(
+    name: string,
+    excludeMovieCd: number,
+    limit: number,
+  ) {
+    const res = await fetch(
+      MovieBackEndApiEndpoint.getMoviesByDirector(name, excludeMovieCd, limit),
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `${this.token}`,
+        },
+        cache: 'no-cache',
+      },
+    )
+    if (res.status !== 200) {
+      throw new Error('감독 필모그래피를 받아 올 수 없습니다.')
+    }
+    return res.json()
+  }
   async updateScore(id: number, score: number) {
-    const res = await fetch(AppBackEndApiEndpoint.updateScore(id), {
+    const res = await fetch(MovieBackEndApiEndpoint.updateScore(id), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -53,7 +75,7 @@ export class MovieDatasource {
   }
 
   async getScore(id: string) {
-    const res = await fetch(AppBackEndApiEndpoint.getScore(id), {
+    const res = await fetch(MovieBackEndApiEndpoint.getScore(id), {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -67,7 +89,7 @@ export class MovieDatasource {
     return res.json()
   }
   async getAverageScore(id: string) {
-    const res = await fetch(AppBackEndApiEndpoint.getAverageScore(id), {
+    const res = await fetch(MovieBackEndApiEndpoint.getAverageScore(id), {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -82,7 +104,7 @@ export class MovieDatasource {
   }
 
   async getMovieTheaterList() {
-    const res = await fetch(AppBackEndApiEndpoint.getMovieTheaterList(), {
+    const res = await fetch(MovieBackEndApiEndpoint.getMovieTheaterList(), {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -97,7 +119,7 @@ export class MovieDatasource {
   }
 
   async getMovieTheaterDetail(id: number) {
-    const res = await fetch(AppBackEndApiEndpoint.getMovieTheaterDetail(id), {
+    const res = await fetch(MovieBackEndApiEndpoint.getMovieTheaterDetail(id), {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -113,7 +135,7 @@ export class MovieDatasource {
 
   async getMoviesByTheaterId(theaterId: number) {
     const res = await fetch(
-      AppBackEndApiEndpoint.getMoviesByTheaterId(theaterId),
+      MovieBackEndApiEndpoint.getMoviesByTheaterId(theaterId),
       {
         method: 'GET',
         headers: {
@@ -131,7 +153,7 @@ export class MovieDatasource {
 
   async getMovieDetailByTheater(movieCd: string) {
     const res = await fetch(
-      AppBackEndApiEndpoint.getMovieDetailByTheater(movieCd),
+      MovieBackEndApiEndpoint.getMovieDetailByTheater(movieCd),
       {
         method: 'GET',
         headers: {

--- a/src/modules/movie/movie-repository.ts
+++ b/src/modules/movie/movie-repository.ts
@@ -30,6 +30,21 @@ export class MovieRepository {
     return this.convertUnkownToMovie(data)
   }
 
+  async getMoviesByDirector(
+    name: string,
+    excludeMovieCd: number,
+    limit = 12,
+  ): Promise<Movie[]> {
+    const data = await this.datasource.getMoviesByDirector(
+      name,
+      excludeMovieCd,
+      limit,
+    )
+    return data.MovieData?.map((item: any) => {
+      return this.convertUnkownToMovie(item)
+    })
+  }
+
   private convertUnkownToMovie(unknown: any): Movie {
     const result = {
       id: unknown.movieCd,


### PR DESCRIPTION
## Summary
영화 상세 화면에서 현재 영화 감독의 다른 작품을 가로 카드 리스트로 볼 수 있도록 필모그래피 섹션을 추가합니다.

## 변경
- `/api/movie/director` BFF route 추가
- movie datasource/repository에 감독 필모그래피 조회 연결
- 영화 상세에 감독 필모그래피 섹션과 SWR hook 추가

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build` (build-time placeholder env 사용)
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)