### PR TITLE
🐛 프로필 이미지 조회 원본 통일

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -85,7 +85,7 @@ const Page: FunctionComponent = async () => {
 
       <div className="flex items-center gap-2 px-4 pb-3 pt-5">
         <h2 className="text-[16px] font-semibold text-foreground">박스오피스</h2>
-        <span className="font-mono text-[10px] text-muted-foreground">KOFIC · TOP 10</span>
+        <span className="font-mono text-[10px] text-muted-foreground">TOP 10</span>
       </div>
 
       <div className="grid gap-3 px-4 lg:grid-cols-2">

--- a/src/app/(root)/(routes)/chat/[chatRoomId]/page.tsx
+++ b/src/app/(root)/(routes)/chat/[chatRoomId]/page.tsx
@@ -2,7 +2,7 @@
 
 import useChatSocket from '@/app/(root)/(routes)/(home)/hooks/use-chat-socket'
 import { DmChatBubble, DmUserAvatar } from '@/components/dm'
-import { ChatMessageEntity } from '@/modules/chat'
+import { ChatMessageEntity, findChatMemberProfile } from '@/modules/chat'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
@@ -48,9 +48,8 @@ export default function ChatRoomPage({ params: { chatRoomId } }: PageProps) {
     }),
   )
   const messages = [...serverMessages, ...localMessages]
