### PR TITLE
✨ 영화 댓글 반응과 상태 UI 추가

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/hooks/comment-fetchers.ts
+++ b/src/app/(root)/(routes)/movie/[id]/hooks/comment-fetchers.ts
@@ -12,6 +12,10 @@ export interface ModifyCommentArgs extends DeleteCommentArgs {
   comment: string
 }
 
+export interface ReactCommentArgs extends DeleteCommentArgs {
+  reaction: 'like' | 'dislike'
+}
+
 export const createCommentFetcher = async (
   url: string,
   { arg }: { arg: CreateCommentArgs },
@@ -58,4 +62,17 @@ export const modifyCommentFetcher = async (
   const result = await res.json()
   if (!res.ok) throw new Error(result.message || '댓글 수정에 실패했습니다.')
   return result
+}
+
+export const reactCommentFetcher = async (
+  url: string,
+  { arg }: { arg: ReactCommentArgs },
+) => {
+  const formData = new FormData()
+  formData.append('commentId', String(arg.commentId))
+  formData.append('reaction', arg.reaction)
+  const res = await fetch(url, { method: 'PATCH', body: formData })
+  const result = await res.json()
+  if (!res.ok) throw new Error(result.message || '반응 저장에 실패했습니다.')
+  return result.data
 }

--- a/src/app/(root)/(routes)/movie/[id]/hooks/use-comment-reaction.ts
+++ b/src/app/(root)/(routes)/movie/[id]/hooks/use-comment-reaction.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { CommentApiEndpoint } from '@/config/comment-api-endpoint'
+import { useAppToast } from '@/hooks/use-app-toast'
+import { useAuthenticationCheck } from '@/hooks/use-authentication-check'
+import { useParams } from 'next/navigation'
+import useSWRMutation from 'swr/mutation'
+import { ReactCommentArgs, reactCommentFetcher } from './comment-fetchers'
+
+export function useCommentReaction(onChanged: () => void) {
+  const params = useParams()
+  const { showToast } = useAppToast()
+  const { requireAuthentication } = useAuthenticationCheck()
+  const movieId = Number(params?.id)
+  const { trigger, isMutating } = useSWRMutation(
+    CommentApiEndpoint.clientReaction(movieId),
+    reactCommentFetcher,
+  )
+
+  const reactComment = requireAuthentication(async (args: ReactCommentArgs) => {
+    try {
+      await trigger(args)
+      onChanged()
+    } catch (error) {
+      showToast('댓글 반응을 저장하지 못했습니다.')
+    }
+  })
+
+  return { reactComment, isReacting: isMutating }
+}

--- a/src/app/(root)/(routes)/movie/[id]/hooks/use-comments.ts
+++ b/src/app/(root)/(routes)/movie/[id]/hooks/use-comments.ts
@@ -155,5 +155,6 @@ export const useComments = () => {
     modifyComment,
     isModifyingComment,
     modifyCommentError,
+    refresh: mutate,
   }
 }

--- a/src/app/(root)/(routes)/movie/[id]/sections/comment-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/comment-section.tsx
@@ -11,6 +11,7 @@ import { ReplyCommentForm } from '../components/reply-comment-form'
 import { CommentFormProvider } from '../hooks/comment-form-context'
 import { ModifyCommentFormProvider } from '../hooks/modify-comment-context'
 import { useComments } from '../hooks/use-comments'
