### PR TITLE
✨ 영화 상세 감독·포스터 확대 추가

### DIFF
--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -4,6 +4,7 @@ import { Movie } from '@/modules/movie/movie.entity'
 import Link from 'next/link'
 import { Poster } from './poster'
 import { paletteForMovie } from './poster-palette'
+import { PosterPreviewDialog } from './poster-preview-dialog'
 import { RatingInput } from './rating-input'
 import { SectionHead } from './section-head'
 import { Stars } from './stars'
@@ -27,6 +28,7 @@ export function DmMovieDetail({
   const reviews = scoreCount ?? movie.scoreCount ?? 0
   const matchHref = `/match?movieTitle=${encodeURIComponent(movie.title)}`
   const shouldShowRank = movie.isRanked && movie.rank > 0
+  const director = movie.director?.trim()
   const genres =
     movie.genre
       ?.split(/[,/·]/)
@@ -52,11 +54,16 @@ export function DmMovieDetail({
       <div className="relative -mt-[70px] px-4">
         <div className="flex items-end gap-3.5">
           <div className="w-[106px] shrink-0">
-            <Poster
+            <PosterPreviewDialog
               title={movie.title}
-              palette={palette}
               imageUrl={movie.poster}
-            />
+            >
+              <Poster
+                title={movie.title}
+                palette={palette}
+                imageUrl={movie.poster}
+              />
+            </PosterPreviewDialog>
           </div>
           <div className="pb-1">
             {shouldShowRank && (
@@ -70,6 +77,12 @@ export function DmMovieDetail({
             <div className="mt-1 font-mono text-[11px] text-muted-foreground">
               {metadata}
             </div>
+            {director && (
+              <div className="mt-1.5 text-[12px] text-muted-foreground">
+                <span className="mr-1.5 font-medium text-foreground">감독</span>
+                {director}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/dm/index.ts
+++ b/src/components/dm/index.ts
@@ -1,6 +1,7 @@
 export * from './pill'
 export * from './stars'
 export * from './poster'
+export * from './poster-preview-dialog'
 export * from './poster-palette'
 export * from './app-header'
 export * from './bottom-nav'

--- a/src/components/dm/poster-preview-dialog.tsx
+++ b/src/components/dm/poster-preview-dialog.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import * as Dialog from '@radix-ui/react-dialog'
+import { Maximize2, X } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+interface PosterPreviewDialogProps {
+  title: string
+  imageUrl?: string
+  children: ReactNode
+}
+
+export function PosterPreviewDialog({
+  title,
+  imageUrl,
+  children,
+}: PosterPreviewDialogProps) {
+  if (!imageUrl) return <>{children}</>
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          aria-label={`${title} 포스터 크게 보기`}
+          title="포스터 크게 보기"
+          className="group relative block w-full cursor-zoom-in text-left"
+        >
+          {children}
+          <span className="absolute bottom-1.5 right-1.5 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white opacity-90 transition-opacity group-hover:opacity-100">
+            <Maximize2 className="h-3.5 w-3.5" aria-hidden />
+          </span>
+        </button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 max-h-[calc(100dvh-2rem)] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 outline-none sm:max-h-[calc(100dvh-4rem)] sm:max-w-[calc(100vw-4rem)]">
+          <Dialog.Title className="sr-only">{title} 포스터</Dialog.Title>
+          <Dialog.Description className="sr-only">
+            {title} 포스터 확대 이미지
+          </Dialog.Description>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt={`${title} 포스터`}
+            className="block max-h-[calc(100dvh-2rem)] max-w-[calc(100vw-2rem)] object-contain shadow-2xl sm:max-h-[calc(100dvh-4rem)] sm:max-w-[calc(100vw-4rem)]"
+          />
+          <Dialog.Close
+            aria-label="포스터 닫기"
+            className="absolute right-2 top-2 flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-black/70 text-white transition-colors hover:bg-white hover:text-black"
+          >
+            <X className="h-5 w-5" aria-hidden />
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}


### PR DESCRIPTION
## Summary
영화 상세 상단에서 감독 정보를 바로 확인하고, 포스터를 눌러 원본 비율의 큰 이미지로 볼 수 있도록 개선합니다.

## 변경
- 영화 제목 메타데이터 아래에 감독명 노출
- 포스터 클릭용 확대 아이콘과 Radix Dialog 기반 이미지 미리보기 추가
- ESC, 배경 클릭, 닫기 버튼 지원 및 모바일 viewport 내 이미지 맞춤

## Test plan
- [x] `pnpm build` 완료 (더미 env, 네트워크 허용)
- [x] 모바일 390x844 Chrome 검증: 감독 정보/확대 트리거/모달 이미지/닫기 버튼 확인
- [x] 모바일 가로 오버플로 없음 확인
- [x] 수정 파일 200줄 상한 및 `git diff --check` 확인
- [ ] `pnpm lint` (기존 `next/core-web-vitals` config resolve 이슈로 실패)
- [ ] `pnpm exec tsc --noEmit --incremental false` (기존 `/public/assets/circle-x.png` 모듈 타입 오류로 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)