### PR TITLE
🐛 관리자 통계 OAuth 인증 수정

### DIFF
--- a/src/app/api/analytics/summary/route.test.ts
+++ b/src/app/api/analytics/summary/route.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('analytics summary authentication', () => {
+  it('resolves the token from the current NextAuth request', () => {
+    const source = readFileSync(new URL('./route.ts', import.meta.url), 'utf8')
+
+    expect(source).toContain('getAuthTokenFromRequest(request)')
+    expect(source).not.toContain('getTokenFromCookie()')
+  })
+})

--- a/src/app/api/analytics/summary/route.ts
+++ b/src/app/api/analytics/summary/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { AnalyticsRepository } from '@/modules/analytics'
 
-export async function GET(_request: NextRequest) {
-  const token = getTokenFromCookie()
+export async function GET(request: NextRequest) {
+  const token = await getAuthTokenFromRequest(request)
   if (!token) {
     return NextResponse.json(
       { message: '로그인이 필요합니다.' },


### PR DESCRIPTION
## Summary
- 관리자 통계 BFF가 쿠키 전용 토큰 대신 현재 NextAuth 요청 JWT를 사용하도록 수정
- Google OAuth 로그인 상태에서 발생하던 401 해결
- 인증 방식 회귀 테스트 추가

## Root cause
- `/api/analytics/summary`만 `getTokenFromCookie()`를 사용해 OAuth 세션 쿠키를 읽지 못함
- 기존 정상 인증 API와 동일하게 `getAuthTokenFromRequest(request)` 적용

## Test plan
- [x] 회귀 테스트 red → green 확인
- [x] `pnpm lint`
- [x] placeholder 환경으로 `pnpm build`
- [x] 파일 200줄 상한 및 `git diff --check`
- [ ] 배포 후 OAuth 로그인 상태 `/analytics` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)