### PR TITLE
💄 영화 포스터 장식 질감 제거

### DIFF
--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -23,7 +23,6 @@ export function DmMovieDetail({
   onVodClick,
 }: DmMovieDetailProps) {
   const palette = paletteForMovie(movie.id, movie.title)
-  const { h, c, lt, lb } = palette
   const rating = averageScore ?? movie.averageScore ?? 0
   const reviews = scoreCount ?? movie.scoreCount ?? 0
   const matchHref = `/match?movieTitle=${encodeURIComponent(movie.title)}`
@@ -43,21 +42,12 @@ export function DmMovieDetail({
 
   return (
     <div className="pb-5">
-      {/* 포스터 배경 그라디언트 */}
-      <div
-        className="h-[140px] w-full"
-        style={{
-          background: `linear-gradient(160deg, oklch(${lt} ${c} ${h}) 0%, oklch(${lb} ${c * 0.6} ${h}) 100%)`,
-        }}
-      />
+      <div className="h-[140px] w-full border-b border-border bg-muted/40" />
 
       <div className="relative -mt-[70px] px-4">
         <div className="flex items-end gap-3.5">
           <div className="relative w-[106px] shrink-0">
-            <PosterPreviewDialog
-              title={movie.title}
-              imageUrl={movie.poster}
-            >
+            <PosterPreviewDialog title={movie.title} imageUrl={movie.poster}>
               <Poster
                 title={movie.title}
                 palette={palette}
@@ -65,7 +55,7 @@ export function DmMovieDetail({
               />
             </PosterPreviewDialog>
             {shouldShowRank && (
-              <span className="pointer-events-none absolute left-2 top-2 z-10 bg-black/85 px-2 py-1 font-mono text-[9px] font-semibold text-white shadow-sm">
+              <span className="bg-black/85 pointer-events-none absolute left-2 top-2 z-10 px-2 py-1 font-mono text-[9px] font-semibold text-white shadow-sm">
                 박스오피스 {movie.rank}위
               </span>
             )}

--- a/src/components/dm/movie-backdrop.tsx
+++ b/src/components/dm/movie-backdrop.tsx
@@ -7,24 +7,10 @@ interface MovieBackdropProps {
 }
 
 export function MovieBackdrop({ palette, height = 220 }: MovieBackdropProps) {
-  const { h, c } = palette
+  void palette
   const style: CSSProperties = {
     height,
-    background: [
-      `linear-gradient(180deg, transparent 0%, var(--dm-bg) 95%)`,
-      `linear-gradient(135deg, oklch(0.25 ${c} ${h}) 0%, oklch(0.08 ${c * 0.5} ${h}) 100%)`,
-    ].join(', '),
+    background: 'hsl(var(--muted))',
   }
-  return (
-    <div className="relative" style={style} aria-hidden>
-      <div
-        className="absolute inset-0"
-        style={{
-          backgroundImage:
-            'radial-gradient(rgba(255,255,255,0.03) 1px, transparent 1px)',
-          backgroundSize: '3px 3px',
-        }}
-      />
-    </div>
-  )
+  return <div className="relative" style={style} aria-hidden />
 }

--- a/src/components/dm/poster.tsx
+++ b/src/components/dm/poster.tsx
@@ -12,20 +12,18 @@ interface PosterProps {
 
 export function Poster({
   title,
-  palette,
+  palette: _palette,
   imageUrl,
   className,
   rounded = 'sm',
 }: PosterProps) {
-  const { h, c, lt, lb } = palette
   const style: CSSProperties = imageUrl
-    ? { backgroundImage: `url(${imageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }
-    : {
-        background: [
-          `linear-gradient(155deg, oklch(${lt} ${c} ${h}) 0%, oklch(${lb} ${c * 0.6} ${h}) 100%)`,
-          `repeating-linear-gradient(0deg, rgba(255,255,255,0.03) 0 2px, transparent 2px 4px)`,
-        ].join(', '),
+    ? {
+        backgroundImage: `url(${imageUrl})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
       }
+    : { background: 'hsl(var(--muted))' }
 
   return (
     <div
@@ -38,29 +36,9 @@ export function Poster({
         className,
       )}
     >
-      {/* grain */}
-      <div
-        className="absolute inset-0"
-        style={{
-          backgroundImage:
-            'radial-gradient(rgba(255,255,255,0.05) 1px, transparent 1px)',
-          backgroundSize: '3px 3px',
-        }}
-        aria-hidden
-      />
-      {/* vignette */}
-      {!imageUrl && (
-        <div
-          className="absolute inset-0"
-          style={{
-            background: `radial-gradient(ellipse at 30% 30%, oklch(${lt + 0.1} ${c} ${h} / 0.35) 0%, transparent 60%)`,
-          }}
-          aria-hidden
-        />
-      )}
       {/* title card (only when no image) */}
       {!imageUrl && (
-        <div className="absolute inset-x-1.5 bottom-1.5 break-keep font-dm-display text-[11px] italic leading-[1.15] text-foreground [text-shadow:0_1px_4px_rgba(0,0,0,0.8)]">
+        <div className="absolute inset-x-2 bottom-2 break-keep font-dm-display text-[11px] italic leading-[1.15] text-muted-foreground">
           {title}
         </div>
       )}


### PR DESCRIPTION
## Summary
- 영화 상세 포스터 뒤 자동 색상 그라디언트를 중립 단색 배경으로 교체
- 포스터 이미지가 없을 때 생성하던 그라디언트·점무늬·비네트 제거
- 공용 영화 backdrop도 단색으로 통일
- 로그인 필름 장식과 채팅 상태 강조선처럼 기능적 배경은 유지

## Test plan
- [x] 영화 관련 생성 gradient/radial/repeating 패턴 전수 검색
- [x] `pnpm lint`
- [x] placeholder 환경으로 `pnpm build`
- [x] 변경 파일 모두 200줄 이하 및 `git diff --check`
- [ ] 배포 후 영화 상세와 포스터 없는 매칭 카드 운영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)