### PR TITLE
💄 영화 순위 뱃지를 제목 옆으로 이동

### DIFF
--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -52,16 +52,18 @@ export function DmMovieDetail({
                 imageUrl={movie.poster}
               />
             </PosterPreviewDialog>
-            {shouldShowRank && (
-              <span className="bg-black/85 pointer-events-none absolute left-2 top-2 z-10 px-2 py-1 font-mono text-[9px] font-semibold text-white shadow-sm">
-                박스오피스 {movie.rank}위
-              </span>
-            )}
           </div>
-          <div className="pb-1">
-            <h1 className="text-[24px] font-bold leading-tight tracking-tight text-foreground">
-              {movie.title}
-            </h1>
+          <div className="min-w-0 pb-1">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <h1 className="text-[24px] font-bold leading-tight tracking-tight text-foreground">
+                {movie.title}
+              </h1>
+              {shouldShowRank && (
+                <span className="whitespace-nowrap rounded-sm bg-foreground px-2 py-1 font-mono text-[10px] font-semibold text-background">
+                  박스오피스 {movie.rank}위
+                </span>
+              )}
+            </div>
             <div className="mt-1 font-mono text-[11px] text-muted-foreground">
               {metadata}
             </div>


### PR DESCRIPTION
## Summary
- 박스오피스 순위 뱃지를 포스터 위에서 영화 제목 옆으로 이동
- 긴 제목에서는 뱃지가 자연스럽게 다음 줄로 배치되도록 flex-wrap 적용
- 순위가 없는 영화의 숨김 조건 유지

## Test plan
- [x] `pnpm lint`
- [x] placeholder 환경으로 `pnpm build`
- [x] 수정 파일 127줄 및 `git diff --check`
- [ ] 배포 후 모바일·데스크톱 운영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)