### PR TITLE
💄 영화 상세 장식 배경 영역 제거

### DIFF
--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -42,9 +42,7 @@ export function DmMovieDetail({
 
   return (
     <div className="pb-5">
-      <div className="h-[140px] w-full border-b border-border bg-muted/40" />
-
-      <div className="relative -mt-[70px] px-4">
+      <div className="px-4 pt-6">
         <div className="flex items-end gap-3.5">
           <div className="relative w-[106px] shrink-0">
             <PosterPreviewDialog title={movie.title} imageUrl={movie.poster}>


### PR DESCRIPTION
## Summary
- 그라디언트 제거 후 남아 있던 140px 장식 배경 영역 자체를 제거
- 포스터와 제목을 헤더 아래 24px 정상 여백으로 배치
- 모바일 첫 화면의 불필요한 빈 공간 축소

## Test plan
- [x] `pnpm lint`
- [x] placeholder 환경으로 `pnpm build`
- [x] 수정 파일 125줄 및 `git diff --check`
- [ ] 배포 후 모바일·데스크톱 운영 화면 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)