### PR TITLE
🐛 순위 없는 영화 상세 배지 숨김

### DIFF
--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -9,7 +9,7 @@ import { SectionHead } from './section-head'
 import { Stars } from './stars'
 
 interface DmMovieDetailProps {
-  movie: Movie & { rank?: number }
+  movie: Movie
   averageScore?: number | null
   scoreCount?: number | null
   onVodClick?: () => void
@@ -26,6 +26,7 @@ export function DmMovieDetail({
   const rating = averageScore ?? movie.averageScore ?? 0
   const reviews = scoreCount ?? movie.scoreCount ?? 0
   const matchHref = `/match?movieTitle=${encodeURIComponent(movie.title)}`
+  const shouldShowRank = movie.isRanked && movie.rank > 0
   const genres =
     movie.genre
       ?.split(/[,/·]/)
@@ -58,7 +59,7 @@ export function DmMovieDetail({
             />
           </div>
           <div className="pb-1">
-            {movie.rank && (
+            {shouldShowRank && (
               <span className="inline-flex items-center rounded-full border border-border px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
                 #{movie.rank} 박스오피스
               </span>

--- a/src/modules/movie/movie-repository.ts
+++ b/src/modules/movie/movie-repository.ts
@@ -47,6 +47,7 @@ export class MovieRepository {
   }
 
   private convertUnkownToMovie(unknown: any): Movie {
+    const rank = Number(unknown.rank) || 0
     const result = {
       id: unknown.movieCd,
       audience: unknown.audience,
@@ -54,7 +55,9 @@ export class MovieRepository {
       createdAt: new Date(unknown.createdAt),
       updatedAt: new Date(unknown.updatedAt),
       poster: unknown.poster,
-      rank: Number(unknown.rank) || 0,
+      rank,
+      isRanked:
+        typeof unknown.isRanked === 'boolean' ? unknown.isRanked : rank > 0,
       rankInten: unknown.rankInten,
       plot: unknown.plot,
       rankOldAndNew: unknown.rankOldAndNew,

--- a/src/modules/movie/movie.entity.ts
+++ b/src/modules/movie/movie.entity.ts
@@ -6,6 +6,7 @@ export interface Movie {
   updatedAt: Date
   poster: string
   rank: number
+  isRanked: boolean
   rankInten: number
   plot: string
   rankOldAndNew: string
@@ -37,6 +38,8 @@ export function isMovie(arg: any): arg is Movie {
     typeof arg.audience === 'number' &&
     typeof arg.title === 'string' &&
     typeof arg.poster === 'string' &&
+    typeof arg.rank === 'number' &&
+    typeof arg.isRanked === 'boolean' &&
     arg.createdAt instanceof Date &&
     arg.updatedAt instanceof Date &&
     typeof arg.genre === 'string' &&


### PR DESCRIPTION
## Summary
영화 상세 화면에서 박스오피스 TOP10 영화일 때만 순위 배지를 표시하도록 수정합니다.

## 원인
감독 필모그래피에서 진입한 영화는 TOP10 랭킹 정보가 없는데도 rank 기본값이 화면 조건으로 사용될 수 있었습니다.

## 변경
- Movie 엔티티에 `isRanked` 추가
- API 응답 매핑 시 `isRanked`를 우선 사용하고, 구버전 응답은 `rank > 0`으로 fallback
- 영화 상세 배지를 `isRanked && rank > 0` 조건에서만 표시

## Test plan
- [x] `pnpm build` (더미 env, 네트워크 허용)
- [x] 수정 파일 200줄 상한 확인
- [x] 선택 수정 파일 `git diff --check`
- [ ] `pnpm lint` (현재 `next/core-web-vitals` config resolve 이슈로 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)