### PR TITLE
🐛 OAuth 인증 BFF 토큰 전달 통일

### DIFF
--- a/src/app/api/article/[id]/like/route.test.ts
+++ b/src/app/api/article/[id]/like/route.test.ts
@@ -20,25 +20,28 @@ describe('article like authentication', () => {
     vi.clearAllMocks()
   })
 
-  it('uses the current NextAuth token to update a like', async () => {
-    const updateArticleLike = vi
-      .fn()
-      .mockResolvedValue({ likes: 2, dislikes: 0 })
-    mockAuthToken.mockResolvedValue('oauth-token')
-    MockArticleRepository.mockImplementation(
-      () => ({ updateArticleLike } as unknown as ArticleRepository),
-    )
-    const request = new NextRequest(
-      'http://localhost/api/article/4/like?state=like',
-      { method: 'POST' },
-    )
+  it.each(['like', 'dislike'] as const)(
+    'uses the current NextAuth token to update a %s',
+    async (state) => {
+      const updateArticleLike = vi
+        .fn()
+        .mockResolvedValue({ likes: 2, dislikes: 0 })
+      mockAuthToken.mockResolvedValue('oauth-token')
+      MockArticleRepository.mockImplementation(
+        () => ({ updateArticleLike } as unknown as ArticleRepository),
+      )
+      const request = new NextRequest(
+        `http://localhost/api/article/4/like?state=${state}`,
+        { method: 'POST' },
+      )
 
-    const response = await POST(request, { params: { id: '4' } })
+      const response = await POST(request, { params: { id: '4' } })
 
-    expect(MockArticleRepository).toHaveBeenCalledWith('oauth-token')
-    expect(updateArticleLike).toHaveBeenCalledWith('4', 'like')
-    expect(response.status).toBe(200)
-  })
+      expect(MockArticleRepository).toHaveBeenCalledWith('oauth-token')
+      expect(updateArticleLike).toHaveBeenCalledWith('4', state)
+      expect(response.status).toBe(200)
+    },
+  )
 
   it('returns 401 when no session token exists', async () => {
     mockAuthToken.mockResolvedValue(undefined)

--- a/src/app/api/article/[id]/like/route.test.ts
+++ b/src/app/api/article/[id]/like/route.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
+import { ArticleRepository } from '@/modules/article/article-repository'
+import { POST } from './route'
+
+vi.mock('@/lib/utils/getToken', () => ({
+  getAuthTokenFromRequest: vi.fn(),
+}))
+
+vi.mock('@/modules/article/article-repository', () => ({
+  ArticleRepository: vi.fn(),
+}))
+
+const mockAuthToken = vi.mocked(getAuthTokenFromRequest)
+const MockArticleRepository = vi.mocked(ArticleRepository)
+
+describe('article like authentication', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the current NextAuth token to update a like', async () => {
+    const updateArticleLike = vi
+      .fn()
+      .mockResolvedValue({ likes: 2, dislikes: 0 })
+    mockAuthToken.mockResolvedValue('oauth-token')
+    MockArticleRepository.mockImplementation(
+      () => ({ updateArticleLike } as unknown as ArticleRepository),
+    )
+    const request = new NextRequest(
+      'http://localhost/api/article/4/like?state=like',
+      { method: 'POST' },
+    )
+
+    const response = await POST(request, { params: { id: '4' } })
+
+    expect(MockArticleRepository).toHaveBeenCalledWith('oauth-token')
+    expect(updateArticleLike).toHaveBeenCalledWith('4', 'like')
+    expect(response.status).toBe(200)
+  })
+
+  it('returns 401 when no session token exists', async () => {
+    mockAuthToken.mockResolvedValue(undefined)
+    const request = new NextRequest(
+      'http://localhost/api/article/4/like?state=like',
+      { method: 'POST' },
+    )
+
+    const response = await POST(request, { params: { id: '4' } })
+
+    expect(response.status).toBe(401)
+    expect(MockArticleRepository).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/article/[id]/like/route.ts
+++ b/src/app/api/article/[id]/like/route.ts
@@ -1,5 +1,5 @@
 import { LikeState } from '@/lib/type'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { ArticleRepository } from '@/modules/article/article-repository'
 import { NextRequest } from 'next/server'
 
@@ -40,7 +40,7 @@ export const POST = async (
   }
 
   try {
-    const token = await getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(req)
     if (!token) return new Response(null, { status: 401 })
 
     const repo = new ArticleRepository(token)

--- a/src/app/api/article/comment/[id]/route.ts
+++ b/src/app/api/article/comment/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { ArticleRepository } from '@/modules/article/article-repository'
 import { CommentRepository } from '@/modules/comment/comment-repository'
 import { NextRequest } from 'next/server'
@@ -8,7 +8,7 @@ export const POST = async (req: NextRequest) => {
   const comment = form.get('comment') as string
 
   try {
-    const token = await getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(req)
     if (!token) {
       return new Response(null, { status: 401 })
     }
@@ -40,7 +40,7 @@ export const GET = async (req: NextRequest) => {
   const page = searchParams.get('page') ?? '0'
   const parsedPage = Number(page) + 1
   const articleId = searchParams.get('articleId')
-  const token = await getTokenFromCookie()
+  const token = await getAuthTokenFromRequest(req)
   const repository = new ArticleRepository(token ?? undefined)
   try {
     const data = await repository.getCommentList(articleId + '', parsedPage)
@@ -70,7 +70,7 @@ export const PUT = async (req: NextRequest) => {
   const commentId = form.get('commentId') as string
   const comment = form.get('comment') as string
   try {
-    const token = await getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(req)
     if (!token) {
       return new Response(null, { status: 401 })
     }
@@ -102,7 +102,7 @@ export const DELETE = async (req: NextRequest) => {
   const form = await req.formData()
   const commentId = form.get('commentId') as string
   try {
-    const token = await getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(req)
     if (!token) {
       return new Response(null, { status: 401 })
     }

--- a/src/app/api/article/route.ts
+++ b/src/app/api/article/route.ts
@@ -1,7 +1,4 @@
-import {
-  getAuthTokenFromRequest,
-  getTokenFromCookie,
-} from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { ArticleRepository } from '@/modules/article/article-repository'
 import { NextRequest } from 'next/server'
 
@@ -35,7 +32,7 @@ export const GET = async (req: NextRequest) => {
   const page = Number(searchParams.get('page') ?? '1')
   const pageSize = Number(searchParams.get('pageSize') ?? '10')
   try {
-    const token = await getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(req)
     const repo = new ArticleRepository(token)
     const data = await repo.listArticles(page, pageSize)
     return new Response(JSON.stringify({ data }), {

--- a/src/app/api/auth-token-routes.test.ts
+++ b/src/app/api/auth-token-routes.test.ts
@@ -1,0 +1,23 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const apiDirectory = fileURLToPath(new URL('.', import.meta.url))
+
+const findRouteFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return findRouteFiles(path)
+    return entry.name === 'route.ts' ? [path] : []
+  })
+
+describe('BFF authentication token policy', () => {
+  it('does not read the legacy token cookie directly from API routes', () => {
+    const legacyRoutes = findRouteFiles(apiDirectory)
+      .filter((path) => readFileSync(path, 'utf8').includes('getTokenFromCookie'))
+      .map((path) => path.replace(`${apiDirectory}/`, ''))
+
+    expect(legacyRoutes).toEqual([])
+  })
+})

--- a/src/app/api/comment/[id]/route.ts
+++ b/src/app/api/comment/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { CommentRepository } from '@/modules/comment/comment-repository'
 import { NextRequest } from 'next/server'
 
@@ -7,7 +7,7 @@ export const POST = async (req: NextRequest) => {
   const movieId = form.get('movieId') as string
   const comment = form.get('comment') as string
   try {
-    const token = await getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(req)
     if (!token) {
       return new Response(null, { status: 401 })
     }
@@ -39,7 +39,7 @@ export const GET = async (req: NextRequest) => {
   const page = searchParams.get('page') ?? '0'
   const parsedPage = Number(page) + 1
   const movieId = searchParams.get('movieId')
-  const token = await getTokenFromCookie()
+  const token = await getAuthTokenFromRequest(req)
   const repository = new CommentRepository(token ?? undefined)
   try {
     const data = await repository.getCommentList(movieId + '', parsedPage)
@@ -68,7 +68,7 @@ export const PUT = async (req: NextRequest) => {
   const commentId = form.get('commentId') as string
   const comment = form.get('comment') as string
   try {
-    const token = await getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(req)
     if (!token) {
       return new Response(null, { status: 401 })
     }
@@ -100,7 +100,7 @@ export const DELETE = async (req: NextRequest) => {
   const form = await req.formData()
   const commentId = form.get('commentId') as string
   try {
-    const token = await getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(req)
     if (!token) {
       return new Response(null, { status: 401 })
     }

--- a/src/app/api/match/route.ts
+++ b/src/app/api/match/route.ts
@@ -1,8 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import {
-  getAuthTokenFromRequest,
-  getTokenFromCookie,
-} from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { MatchPostRepository } from '@/modules/match/match-post-repository'
 
 // GET /api/match - match 목록 조회
@@ -15,7 +12,7 @@ export async function GET(request: NextRequest) {
     const filter = searchParams.get('filter')?.trim()
     const userno = Number(searchParams.get('userno')) || undefined
 
-    const token = getTokenFromCookie()
+    const token = await getAuthTokenFromRequest(request)
     const matchRepository = new MatchPostRepository(token)
 
     const data = await matchRepository.getMatchPosts(page, limit, {

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,9 +1,12 @@
-import { NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { NotificationRepository } from '@/modules/notification'
 
-export async function PATCH(_: Request, { params }: { params: { id: string } }) {
-  const token = getTokenFromCookie()
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const token = await getAuthTokenFromRequest(request)
   if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   try {

--- a/src/app/api/notifications/read-all/route.ts
+++ b/src/app/api/notifications/read-all/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { NotificationRepository } from '@/modules/notification'
 
-export async function PATCH() {
-  const token = getTokenFromCookie()
+export async function PATCH(request: NextRequest) {
+  const token = await getAuthTokenFromRequest(request)
   if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   try {

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { NotificationRepository } from '@/modules/notification'
 
 export async function GET(request: NextRequest) {
-  const token = getTokenFromCookie()
+  const token = await getAuthTokenFromRequest(request)
   if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { searchParams } = new URL(request.url)

--- a/src/app/api/notifications/unread-count/route.ts
+++ b/src/app/api/notifications/unread-count/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from 'next/server'
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { NotificationRepository } from '@/modules/notification'
 
-export async function GET() {
-  const token = getTokenFromCookie()
+export async function GET(request: NextRequest) {
+  const token = await getAuthTokenFromRequest(request)
   if (!token) return NextResponse.json({ count: 0 })
 
   try {

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,11 +1,12 @@
-import { getTokenFromCookie } from '@/lib/utils/getToken'
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { UsersRepository } from '@/modules/users/users-repository'
 import { NextRequest } from 'next/server'
 
 export const POST = async (req: NextRequest) => {
   const form = await req.formData()
   const nickname = form.get('nickname') as string
-  const token = await getTokenFromCookie()
+  const token = await getAuthTokenFromRequest(req)
+  if (!token) return new Response(null, { status: 401 })
   try {
     const repo = new UsersRepository(token)
     const data = await repo.updateProfile({ nickname })

--- a/src/lib/utils/getToken.test.ts
+++ b/src/lib/utils/getToken.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cookies } from 'next/dist/client/components/headers'
+import { getToken } from 'next-auth/jwt'
+import type { NextRequest } from 'next/server'
+import { getAuthTokenFromRequest } from './getToken'
+
+vi.mock('@/config/app-env', () => ({
+  AppEnv: {
+    cookieTokenKey: 'legacy-token',
+    nextAuthSecret: 'test-secret',
+  },
+}))
+
+vi.mock('next-auth/jwt', () => ({ getToken: vi.fn() }))
+vi.mock('next/dist/client/components/headers', () => ({ cookies: vi.fn() }))
+
+const mockGetToken = vi.mocked(getToken)
+const mockCookies = vi.mocked(cookies)
+const request = {} as NextRequest
+
+describe('getAuthTokenFromRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('prefers the NextAuth request token for OAuth sessions', async () => {
+    mockGetToken.mockResolvedValue('oauth-token')
+
+    const token = await getAuthTokenFromRequest(request)
+
+    expect(token).toBe('oauth-token')
+    expect(mockGetToken).toHaveBeenCalledWith({
+      req: request,
+      secret: 'test-secret',
+      raw: true,
+    })
+    expect(mockCookies).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the legacy token cookie', async () => {
+    mockGetToken.mockResolvedValue(null)
+    mockCookies.mockReturnValue({
+      get: vi.fn().mockReturnValue({ value: 'legacy-cookie-token' }),
+    } as unknown as ReturnType<typeof cookies>)
+
+    expect(await getAuthTokenFromRequest(request)).toBe('legacy-cookie-token')
+  })
+})


### PR DESCRIPTION
## Summary
아티클 좋아요·싫어요에서 Google OAuth 사용자에게 발생한 401을 수정하고, 같은 인증 누락 위험이 있는 BFF 라우트를 전수 정리합니다.

## 원인
일부 BFF가 NextAuth 요청 JWT가 아니라 구형 별도 쿠키만 직접 읽어 OAuth 세션을 로그인 상태로 인식하지 못했습니다.

## 변경
- 좋아요·싫어요 POST를 요청 기반 NextAuth 토큰으로 전환
- 아티클/영화 댓글, 알림, 프로필 수정의 인증 전달 통일
- 매칭·아티클 목록의 선택적 로그인 토큰 전달 통일
- API 라우트의 구형 쿠키 직접 접근을 금지하는 감사 테스트 추가
- OAuth 토큰 우선순위 및 like/dislike 분기 회귀 테스트 추가

## Test plan
- [x] `pnpm exec vitest run` (10 tests)
- [x] `pnpm lint` (오류 0, 기존 경고만 존재)
- [x] placeholder env `pnpm build`
- [x] 수정·신규 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 운영 `/articles/4` 좋아요·싫어요 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)