### PR TITLE
✨ 아티클 댓글 반응과 대댓글 UI 추가

### DIFF
--- a/src/app/(root)/(routes)/articles/[id]/components/reply-comment-form.tsx
+++ b/src/app/(root)/(routes)/articles/[id]/components/reply-comment-form.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { Reply } from '@/lib/type'
+import { FormEvent, useState } from 'react'
+import { useArticleComments } from '../hooks/use-article-comments'
+import { useCreateArticleComment } from '../hooks/use-create-article-comment'
+
+interface ReplyCommentFormProps {
+  articleId: string
+  parent: Reply
+  onClose: () => void
+}
+
+export function ReplyCommentForm({
+  articleId,
+  parent,
+  onClose,
+}: ReplyCommentFormProps) {
+  const [comment, setComment] = useState('')
+  const { mutate } = useArticleComments()
+  const { createComment, isCreatingComment } = useCreateArticleComment(mutate)
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    if (!comment.trim()) return
+    createComment(
+      { articleId, comment: comment.trim(), parentId: parent.id },
+      { onSuccess: onClose },
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="ml-9 border-l border-border py-3 pl-3"
+    >
+      <label className="mb-2 block text-[11px] text-muted-foreground">
+        {parent.nickname}님에게 답글
+      </label>
+      <div className="flex gap-2">
+        <input
+          autoFocus
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          placeholder="답글을 입력해주세요."
+          className="h-9 min-w-0 flex-1 rounded-md border border-border bg-secondary px-3 text-[13px] outline-none focus:border-primary"
+        />
+        <button
+          type="submit"
+          disabled={!comment.trim() || isCreatingComment}
+          className="h-9 rounded-md bg-primary px-3 text-[12px] text-primary-foreground disabled:opacity-50"
+        >
+          등록
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-1 text-[12px] text-muted-foreground"
+        >
+          취소
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/app/(root)/(routes)/articles/[id]/hooks/use-article-comment-reaction.ts
+++ b/src/app/(root)/(routes)/articles/[id]/hooks/use-article-comment-reaction.ts
@@ -1,0 +1,38 @@
+'use client'
+
+import { ArticleCommentApiEndpoint } from '@/config/article-comment-api-endpoint'
+import { useAppToast } from '@/hooks/use-app-toast'
+import { useAuthenticationCheck } from '@/hooks/use-authentication-check'
+import useSWRMutation from 'swr/mutation'
+
+interface ReactionArgs {
+  commentId: number
+  reaction: 'like' | 'dislike'
+}
+
+async function reactionFetcher(url: string, { arg }: { arg: ReactionArgs }) {
+  const form = new FormData()
+  form.set('commentId', String(arg.commentId))
+  form.set('reaction', arg.reaction)
+  const response = await fetch(url, { method: 'PATCH', body: form })
+  if (!response.ok) throw new Error('반응 저장 실패')
+  return response.json()
+}
+
+export function useArticleCommentReaction(onChanged: () => void) {
+  const { showToast } = useAppToast()
+  const { requireAuthentication } = useAuthenticationCheck()
+  const { trigger, isMutating } = useSWRMutation(
+    ArticleCommentApiEndpoint.clientReaction(),
+    reactionFetcher,
+  )
+  const reactComment = requireAuthentication(async (args: ReactionArgs) => {
+    try {
+      await trigger(args)
+      onChanged()
+    } catch (error) {
+      showToast('댓글 반응을 저장하지 못했습니다.')
+    }
+  })
+  return { reactComment, isReacting: isMutating }
+}

--- a/src/app/(root)/(routes)/articles/[id]/hooks/use-create-article-comment.ts
+++ b/src/app/(root)/(routes)/articles/[id]/hooks/use-create-article-comment.ts
@@ -9,6 +9,7 @@ import useSWRMutation from 'swr/mutation'
 interface CreateArticleCommentArgs {
   articleId: string
   comment: string
+  parentId?: number
 }
 
 const createCommentFetcher = async (
@@ -18,6 +19,7 @@ const createCommentFetcher = async (
   const formData = new FormData()
   formData.append('articleId', arg.articleId)
   formData.append('comment', arg.comment)
+  if (arg.parentId) formData.append('parentId', String(arg.parentId))
 
   const res = await fetch(url, {
     method: 'POST',

--- a/src/app/(root)/(routes)/articles/[id]/sections/comment-section.tsx
+++ b/src/app/(root)/(routes)/articles/[id]/sections/comment-section.tsx
@@ -3,13 +3,16 @@
 import { DmReviewCard } from '@/components/dm'
 import { Reply } from '@/lib/type'
 import { useSession } from 'next-auth/react'
-import { FunctionComponent } from 'react'
+import { useParams } from 'next/navigation'
+import { FunctionComponent, useState } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import { ModifyCommentModal } from '../components/modify-comment-modal'
+import { ReplyCommentForm } from '../components/reply-comment-form'
 import { ModifyCommentFormProvider } from '../hooks/modify-comment-context'
 import { useArticleComments } from '../hooks/use-article-comments'
 import { useDeleteArticleComment } from '../hooks/use-delete-article-comment'
 import { useModifyCommentModalContext } from '../hooks/use-modify-comment-context'
+import { useArticleCommentReaction } from '../hooks/use-article-comment-reaction'
 
 const CommentSection: FunctionComponent = () => {
   const { data, next, hasMore, isLoading, error, mutate } = useArticleComments()
@@ -17,6 +20,9 @@ const CommentSection: FunctionComponent = () => {
   const { deleteComment, isDeletingComment } = useDeleteArticleComment(mutate)
   const { setOpen, setComment, setReplyId } = useModifyCommentModalContext()
   const userId = session.data?.user?.id
+  const articleId = String(useParams()?.id ?? '')
+  const [replyingTo, setReplyingTo] = useState<number | null>(null)
+  const { reactComment } = useArticleCommentReaction(() => mutate())
 
   const handleModify = (reply: Reply) => {
     setReplyId(reply.id)
@@ -38,9 +44,7 @@ const CommentSection: FunctionComponent = () => {
   return (
     <div className="px-4 pt-5">
       <div className="mb-4 flex items-center gap-2">
-        <span className="text-[15px] font-semibold text-foreground">
-          댓글
-        </span>
+        <span className="text-[15px] font-semibold text-foreground">댓글</span>
         <span className="font-mono text-[11px] text-muted-foreground">
           {totalCount}
         </span>
@@ -59,25 +63,47 @@ const CommentSection: FunctionComponent = () => {
         <div className="space-y-3">
           {data.map((page) =>
             page?.comments?.map((comment: Reply) => (
-              <DmReviewCard
-                key={comment.id}
-                reply={{
-                  id: comment.id,
-                  content: comment.content,
-                  userno: comment.userno,
-                  nickname: comment.nickname,
-                  avatar: comment.avatar,
-                  updatedAt: new Date(comment.updatedAt),
-                  createdAt: new Date(comment.createdAt),
-                }}
-                onDelete={
-                  isDeletingComment
-                    ? undefined
-                    : () => deleteComment({ commentId: comment.id })
-                }
-                onModify={handleModify}
-                userId={userId}
-              />
+              <div key={comment.id}>
+                <DmReviewCard
+                  reply={comment}
+                  onDelete={
+                    isDeletingComment
+                      ? undefined
+                      : () => deleteComment({ commentId: comment.id })
+                  }
+                  onModify={handleModify}
+                  onReply={() => setReplyingTo(comment.id)}
+                  onReact={(reaction) =>
+                    reactComment({ commentId: comment.id, reaction })
+                  }
+                  userId={userId}
+                />
+                {replyingTo === comment.id && (
+                  <ReplyCommentForm
+                    articleId={articleId}
+                    parent={comment}
+                    onClose={() => setReplyingTo(null)}
+                  />
+                )}
+                {comment.replies?.map((child) => (
+                  <div key={child.id} className="ml-7">
+                    <DmReviewCard
+                      reply={child}
+                      nested
+                      onDelete={
+                        isDeletingComment
+                          ? undefined
+                          : () => deleteComment({ commentId: child.id })
+                      }
+                      onModify={handleModify}
+                      onReact={(reaction) =>
+                        reactComment({ commentId: child.id, reaction })
+                      }
+                      userId={userId}
+                    />
+                  </div>
+                ))}
+              </div>
             )),
           )}
         </div>

--- a/src/app/api/article/comment/[id]/route.test.ts
+++ b/src/app/api/article/comment/[id]/route.test.ts
@@ -1,0 +1,40 @@
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
+import { ArticleRepository } from '@/modules/article/article-repository'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PATCH } from './route'
+
+vi.mock('@/lib/utils/getToken', () => ({
+  getAuthTokenFromRequest: vi.fn(),
+}))
+vi.mock('@/modules/article/article-repository', () => ({
+  ArticleRepository: vi.fn(),
+}))
+
+const mockToken = vi.mocked(getAuthTokenFromRequest)
+const MockRepository = vi.mocked(ArticleRepository)
+
+describe('article comment reaction', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('uses the current token to react to a comment', async () => {
+    const reactComment = vi.fn().mockResolvedValue({ likeCount: 1 })
+    mockToken.mockResolvedValue('oauth-token')
+    MockRepository.mockImplementation(
+      () => ({ reactComment }) as unknown as ArticleRepository,
+    )
+    const form = new FormData()
+    form.set('commentId', '10')
+    form.set('reaction', 'like')
+    const request = new NextRequest('http://localhost/api/article/comment/10', {
+      method: 'PATCH',
+      body: form,
+    })
+
+    const response = await PATCH(request)
+
+    expect(MockRepository).toHaveBeenCalledWith('oauth-token')
+    expect(reactComment).toHaveBeenCalledWith(10, 'like')
+    expect(response.status).toBe(200)
+  })
+})

--- a/src/app/api/article/comment/[id]/route.ts
+++ b/src/app/api/article/comment/[id]/route.ts
@@ -1,11 +1,11 @@
 import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
 import { ArticleRepository } from '@/modules/article/article-repository'
-import { CommentRepository } from '@/modules/comment/comment-repository'
 import { NextRequest } from 'next/server'
 export const POST = async (req: NextRequest) => {
   const form = await req.formData()
   const ArticleId = form.get('articleId') as string
   const comment = form.get('comment') as string
+  const parentId = Number(form.get('parentId')) || undefined
 
   try {
     const token = await getAuthTokenFromRequest(req)
@@ -13,7 +13,7 @@ export const POST = async (req: NextRequest) => {
       return new Response(null, { status: 401 })
     }
     const repo = new ArticleRepository(token)
-    const data = await repo.createComment(ArticleId, comment)
+    const data = await repo.createComment(ArticleId, comment, parentId)
     return new Response(
       JSON.stringify({
         data,
@@ -125,6 +125,27 @@ export const DELETE = async (req: NextRequest) => {
       headers: {
         'Content-Type': 'application/json',
       },
+    })
+  }
+}
+
+export const PATCH = async (req: NextRequest) => {
+  const form = await req.formData()
+  const commentId = Number(form.get('commentId'))
+  const reaction = form.get('reaction') as 'like' | 'dislike'
+  try {
+    const token = await getAuthTokenFromRequest(req)
+    if (!token) return new Response(null, { status: 401 })
+    const repo = new ArticleRepository(token)
+    const data = await repo.reactComment(commentId, reaction)
+    return new Response(JSON.stringify({ data }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    return new Response(JSON.stringify({ message: 'An error occurred' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
     })
   }
 }

--- a/src/components/dm/dm-review-card.tsx
+++ b/src/components/dm/dm-review-card.tsx
@@ -47,9 +47,7 @@ export function DmReviewCard({
       <article
         className={cn('border-b border-border py-3', nested && 'border-l pl-3')}
       >
-        <p className="text-[13px] text-muted-foreground">
-          삭제된 댓글입니다.
-        </p>
+        <p className="text-[13px] text-muted-foreground">삭제된 댓글입니다.</p>
       </article>
     )
   }
@@ -99,33 +97,37 @@ export function DmReviewCard({
       <p className="mt-1.5 break-keep text-[13px] leading-relaxed text-foreground">
         {reply.content}
       </p>
-      {onReact && (
+      {(onReact || (onReply && !nested)) && (
         <div className="mt-2 flex items-center gap-1">
-          <ReactionButton
-            label="좋아요"
-            active={reply.userReaction === 'like'}
-            count={reply.likeCount ?? 0}
-            onClick={() => onReact('like')}
-            icon={<ThumbsUp className="h-3.5 w-3.5" />}
-          />
-          <ReactionButton
-            label="싫어요"
-            active={reply.userReaction === 'dislike'}
-            count={reply.dislikeCount ?? 0}
-            onClick={() => onReact('dislike')}
-            icon={<ThumbsDown className="h-3.5 w-3.5" />}
-          />
+          {onReact && (
+            <>
+              <ReactionButton
+                label="좋아요"
+                active={reply.userReaction === 'like'}
+                count={reply.likeCount ?? 0}
+                onClick={() => onReact('like')}
+                icon={<ThumbsUp className="h-3.5 w-3.5" />}
+              />
+              <ReactionButton
+                label="싫어요"
+                active={reply.userReaction === 'dislike'}
+                count={reply.dislikeCount ?? 0}
+                onClick={() => onReact('dislike')}
+                icon={<ThumbsDown className="h-3.5 w-3.5" />}
+              />
+            </>
+          )}
+          {onReply && !nested && (
+            <button
+              type="button"
+              onClick={() => onReply(reply)}
+              className="inline-flex h-7 items-center gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+            >
+              <MessageCircle className="h-3.5 w-3.5" />
+              답글
+            </button>
+          )}
         </div>
-      )}
-      {onReply && !nested && (
-        <button
-          type="button"
-          onClick={() => onReply(reply)}
-          className="mt-2 inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
-        >
-          <MessageCircle className="h-3.5 w-3.5" />
-          답글
-        </button>
       )}
     </article>
   )

--- a/src/config/article-comment-api-endpoint.ts
+++ b/src/config/article-comment-api-endpoint.ts
@@ -1,0 +1,10 @@
+const base =
+  process.env.SERVER_API ||
+  process.env.NEXT_PUBLIC_SERVER_API ||
+  'http://127.0.0.1:3030'
+
+export const ArticleCommentApiEndpoint = {
+  backendReaction: (commentId: number) =>
+    `${base}/article/comments/${commentId}/reaction`,
+  clientReaction: () => '/api/article/comment/reaction',
+}

--- a/src/modules/article/article-datasource.ts
+++ b/src/modules/article/article-datasource.ts
@@ -1,4 +1,5 @@
 import { AppBackEndApiEndpoint } from '@/config/app-backend-api-endpoint'
+import { ArticleCommentApiEndpoint } from '@/config/article-comment-api-endpoint'
 import { Article, LikeState } from '@/lib/type'
 
 export class ArticleDatasource {
@@ -123,7 +124,7 @@ export class ArticleDatasource {
     }
     return res.json()
   }
-  async createComment(id: string, comment: string) {
+  async createComment(id: string, comment: string, parentId?: number) {
     const res = await fetch(AppBackEndApiEndpoint.createArticleComment(+id), {
       method: 'POST',
       headers: {
@@ -133,6 +134,7 @@ export class ArticleDatasource {
       cache: 'no-cache',
       body: JSON.stringify({
         content: comment,
+        parentId,
       }),
     })
     if (!res.ok) {
@@ -171,6 +173,19 @@ export class ArticleDatasource {
     if (!res.ok) {
       throw new Error('댓글을 수정할 수 없습니다.')
     }
+    return res.json()
+  }
+
+  async reactComment(id: number, reaction: 'like' | 'dislike') {
+    const res = await fetch(ArticleCommentApiEndpoint.backendReaction(id), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify({ reaction }),
+    })
+    if (!res.ok) throw new Error('댓글 반응을 저장할 수 없습니다.')
     return res.json()
   }
 }

--- a/src/modules/article/article-repository.test.ts
+++ b/src/modules/article/article-repository.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ArticleRepository } from './article-repository'
+
+vi.mock('./article-datasource', () => ({ ArticleDatasource: class {} }))
+
+describe('ArticleRepository comments', () => {
+  it('keeps nested replies, reactions, and edit state', async () => {
+    const getCommentList = vi.fn().mockResolvedValue({
+      comments: [
+        {
+          id: 1,
+          userno: 4,
+          content: '원댓글',
+          nickname: '볼래',
+          avatar: 'avatar.png',
+          createdAt: '2026-07-17T00:00:00.000Z',
+          updatedAt: '2026-07-17T00:00:00.000Z',
+          likeCount: 2,
+          dislikeCount: 1,
+          userReaction: 'like',
+          isEdited: true,
+          replies: [
+            {
+              id: 2,
+              userno: 5,
+              content: '대댓글',
+              nickname: '영화팬',
+              avatar: 'reply.png',
+              createdAt: '2026-07-17T00:01:00.000Z',
+              updatedAt: '2026-07-17T00:01:00.000Z',
+              parentId: 1,
+              replies: [],
+            },
+          ],
+        },
+      ],
+      hasNext: false,
+      totalCount: 1,
+    })
+    const repository = new ArticleRepository(undefined, {
+      getCommentList,
+    } as never)
+
+    const result = await repository.getCommentList('4', 1)
+
+    expect(result.comments[0]).toMatchObject({
+      likeCount: 2,
+      userReaction: 'like',
+      isEdited: true,
+    })
+    expect(result.comments[0].replies?.[0]).toMatchObject({
+      content: '대댓글',
+      parentId: 1,
+    })
+  })
+
+  it('forwards a reaction through the datasource', async () => {
+    const reactComment = vi.fn().mockResolvedValue({ likeCount: 1 })
+    const repository = new ArticleRepository(undefined, {
+      reactComment,
+    } as never)
+
+    await (repository as any).reactComment(10, 'like')
+
+    expect(reactComment).toHaveBeenCalledWith(10, 'like')
+  })
+})

--- a/src/modules/article/article-repository.ts
+++ b/src/modules/article/article-repository.ts
@@ -105,8 +105,16 @@ export class ArticleRepository {
       dislikes: data.dislikes,
     }
   }
-  async createComment(articleId: string, comment: string): Promise<Reply> {
-    const data = await this.datasource.createComment(articleId, comment)
+  async createComment(
+    articleId: string,
+    comment: string,
+    parentId?: number,
+  ): Promise<Reply> {
+    const data = await this.datasource.createComment(
+      articleId,
+      comment,
+      parentId,
+    )
     return this.convertUnknownToComment(data)
   }
   private convertUnknownToComment(unknown: any): Reply {
@@ -118,6 +126,15 @@ export class ArticleRepository {
       avatar: unknown.avatar,
       createdAt: new Date(unknown.createdAt),
       updatedAt: new Date(unknown.updatedAt),
+      parentId: unknown.parentId || undefined,
+      replies: unknown.replies?.map((reply: unknown) =>
+        this.convertUnknownToComment(reply),
+      ),
+      likeCount: unknown.likeCount ?? 0,
+      dislikeCount: unknown.dislikeCount ?? 0,
+      userReaction: unknown.userReaction || undefined,
+      isEdited: unknown.isEdited ?? false,
+      isDeleted: unknown.isDeleted ?? false,
     }
     assertArticleComment(result)
     return result
@@ -142,5 +159,8 @@ export class ArticleRepository {
   async modifyComment(id: string, comment: string): Promise<Reply> {
     const data = await this.datasource.modifyComment(id, comment)
     return data
+  }
+  async reactComment(id: number, reaction: 'like' | 'dislike') {
+    return this.datasource.reactComment(id, reaction)
   }
 }


### PR DESCRIPTION
## Summary
영화 댓글 액션을 한 행으로 정리하고 아티클 댓글에 반응·대댓글 UI를 추가합니다.

## 원인
답글 버튼이 좋아요·싫어요와 분리되어 줄바꿈됐고, 아티클 댓글에는 동일한 상호작용이 없었습니다.

## 변경
- 좋아요·싫어요·답글을 하나의 액션 행에 배치
- 아티클 원댓글·대댓글 반응, 작성, 수정, 삭제 연결
- 삭제된 댓글 및 수정됨 상태 렌더링
- OAuth 세션 토큰을 사용하는 BFF 반응 요청 추가

## Test plan
- [x] Vitest 3개
- [x] pnpm lint
- [x] pnpm build
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)