### PR TITLE
🐛 영화 평점 OAuth 인증 수정

### DIFF
--- a/src/app/api/score/[id]/route.test.ts
+++ b/src/app/api/score/[id]/route.test.ts
@@ -1,11 +1,76 @@
-import { readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
+import { MovieRepository } from '@/modules/movie/movie-repository'
+import { GET, POST } from './route'
+
+vi.mock('@/lib/utils/getToken', () => ({
+  getAuthTokenFromRequest: vi.fn(),
+}))
+
+vi.mock('@/modules/movie/movie-repository', () => ({
+  MovieRepository: vi.fn(),
+}))
+
+const mockAuthToken = vi.mocked(getAuthTokenFromRequest)
+const MockMovieRepository = vi.mocked(MovieRepository)
+const score = { id: 7, movieCd: 20259946, score: 4, userId: 4 }
 
 describe('movie score authentication', () => {
-  it('resolves the token from the current NextAuth request', () => {
-    const source = readFileSync(new URL('./route.ts', import.meta.url), 'utf8')
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
 
-    expect(source.match(/getAuthTokenFromRequest\(req\)/g)).toHaveLength(2)
-    expect(source).not.toContain('getTokenFromCookie()')
+  it('uses the current NextAuth token to update a score', async () => {
+    const updateScore = vi.fn().mockResolvedValue(score)
+    mockAuthToken.mockResolvedValue('oauth-token')
+    MockMovieRepository.mockImplementation(
+      () => ({ updateScore } as unknown as MovieRepository),
+    )
+    const request = new NextRequest('http://localhost/api/score/20259946', {
+      method: 'POST',
+      body: JSON.stringify({ score: 4 }),
+    })
+
+    const response = await POST(request, { params: { id: 20259946 } })
+
+    expect(MockMovieRepository).toHaveBeenCalledWith('oauth-token')
+    expect(updateScore).toHaveBeenCalledWith(20259946, 4)
+    expect(response.status).toBe(200)
+  })
+
+  it('uses the current NextAuth token to read a score', async () => {
+    const getScore = vi.fn().mockResolvedValue(score)
+    mockAuthToken.mockResolvedValue('oauth-token')
+    MockMovieRepository.mockImplementation(
+      () => ({ getScore } as unknown as MovieRepository),
+    )
+    const request = new NextRequest('http://localhost/api/score/20259946')
+
+    const response = await GET(request, { params: { id: '20259946' } })
+
+    expect(MockMovieRepository).toHaveBeenCalledWith('oauth-token')
+    expect(getScore).toHaveBeenCalledWith('20259946')
+    expect(response.status).toBe(200)
+  })
+
+  it('returns the expected unauthenticated responses', async () => {
+    mockAuthToken.mockResolvedValue(undefined)
+    const postRequest = new NextRequest(
+      'http://localhost/api/score/20259946',
+      { method: 'POST', body: JSON.stringify({ score: 4 }) },
+    )
+    const getRequest = new NextRequest('http://localhost/api/score/20259946')
+
+    const postResponse = await POST(postRequest, {
+      params: { id: 20259946 },
+    })
+    const getResponse = await GET(getRequest, { params: { id: '20259946' } })
+
+    expect(postResponse.status).toBe(401)
+    expect(await getResponse.json()).toEqual({
+      data: { id: 0, score: 0, userId: 0, movieCd: 20259946 },
+    })
+    expect(MockMovieRepository).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/score/[id]/route.test.ts
+++ b/src/app/api/score/[id]/route.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('movie score authentication', () => {
+  it('resolves the token from the current NextAuth request', () => {
+    const source = readFileSync(new URL('./route.ts', import.meta.url), 'utf8')
+
+    expect(source.match(/getAuthTokenFromRequest\(req\)/g)).toHaveLength(2)
+    expect(source).not.toContain('getTokenFromCookie()')
+  })
+})

--- a/src/app/api/score/[id]/route.ts
+++ b/src/app/api/score/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MovieRepository } from '@/modules/movie/movie-repository'
 import { NextRequest } from 'next/server'
 
@@ -22,7 +22,13 @@ export const POST = async (
   { params }: { params: { id: number } },
 ) => {
   const { id } = params
-  const token = await getTokenFromCookie()
+  const token = await getAuthTokenFromRequest(req)
+  if (!token) {
+    return new Response(JSON.stringify({ message: '로그인이 필요합니다.' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
   const { score } = await req.json()
   const repository = new MovieRepository(token)
   try {
@@ -64,7 +70,7 @@ export const GET = async (
   { params }: { params: { id: string } },
 ) => {
   const { id } = params
-  const token = await getTokenFromCookie()
+  const token = await getAuthTokenFromRequest(req)
 
   if (!token) {
     return scoreResponse(createEmptyScore(id))


### PR DESCRIPTION
## Summary
Google OAuth 로그인 사용자의 영화 평점 저장·조회 인증을 현재 NextAuth 요청 기준으로 수정합니다.

## 원인
평점 BFF가 구형 별도 쿠키만 조회해 OAuth 세션에서는 백엔드로 `Bearer undefined`가 전달됐고, 백엔드 401이 BFF에서 500으로 감춰졌습니다.

## 변경
- POST/GET 모두 요청 기반 NextAuth JWT를 해석
- 비로그인 POST는 명시적으로 401 반환
- OAuth 토큰 전달과 비로그인 동작을 핸들러 단위 회귀 테스트로 검증

## Test plan
- [x] `pnpm exec vitest run` (4 tests)
- [x] `pnpm lint` (오류 0, 기존 경고만 존재)
- [x] placeholder env `pnpm build`
- [x] 수정 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 운영 OAuth 세션에서 평점 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)