+import { useCommentReaction } from '../hooks/use-comment-reaction'
 import { useModifyCommentModalContext } from '../hooks/use-modify-comment-context'
 
 interface CommentSectionProps {
@@ -18,10 +19,11 @@ interface CommentSectionProps {
 }
 
 const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
-  const { data, next, hasMore, isLoading, error } = useComments()
+  const { data, next, hasMore, isLoading, error, deleteComment, refresh } =
+    useComments()
   const session = useSession()
   const userId = session.data?.user?.id
-  const { deleteComment } = useComments()
+  const { reactComment } = useCommentReaction(() => refresh())
   const { setOpen, setComment, setReplyId } = useModifyCommentModalContext()
   const [replyingTo, setReplyingTo] = useState<number | null>(null)
 
@@ -77,6 +79,9 @@ const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
                     onDelete={() => deleteComment({ commentId: comment.id })}
                     onModify={handleModifyComment}
                     onReply={() => setReplyingTo(comment.id)}
+                    onReact={(reaction) =>
+                      reactComment({ commentId: comment.id, reaction })
+                    }
                     userId={userId}
                   />
                   {replyingTo === comment.id && (
@@ -93,6 +98,9 @@ const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
                         nested
                         onDelete={() => deleteComment({ commentId: child.id })}
                         onModify={handleModifyComment}
+                        onReact={(reaction) =>
+                          reactComment({ commentId: child.id, reaction })
+                        }
                         userId={userId}
                       />
                     </div>

--- a/src/app/api/comment/[id]/route.test.ts
+++ b/src/app/api/comment/[id]/route.test.ts
@@ -2,7 +2,7 @@ import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { CommentRepository } from '@/modules/comment/comment-repository'
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { POST } from './route'
+import * as route from './route'
 
 vi.mock('@/lib/utils/getToken', () => ({ getAuthTokenFromRequest: vi.fn() }))
 vi.mock('@/modules/comment/comment-repository', () => ({
@@ -26,7 +26,7 @@ describe('movie comment reply route', () => {
     form.append('comment', '대댓글입니다')
     form.append('parentId', '10')
 
-    const response = await POST(
+    const response = await route.POST(
       new NextRequest('http://localhost/api/comment/20233219', {
         method: 'POST',
         body: form,
@@ -35,6 +35,32 @@ describe('movie comment reply route', () => {
 
     expect(MockCommentRepository).toHaveBeenCalledWith('oauth-token')
     expect(createComment).toHaveBeenCalledWith('20233219', '대댓글입니다', 10)
+    expect(response.status).toBe(200)
+  })
+
+  it('forwards the OAuth token and comment reaction', async () => {
+    const reactComment = vi.fn().mockResolvedValue({
+      likeCount: 1,
+      dislikeCount: 0,
+      reaction: 'like',
+    })
+    mockAuthToken.mockResolvedValue('oauth-token')
+    MockCommentRepository.mockImplementation(
+      () => ({ reactComment }) as unknown as CommentRepository,
+    )
+    const form = new FormData()
+    form.append('commentId', '10')
+    form.append('reaction', 'like')
+
+    const response = await (route as any).PATCH(
+      new NextRequest('http://localhost/api/comment/20233219', {
+        method: 'PATCH',
+        body: form,
+      }),
+    )
+
+    expect(MockCommentRepository).toHaveBeenCalledWith('oauth-token')
+    expect(reactComment).toHaveBeenCalledWith(10, 'like')
     expect(response.status).toBe(200)
   })
 })

--- a/src/app/api/comment/[id]/route.ts
+++ b/src/app/api/comment/[id]/route.ts
@@ -65,6 +65,26 @@ export const GET = async (req: NextRequest) => {
     })
   }
 }
+export const PATCH = async (req: NextRequest) => {
+  const form = await req.formData()
+  const commentId = Number(form.get('commentId'))
+  const reaction = form.get('reaction') as 'like' | 'dislike'
+  try {
+    const token = await getAuthTokenFromRequest(req)
+    if (!token) return new Response(null, { status: 401 })
+    const repo = new CommentRepository(token)
+    const data = await repo.reactComment(commentId, reaction)
+    return new Response(JSON.stringify({ data }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    return new Response(JSON.stringify({ message: 'An error occurred' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
 export const PUT = async (req: NextRequest) => {
   const form = await req.formData()
   const commentId = form.get('commentId') as string

--- a/src/components/dm/dm-review-card.tsx
+++ b/src/components/dm/dm-review-card.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { Reply } from '@/lib/type'
-import { MessageCircle, Pencil, X } from 'lucide-react'
+import { MessageCircle, Pencil, ThumbsDown, ThumbsUp, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import type { ReactNode } from 'react'
 import { DmUserAvatar } from './dm-user-avatar'
 
 interface DmReviewCardProps {
@@ -11,6 +12,7 @@ interface DmReviewCardProps {
   onModify?: (_reply: Reply) => void
   onDelete?: (_reply: Reply) => void
   onReply?: (_reply: Reply) => void
+  onReact?: (_reaction: 'like' | 'dislike') => void
   nested?: boolean
 }
 
@@ -34,10 +36,23 @@ export function DmReviewCard({
   onModify,
   onDelete,
   onReply,
+  onReact,
   nested = false,
 }: DmReviewCardProps) {
   if (!reply) return null
   const isOwner = userId !== undefined && +userId === reply.userno
+
+  if (reply.isDeleted) {
+    return (
+      <article
+        className={cn('border-b border-border py-3', nested && 'border-l pl-3')}
+      >
+        <p className="text-[13px] text-muted-foreground">
+          삭제된 댓글입니다.
+        </p>
+      </article>
+    )
+  }
 
   return (
     <article
@@ -54,6 +69,7 @@ export function DmReviewCard({
         </span>
         <span className="ml-auto font-mono text-[11px] text-muted-foreground">
           {formatWhen(reply.updatedAt)}
+          {reply.isEdited && ' · 수정됨'}
         </span>
         {isOwner && (
           <span className="flex gap-2">
@@ -83,6 +99,24 @@ export function DmReviewCard({
       <p className="mt-1.5 break-keep text-[13px] leading-relaxed text-foreground">
         {reply.content}
       </p>
+      {onReact && (
+        <div className="mt-2 flex items-center gap-1">
+          <ReactionButton
+            label="좋아요"
+            active={reply.userReaction === 'like'}
+            count={reply.likeCount ?? 0}
+            onClick={() => onReact('like')}
+            icon={<ThumbsUp className="h-3.5 w-3.5" />}
+          />
+          <ReactionButton
+            label="싫어요"
+            active={reply.userReaction === 'dislike'}
+            count={reply.dislikeCount ?? 0}
+            onClick={() => onReact('dislike')}
+            icon={<ThumbsDown className="h-3.5 w-3.5" />}
+          />
+        </div>
+      )}
       {onReply && !nested && (
         <button
           type="button"
@@ -94,5 +128,36 @@ export function DmReviewCard({
         </button>
       )}
     </article>
+  )
+}
+
+function ReactionButton({
+  label,
+  active,
+  count,
+  onClick,
+  icon,
+}: {
+  label: string
+  active: boolean
+  count: number
+  onClick: () => void
+  icon: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        'inline-flex h-7 min-w-[44px] items-center justify-center gap-1 px-2 text-[11px] text-muted-foreground transition hover:text-foreground',
+        active && 'text-primary',
+      )}
+    >
+      {icon}
+      <span>{count}</span>
+    </button>
   )
 }

--- a/src/config/comment-api-endpoint.ts
+++ b/src/config/comment-api-endpoint.ts
@@ -1,0 +1,10 @@
+const serverBase =
+  process.env.SERVER_API ||
+  process.env.NEXT_PUBLIC_SERVER_API ||
+  'http://127.0.0.1:3030'
+
+export const CommentApiEndpoint = {
+  clientReaction: (movieId: number) => `/api/comment/${movieId}`,
+  serverReaction: (commentId: number) =>
+    `${serverBase}/reply/${commentId}/reaction`,
+}

--- a/src/lib/type/reply.tsx
+++ b/src/lib/type/reply.tsx
@@ -8,6 +8,11 @@ export type Reply = {
   avatar?: string
   parentId?: number
   replies?: Reply[]
+  likeCount?: number
+  dislikeCount?: number
+  userReaction?: 'like' | 'dislike'
+  isEdited?: boolean
+  isDeleted?: boolean
 }
 export interface ArticleRepliesResponse {
   comments: Reply[]

--- a/src/modules/comment/comment-datasource.ts
+++ b/src/modules/comment/comment-datasource.ts
@@ -1,4 +1,5 @@
 import { AppBackEndApiEndpoint } from '@/config/app-backend-api-endpoint'
+import { CommentApiEndpoint } from '@/config/comment-api-endpoint'
 
 export class CommentDatasource {
   private token?: string
@@ -70,6 +71,18 @@ export class CommentDatasource {
     if (!res.ok) {
       throw new Error('댓글을 수정할 수 없습니다.')
     }
+    return res.json()
+  }
+  async reactComment(id: number, reaction: 'like' | 'dislike') {
+    const res = await fetch(CommentApiEndpoint.serverReaction(id), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify({ reaction }),
+    })
+    if (!res.ok) throw new Error('댓글 반응을 저장할 수 없습니다.')
     return res.json()
   }
 }

--- a/src/modules/comment/comment-repository.test.ts
+++ b/src/modules/comment/comment-repository.test.ts
@@ -16,6 +16,11 @@ describe('CommentRepository', () => {
           comment: '원댓글',
           createdAt: '2026-07-17T00:00:00Z',
           updatedAt: '2026-07-17T00:00:00Z',
+          likeCount: 3,
+          dislikeCount: 1,
+          userReaction: 'like',
+          isEdited: true,
+          isDeleted: false,
           replies: [
             {
               replyId: 11,
@@ -37,9 +42,30 @@ describe('CommentRepository', () => {
     const result = await repository.getCommentList('20233219', 1)
 
     expect(result.comments[0].avatar).toBe('https://cdn.bollae.kr/profile.png')
+    expect(result.comments[0]).toMatchObject({
+      likeCount: 3,
+      dislikeCount: 1,
+      userReaction: 'like',
+      isEdited: true,
+      isDeleted: false,
+    })
     expect(result.comments[0].replies?.[0]).toMatchObject({
       parentId: 10,
       avatar: 'https://cdn.bollae.kr/replier.png',
     })
+  })
+
+  it('forwards a comment reaction through the datasource', async () => {
+    const reactComment = vi.fn().mockResolvedValue({
+      likeCount: 2,
+      dislikeCount: 0,
+      reaction: 'like',
+    })
+    const repository = new CommentRepository(undefined, { reactComment } as never)
+
+    const result = await (repository as any).reactComment(10, 'like')
+
+    expect(reactComment).toHaveBeenCalledWith(10, 'like')
+    expect(result).toMatchObject({ likeCount: 2, reaction: 'like' })
   })
 })

--- a/src/modules/comment/comment-repository.ts
+++ b/src/modules/comment/comment-repository.ts
@@ -45,6 +45,9 @@ export class CommentRepository {
     const data = await this.datasource.modifyComment(id, comment)
     return data
   }
+  async reactComment(id: number, reaction: 'like' | 'dislike') {
+    return this.datasource.reactComment(id, reaction)
+  }
   private convertUnkownToComment(unknown: any): Reply {
     const result = {
       id: unknown.replyId,
@@ -56,6 +59,11 @@ export class CommentRepository {
       replies: unknown.replies?.map((reply: any) =>
         this.convertUnkownToComment(reply),
       ),
+      likeCount: unknown.likeCount ?? 0,
+      dislikeCount: unknown.dislikeCount ?? 0,
+      userReaction: unknown.userReaction || undefined,
+      isEdited: unknown.isEdited ?? false,
+      isDeleted: unknown.isDeleted ?? false,
       createdAt: new Date(unknown.createdAt),
       updatedAt: new Date(unknown.updatedAt),
     } as Reply


### PR DESCRIPTION
## Summary
영화 상세의 댓글과 대댓글에서 좋아요·싫어요를 누르고 삭제·수정 상태를 확인할 수 있도록 UI와 BFF를 확장합니다.

## 변경
- 댓글·대댓글 반응 아이콘 버튼과 집계·선택 상태 추가
- 삭제 부모 댓글 자리 표시자 및 수정됨 라벨 추가
- OAuth/JWT 공통 인증 토큰 기반 댓글 반응 BFF 추가
- 반응 후 댓글 목록을 즉시 갱신

## Test plan
- [x] `pnpm exec vitest run`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정·신규 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)