-  const targetProfile = room?.memberProfiles?.find(
-    (profile: { userId: number }) => profile.userId !== myUserId,
-  )
+  const targetUserId = room?.memberIds?.find((id: number) => id !== myUserId)
+  const targetProfile = findChatMemberProfile(room, targetUserId ?? 0)
 
   const { sendMessage, isConnected } = useChatSocket({
     namespace: 'ws-home',

--- a/src/app/(root)/(routes)/chat/public/components/public-chat-avatar.tsx
+++ b/src/app/(root)/(routes)/chat/public/components/public-chat-avatar.tsx
@@ -2,8 +2,8 @@
 
 import { forwardRef } from 'react'
 import type { ButtonHTMLAttributes } from 'react'
-import { UserRound } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { DmUserAvatar } from '@/components/dm'
 
 interface PublicChatAvatarProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -14,14 +14,7 @@ interface PublicChatAvatarProps
 export const PublicChatAvatar = forwardRef<
   HTMLButtonElement,
   PublicChatAvatarProps
->(function PublicChatAvatar({
-  image,
-  nickName,
-  className,
-  ...props
-}, ref) {
-  const initial = nickName.trim().charAt(0).toUpperCase()
-
+>(function PublicChatAvatar({ image, nickName, className, ...props }, ref) {
   return (
     <button
       ref={ref}
@@ -29,18 +22,15 @@ export const PublicChatAvatar = forwardRef<
       aria-label={`${nickName} 프로필 메뉴 열기`}
       className={cn(
         'mt-1 flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-background text-[13px] font-semibold text-muted-foreground',
-        className
+        className,
       )}
       {...props}
     >
-      {image ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={image} alt="" className="h-full w-full object-cover" />
-      ) : initial ? (
-        initial
-      ) : (
-        <UserRound className="h-4 w-4" />
-      )}
+      <DmUserAvatar
+        name={nickName}
+        image={image}
+        className="h-full w-full border-0"
+      />
     </button>
   )
 })

--- a/src/app/(root)/(routes)/match/[id]/chat/[targetUserId]/components/chat-container.tsx
+++ b/src/app/(root)/(routes)/match/[id]/chat/[targetUserId]/components/chat-container.tsx
@@ -3,8 +3,8 @@
 import useChatSocket from '@/app/(root)/(routes)/(home)/hooks/use-chat-socket'
 import { useChatRoom } from '@/app/(root)/(routes)/match/hooks/use-chat-room'
 import { useMatchPost } from '@/app/(root)/(routes)/match/hooks/use-match-post'
-import { DmChatBubble, DmChatTicketPin } from '@/components/dm'
-import { ChatMessageEntity } from '@/modules/chat'
+import { DmChatBubble, DmChatTicketPin, DmUserAvatar } from '@/components/dm'
+import { ChatMessageEntity, findChatMemberProfile } from '@/modules/chat'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
@@ -82,10 +82,13 @@ const ChatContainer = ({ matchId, targetUserId }: ChatContainerProps) => {
     return <ChatStatus>채팅방을 준비하고 있습니다...</ChatStatus>
   }
 
+  const targetProfile = findChatMemberProfile(chatRoom, Number(targetUserId))
   const targetName =
-    matchPost.userno.toString() === targetUserId
+    targetProfile?.nickname ||
+    (matchPost.userno.toString() === targetUserId
       ? matchPost.author
-      : `사용자 ${targetUserId}`
+      : `사용자 ${targetUserId}`)
+  const targetImage = targetProfile?.image
   const myUserId = parseInt(session?.user?.id || '0')
   const initial = targetName.charAt(0).toUpperCase()
 
@@ -108,12 +111,12 @@ const ChatContainer = ({ matchId, targetUserId }: ChatContainerProps) => {
             />
           </svg>
         </button>
-        <span
-          aria-hidden
-          className="flex h-9 w-9 items-center justify-center rounded-full border border-border bg-secondary text-[14px] font-bold text-foreground"
-        >
-          {initial}
-        </span>
+        <DmUserAvatar
+          name={targetName}
+          image={targetImage}
+          className="h-9 w-9"
+          fallbackClassName="text-[14px]"
+        />
         <div className="min-w-0 flex-1">
           <div className="text-[14px] font-semibold text-foreground">
             {targetName}
@@ -149,11 +152,12 @@ const ChatContainer = ({ matchId, targetUserId }: ChatContainerProps) => {
                 content={message.content}
                 isMine={isMine}
                 senderName={
-                  isMine ? undefined : message.senderName ?? targetName
+                  isMine ? undefined : (message.senderName ?? targetName)
                 }
                 createdAt={message.createdAt}
                 showAvatar={showAvatar}
                 avatarInitial={initial}
+                avatarImage={targetImage}
               />
             )
           })

--- a/src/app/api/auth/[...nextauth]/next-option.ts
+++ b/src/app/api/auth/[...nextauth]/next-option.ts
@@ -5,6 +5,7 @@ import { AppPath } from '@/config/app-path'
 import * as jose from 'jose'
 import { AppEnv } from '@/config/app-env'
 import GoogleProvider from 'next-auth/providers/google'
+import { syncSessionUser } from '@/lib/utils/session-user'
 
 export const authOptions: AuthOptions = {
   providers: [
@@ -114,13 +115,9 @@ export const authOptions: AuthOptions = {
     },
 
     async session({ session, token }) {
-      if (token) {
-        session.user.id = token.userId ?? ''
-        session.user.nickname = token.nickname ?? ''
-        session.user.provider = token.provider ?? ''
-        session.user.image = token.image ?? ''
-      }
-      return session
+      if (!token) return session
+      const repo = new UsersRepository()
+      return syncSessionUser(session, token, (id) => repo.getUser(id))
     },
   },
 }

--- a/src/lib/utils/session-user.test.ts
+++ b/src/lib/utils/session-user.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { syncSessionUser } from './session-user'
+
+describe('syncSessionUser', () => {
+  it('prefers the current database profile over stale token values', async () => {
+    const session = {
+      user: { id: '', nickname: '', provider: '', image: '' },
+      expires: '2099-01-01',
+    }
+    const getUser = vi.fn().mockResolvedValue({
+      id: 4,
+      nickname: '현재 닉네임',
+      image: 'current.png',
+    })
+
+    const result = await syncSessionUser(
+      session as any,
+      {
+        userId: 4,
+        nickname: '이전 닉네임',
+        image: 'old.png',
+        provider: 'google',
+      } as any,
+      getUser,
+    )
+
+    expect(result.user).toMatchObject({
+      id: 4,
+      nickname: '현재 닉네임',
+      image: 'current.png',
+      provider: 'google',
+    })
+  })
+})

--- a/src/lib/utils/session-user.ts
+++ b/src/lib/utils/session-user.ts
@@ -1,0 +1,40 @@
+import type { Session } from 'next-auth'
+import type { JWT } from 'next-auth/jwt'
+
+interface CurrentUserProfile {
+  id: number | string
+  nickname?: string | null
+  image?: string | null
+}
+
+type GetCurrentUser = (_id: number) => Promise<CurrentUserProfile>
+
+export async function syncSessionUser(
+  session: Session,
+  token: JWT,
+  getCurrentUser: GetCurrentUser,
+) {
+  const userId = Number(token.userId)
+  let currentUser: CurrentUserProfile | null = null
+
+  if (Number.isInteger(userId) && userId > 0) {
+    try {
+      currentUser = await getCurrentUser(userId)
+    } catch {
+      currentUser = null
+    }
+  }
+
+  const id = currentUser?.id ?? token.userId ?? ''
+  const nickname = currentUser?.nickname ?? token.nickname ?? ''
+  const image = currentUser?.image ?? token.image ?? ''
+
+  session.user.id = id as string
+  session.user.nickname = nickname
+  session.user.provider = token.provider ?? ''
+  session.user.image = image
+  token.nickname = nickname
+  token.image = image
+
+  return session
+}

--- a/src/modules/chat/chat-profile.test.ts
+++ b/src/modules/chat/chat-profile.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { findChatMemberProfile } from './chat-profile'
+
+describe('findChatMemberProfile', () => {
+  it('returns the requested member current profile', () => {
+    const profile = findChatMemberProfile(
+      {
+        chatRoomId: 'room-1',
+        roomName: '채팅방',
+        type: 'direct',
+        memberIds: [4, 7],
+        memberProfiles: [
+          { userId: 4, nickname: '나', image: 'me.png' },
+          { userId: 7, nickname: '상대방', image: 'target.png' },
+        ],
+        createdAt: '2026-07-17',
+        updatedAt: '2026-07-17',
+      },
+      7,
+    )
+
+    expect(profile).toEqual({
+      userId: 7,
+      nickname: '상대방',
+      image: 'target.png',
+    })
+  })
+})

--- a/src/modules/chat/chat-profile.ts
+++ b/src/modules/chat/chat-profile.ts
@@ -1,0 +1,8 @@
+import type { ChatRoomEntity, ChatRoomMemberProfileEntity } from './chat.entity'
+
+export function findChatMemberProfile(
+  room: ChatRoomEntity | null | undefined,
+  userId: number,
+): ChatRoomMemberProfileEntity | undefined {
+  return room?.memberProfiles?.find((profile) => profile.userId === userId)
+}

--- a/src/modules/chat/index.ts
+++ b/src/modules/chat/index.ts
@@ -1,3 +1,4 @@
 export * from './chat.entity'
+export * from './chat-profile'
 export { ChatDatasource } from './chat-datasource'
 export { ChatRepository } from './chat-repository'


### PR DESCRIPTION
## Summary
홈 박스오피스 문구를 정리하고, 계정·댓글·채팅의 아바타가 DB의 현재 프로필 이미지를 일관되게 사용하도록 수정합니다.

## 원인
NextAuth 세션 이미지와 DB User.image가 달랐고, 공개/매칭 채팅 일부는 저장 당시 이미지 또는 한 글자 아바타를 사용했습니다.

## 변경
- `KOFIC · TOP 10`을 `TOP 10`으로 변경
- 세션 생성 시 현재 User 프로필을 조회해 DB 이미지를 단일 원본으로 사용
- 일반·매칭 채팅에서 memberProfiles의 현재 상대방 이미지 사용
- 공개채팅 아바타를 공통 DmUserAvatar로 통일
- 세션/채팅 프로필 선택 회귀 테스트 추가

## Test plan
- [x] Vitest 전체 21개 통과
- [x] `pnpm lint`
- [x] 운영 환경 변수 기준 `pnpm build`
- [x] 변경 파일 200줄 상한 및 `git diff --check`

🤖 Generated with Codex