### PR TITLE
🐛 댓글 삭제 확인 다이얼로그 추가

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/components/comment-delete-confirmation.test.ts
+++ b/src/app/(root)/(routes)/movie/[id]/components/comment-delete-confirmation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+import { confirmCommentDeletion } from './comment-delete-confirmation'
+
+describe('confirmCommentDeletion', () => {
+  it('선택한 댓글을 삭제하고 성공한 뒤 다이얼로그를 닫는다', () => {
+    const closeDialog = vi.fn()
+    let succeed: (() => void) | undefined
+    const deleteComment = vi.fn((_args, options) => {
+      succeed = options.onSuccess
+    })
+
+    confirmCommentDeletion(27, deleteComment, closeDialog)
+
+    expect(deleteComment).toHaveBeenCalledWith(
+      { commentId: 27 },
+      { onSuccess: closeDialog },
+    )
+    expect(closeDialog).not.toHaveBeenCalled()
+
+    succeed?.()
+
+    expect(closeDialog).toHaveBeenCalledOnce()
+  })
+})

--- a/src/app/(root)/(routes)/movie/[id]/components/comment-delete-confirmation.ts
+++ b/src/app/(root)/(routes)/movie/[id]/components/comment-delete-confirmation.ts
@@ -1,0 +1,16 @@
+interface DeleteCommentOptions {
+  onSuccess?: () => void
+}
+
+type DeleteComment = (
+  _args: { commentId: number },
+  _options?: DeleteCommentOptions,
+) => void
+
+export function confirmCommentDeletion(
+  commentId: number,
+  deleteComment: DeleteComment,
+  closeDialog: () => void,
+) {
+  deleteComment({ commentId }, { onSuccess: closeDialog })
+}

--- a/src/app/(root)/(routes)/movie/[id]/components/delete-comment-dialog.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/components/delete-comment-dialog.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface DeleteCommentDialogProps {
+  open: boolean
+  hasReplies: boolean
+  isDeleting: boolean
+  onOpenChange: (_open: boolean) => void
+  onConfirm: () => void
+}
+
+export function DeleteCommentDialog({
+  open,
+  hasReplies,
+  isDeleting,
+  onOpenChange,
+  onConfirm,
+}: DeleteCommentDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-[calc(100vw-2rem)] rounded-lg sm:max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>댓글을 삭제하시겠습니까?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {hasReplies
+              ? '답글이 있어 댓글 내용만 “삭제된 댓글입니다.”로 표시됩니다.'
+              : '삭제한 댓글은 되돌릴 수 없습니다.'}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>취소</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isDeleting}
+            onClick={(event) => {
+              event.preventDefault()
+              onConfirm()
+            }}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isDeleting ? '삭제 중...' : '삭제'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/app/(root)/(routes)/movie/[id]/sections/comment-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/comment-section.tsx
@@ -6,6 +6,8 @@ import { useSession } from 'next-auth/react'
 import { FunctionComponent, useState } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import { CommentForm } from '../components/comment-form'
+import { confirmCommentDeletion } from '../components/comment-delete-confirmation'
+import { DeleteCommentDialog } from '../components/delete-comment-dialog'
 import { ModifyCommentModal } from '../components/modify-comment-modal'
 import { ReplyCommentForm } from '../components/reply-comment-form'
 import { CommentFormProvider } from '../hooks/comment-form-context'
@@ -19,18 +21,34 @@ interface CommentSectionProps {
 }
 
 const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
-  const { data, next, hasMore, isLoading, error, deleteComment, refresh } =
-    useComments()
+  const {
+    data,
+    next,
+    hasMore,
+    isLoading,
+    error,
+    deleteComment,
+    isDeletingComment,
+    refresh,
+  } = useComments()
   const session = useSession()
   const userId = session.data?.user?.id
   const { reactComment } = useCommentReaction(() => refresh())
   const { setOpen, setComment, setReplyId } = useModifyCommentModalContext()
   const [replyingTo, setReplyingTo] = useState<number | null>(null)
+  const [deletingComment, setDeletingComment] = useState<Reply | null>(null)
 
   const handleModifyComment = (reply: Reply) => {
     setReplyId(reply.id)
     setComment(reply.content)
     setOpen(true)
+  }
+
+  const handleConfirmDelete = () => {
+    if (!deletingComment) return
+    confirmCommentDeletion(deletingComment.id, deleteComment, () =>
+      setDeletingComment(null),
+    )
   }
 
   const totalCount = data
@@ -76,7 +94,7 @@ const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
                 <div key={comment.id}>
                   <DmReviewCard
                     reply={comment}
-                    onDelete={() => deleteComment({ commentId: comment.id })}
+                    onDelete={setDeletingComment}
                     onModify={handleModifyComment}
                     onReply={() => setReplyingTo(comment.id)}
                     onReact={(reaction) =>
@@ -96,7 +114,7 @@ const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
                       <DmReviewCard
                         reply={child}
                         nested
-                        onDelete={() => deleteComment({ commentId: child.id })}
+                        onDelete={setDeletingComment}
                         onModify={handleModifyComment}
                         onReact={(reaction) =>
                           reactComment({ commentId: child.id, reaction })
@@ -115,6 +133,16 @@ const CommentSection: FunctionComponent<CommentSectionProps> = ({ id }) => {
       <ModifyCommentFormProvider>
         <ModifyCommentModal />
       </ModifyCommentFormProvider>
+
+      <DeleteCommentDialog
+        open={Boolean(deletingComment)}
+        hasReplies={Boolean(deletingComment?.replies?.length)}
+        isDeleting={isDeletingComment}
+        onOpenChange={(open) => {
+          if (!open && !isDeletingComment) setDeletingComment(null)
+        }}
+        onConfirm={handleConfirmDelete}
+      />
 
       {error && (
         <div className="py-4 text-center font-mono text-[11px] text-destructive">


### PR DESCRIPTION
## Summary
영화 댓글과 대댓글 삭제 전에 확인 다이얼로그를 표시합니다.

## 원인
기존 삭제 아이콘은 클릭 즉시 삭제 API를 호출해 실수로 댓글을 지울 수 있었습니다.

## 변경
- 삭제 대상 댓글을 선택한 뒤 확인 다이얼로그 표시
- 확인 시에만 삭제 요청, 성공 시 다이얼로그 닫기
- 답글이 있는 댓글은 내용만 삭제 표시로 남는다는 안내 추가
- 삭제 중 중복 요청과 다이얼로그 닫기 방지

## Test plan
- [x] `pnpm test -- --run` (13 files, 22 tests)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 및 신규 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)