### PR TITLE
💄 영화 상세 순위 뱃지 위치 개선

### DIFF
--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -53,7 +53,7 @@ export function DmMovieDetail({
 
       <div className="relative -mt-[70px] px-4">
         <div className="flex items-end gap-3.5">
-          <div className="w-[106px] shrink-0">
+          <div className="relative w-[106px] shrink-0">
             <PosterPreviewDialog
               title={movie.title}
               imageUrl={movie.poster}
@@ -64,14 +64,14 @@ export function DmMovieDetail({
                 imageUrl={movie.poster}
               />
             </PosterPreviewDialog>
-          </div>
-          <div className="pb-1">
             {shouldShowRank && (
-              <span className="inline-flex items-center rounded-full border border-border px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
-                #{movie.rank} 박스오피스
+              <span className="pointer-events-none absolute left-2 top-2 z-10 bg-black/85 px-2 py-1 font-mono text-[9px] font-semibold text-white shadow-sm">
+                박스오피스 {movie.rank}위
               </span>
             )}
-            <h1 className="mt-2 text-[24px] font-bold leading-tight tracking-tight text-foreground">
+          </div>
+          <div className="pb-1">
+            <h1 className="text-[24px] font-bold leading-tight tracking-tight text-foreground">
               {movie.title}
             </h1>
             <div className="mt-1 font-mono text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
- 제목 위 경계선에 걸리던 박스오피스 순위 뱃지를 포스터 좌상단으로 이동
- `박스오피스 1위` 형태로 의미를 바로 읽을 수 있게 정리
- 포스터 확대 클릭을 방해하지 않도록 pointer-events 제외
- 순위가 없는 영화의 뱃지 숨김 조건 유지

## Visual review
- 운영 데스크톱 1280x720 및 모바일 390x844에서 기존 위치 확인
- 기존 문제: 배경/본문 경계선에 뱃지가 걸려 제목과 포스터 어디에도 소속되지 않아 보임
- 변경: 포스터 콘텐츠에 직접 귀속되는 고대비 오버레이

## Test plan
- [x] `pnpm lint`
- [x] placeholder 환경으로 `pnpm build`
- [x] 수정 파일 137줄 및 `git diff --check`
- [ ] 배포 후 데스크톱/모바일 운영 스크린샷 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)