### PR TITLE
🐛 빈 프로필 이미지 기본 아바타 처리

### DIFF
--- a/src/components/dm/dm-user-avatar.test.ts
+++ b/src/components/dm/dm-user-avatar.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PROFILE_IMAGE_URL,
+  resolveUserAvatarImage,
+} from '../../lib/utils/user-avatar'
+
+describe('resolveUserAvatarImage', () => {
+  it('uses the default image when a legacy user has no profile image', () => {
+    expect(resolveUserAvatarImage(undefined)).toBe(DEFAULT_PROFILE_IMAGE_URL)
+    expect(resolveUserAvatarImage('')).toBe(DEFAULT_PROFILE_IMAGE_URL)
+    expect(resolveUserAvatarImage('   ')).toBe(DEFAULT_PROFILE_IMAGE_URL)
+  })
+
+  it('keeps an existing profile image', () => {
+    expect(resolveUserAvatarImage('https://example.com/profile.png')).toBe(
+      'https://example.com/profile.png',
+    )
+  })
+})

--- a/src/components/dm/dm-user-avatar.tsx
+++ b/src/components/dm/dm-user-avatar.tsx
@@ -2,6 +2,7 @@
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
+import { resolveUserAvatarImage } from '@/lib/utils/user-avatar'
 
 interface DmUserAvatarProps {
   name?: string | null
@@ -17,17 +18,16 @@ export function DmUserAvatar({
   fallbackClassName,
 }: DmUserAvatarProps) {
   const initial = name?.trim().charAt(0).toUpperCase() || '?'
+  const imageSrc = resolveUserAvatarImage(image)
 
   return (
     <Avatar className={cn('h-8 w-8 border border-border', className)}>
-      {image && (
-        <AvatarImage
-          src={image}
-          alt={`${name || '사용자'} 프로필`}
-          className="object-cover"
-          referrerPolicy="no-referrer"
-        />
-      )}
+      <AvatarImage
+        src={imageSrc}
+        alt={`${name || '사용자'} 프로필`}
+        className="object-cover"
+        referrerPolicy="no-referrer"
+      />
       <AvatarFallback
         delayMs={0}
         className={cn(

--- a/src/lib/utils/user-avatar.ts
+++ b/src/lib/utils/user-avatar.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_PROFILE_IMAGE_URL =
+  'https://bollae-uploads-prod-058511778476-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/profiles/2875139c-f1d8-44b3-b9fd-d39fc61be6e3.png'
+
+export function resolveUserAvatarImage(image?: string | null) {
+  return image?.trim() || DEFAULT_PROFILE_IMAGE_URL
+}


### PR DESCRIPTION
## Summary
- 공통 아바타가 빈 이미지 값에 기본 프로필 이미지를 사용합니다.
- 댓글, 계정, 내비게이션, 채팅 등 공통 아바타 적용 화면을 함께 보완합니다.

## Test plan
- [x] `pnpm exec vitest run` (14 tests)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인