### PR TITLE
🐛 아티클 에디터 모바일 조작 개선

### DIFF
--- a/src/components/app/article-markdown-editor-controls.tsx
+++ b/src/components/app/article-markdown-editor-controls.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/lib/utils'
+import type { ReactNode } from 'react'
+
+interface EditorButtonProps {
+  children: ReactNode
+  disabled?: boolean
+  onClick: () => void
+  title: string
+}
+
+export function EditorButton({
+  children,
+  disabled,
+  onClick,
+  title,
+}: EditorButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={title}
+      title={title}
+      onClick={onClick}
+      disabled={disabled}
+      className="flex h-11 w-11 shrink-0 touch-manipulation items-center justify-center rounded-md border border-border bg-transparent text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50 sm:h-9 sm:w-9"
+    >
+      {children}
+    </button>
+  )
+}
+
+export function ModeButton({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean
+  children: ReactNode
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        'h-10 touch-manipulation rounded px-2.5 text-[12px] text-muted-foreground',
+        active && 'bg-secondary font-medium text-foreground shadow-sm',
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/app/article-markdown-editor-mobile.test.ts
+++ b/src/components/app/article-markdown-editor-mobile.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const editorPath = fileURLToPath(
+  new URL('./article-markdown-editor.tsx', import.meta.url),
+)
+
+describe('article markdown editor mobile controls', () => {
+  const source = readFileSync(editorPath, 'utf8')
+
+  it('opens the image picker through a native label control', () => {
+    expect(source).toContain('htmlFor={fileInputId}')
+    expect(source).not.toContain('fileInputRef.current?.click()')
+  })
+
+  it('provides separate write and preview modes on mobile', () => {
+    expect(source).toContain("useState<'write' | 'preview'>('write')")
+    expect(source).toContain("editorMode === 'preview'")
+  })
+})

--- a/src/components/app/article-markdown-editor-utils.test.ts
+++ b/src/components/app/article-markdown-editor-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { insertMarkdownText } from './article-markdown-editor-utils'
+
+describe('insertMarkdownText', () => {
+  it('선택 영역을 마크다운 텍스트로 교체하고 커서를 뒤로 이동한다', () => {
+    expect(insertMarkdownText('영화 감상평', '**좋아요**', 3, 6)).toEqual({
+      value: '영화 **좋아요**',
+      cursor: 10,
+    })
+  })
+
+  it('선택 영역이 없으면 현재 커서 위치에 삽입한다', () => {
+    expect(insertMarkdownText('영화', '\n- 항목', 2, 2)).toEqual({
+      value: '영화\n- 항목',
+      cursor: 7,
+    })
+  })
+})

--- a/src/components/app/article-markdown-editor-utils.ts
+++ b/src/components/app/article-markdown-editor-utils.ts
@@ -1,0 +1,11 @@
+export function insertMarkdownText(
+  current: string,
+  text: string,
+  start: number,
+  end: number,
+) {
+  return {
+    value: `${current.slice(0, start)}${text}${current.slice(end)}`,
+    cursor: start + text.length,
+  }
+}

--- a/src/components/app/article-markdown-editor.tsx
+++ b/src/components/app/article-markdown-editor.tsx
@@ -8,10 +8,12 @@ import {
 } from '@/components/ui/form'
 import { MarkdownContent } from '@/components/app/markdown-content'
 import { useAppToast } from '@/hooks/use-app-toast'
+import { cn } from '@/lib/utils'
 import { Bold, ImagePlus, Italic, List } from 'lucide-react'
-import type { ReactNode } from 'react'
-import { useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
+import { EditorButton, ModeButton } from './article-markdown-editor-controls'
+import { insertMarkdownText } from './article-markdown-editor-utils'
 
 interface ArticleMarkdownEditorProps {
   form: UseFormReturn<any>
@@ -24,19 +26,23 @@ export function ArticleMarkdownEditor({
 }: ArticleMarkdownEditorProps) {
   const { showToast } = useAppToast()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
-  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const fileInputId = useId()
   const [uploading, setUploading] = useState(false)
+  const [editorMode, setEditorMode] = useState<'write' | 'preview'>('write')
 
   const insertText = (text: string) => {
     const current = form.getValues(name) ?? ''
     const target = textareaRef.current
     const start = target?.selectionStart ?? current.length
     const end = target?.selectionEnd ?? current.length
-    const next = `${current.slice(0, start)}${text}${current.slice(end)}`
-    form.setValue(name, next, { shouldDirty: true, shouldValidate: true })
+    const result = insertMarkdownText(current, text, start, end)
+    form.setValue(name, result.value, {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
     requestAnimationFrame(() => {
       target?.focus()
-      target?.setSelectionRange(start + text.length, start + text.length)
+      target?.setSelectionRange(result.cursor, result.cursor)
     })
   }
 
@@ -56,7 +62,7 @@ export function ArticleMarkdownEditor({
       render={({ field }) => (
         <FormItem className="w-full">
           <div className="rounded-md border border-border bg-secondary">
-            <div className="flex items-center gap-1 border-b border-border p-2">
+            <div className="flex items-center gap-1 overflow-x-auto border-b border-border p-2">
               <EditorButton title="굵게" onClick={() => insertText('**텍스트**')}>
                 <Bold className="h-4 w-4" />
               </EditorButton>
@@ -66,36 +72,58 @@ export function ArticleMarkdownEditor({
               <EditorButton title="목록" onClick={() => insertText('\n- 항목')}>
                 <List className="h-4 w-4" />
               </EditorButton>
-              <EditorButton
-                title="이미지"
-                disabled={uploading}
-                onClick={() => fileInputRef.current?.click()}
+              <label
+                htmlFor={fileInputId}
+                title="이미지 추가"
+                className={cn(
+                  'relative flex h-11 w-11 shrink-0 touch-manipulation items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground sm:h-9 sm:w-9',
+                  uploading && 'pointer-events-none opacity-50',
+                )}
               >
                 <ImagePlus className="h-4 w-4" />
-              </EditorButton>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={async (event) => {
-                  const file = event.target.files?.[0]
-                  event.target.value = ''
-                  if (!file) return
-                  try {
-                    setUploading(true)
-                    await uploadImage(file)
-                    showToast('이미지를 추가했습니다.')
-                  } catch {
-                    showToast('이미지 업로드에 실패했습니다.')
-                  } finally {
-                    setUploading(false)
-                  }
-                }}
-              />
+                <span className="sr-only">
+                  {uploading ? '이미지 업로드 중' : '이미지 추가'}
+                </span>
+                <input
+                  id={fileInputId}
+                  type="file"
+                  accept="image/*"
+                  disabled={uploading}
+                  aria-label="이미지 추가"
+                  className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                  onChange={async (event) => {
+                    const file = event.target.files?.[0]
+                    event.target.value = ''
+                    if (!file) return
+                    try {
+                      setUploading(true)
+                      await uploadImage(file)
+                      showToast('이미지를 추가했습니다.')
+                    } catch {
+                      showToast('이미지 업로드에 실패했습니다.')
+                    } finally {
+                      setUploading(false)
+                    }
+                  }}
+                />
+              </label>
+              <div className="ml-auto flex shrink-0 rounded-md bg-background p-0.5 lg:hidden">
+                <ModeButton
+                  active={editorMode === 'write'}
+                  onClick={() => setEditorMode('write')}
+                >
+                  작성
+                </ModeButton>
+                <ModeButton
+                  active={editorMode === 'preview'}
+                  onClick={() => setEditorMode('preview')}
+                >
+                  미리보기
+                </ModeButton>
+              </div>
             </div>
             <FormControl>
-              <div className="grid min-h-[520px] grid-rows-[minmax(260px,1fr)_minmax(220px,0.8fr)] lg:min-h-[440px] lg:grid-cols-2 lg:grid-rows-1">
+              <div className="min-h-[360px] lg:grid lg:min-h-[440px] lg:grid-cols-2">
                 <textarea
                   {...field}
                   ref={(element) => {
@@ -104,10 +132,18 @@ export function ArticleMarkdownEditor({
                   }}
                   rows={14}
                   placeholder="내용을 입력해주세요."
-                  className="min-h-[260px] w-full resize-none bg-transparent px-3.5 py-3 text-[14px] leading-6 text-foreground placeholder:text-muted-foreground focus:outline-none lg:min-h-[440px]"
+                  className={cn(
+                    'min-h-[360px] w-full resize-none bg-transparent px-3.5 py-3 text-[16px] leading-7 text-foreground placeholder:text-muted-foreground focus:outline-none lg:block lg:min-h-[440px] lg:text-[14px] lg:leading-6',
+                    editorMode === 'preview' && 'hidden',
+                  )}
                 />
-                <div className="border-t border-border bg-background px-3.5 py-3 lg:border-l lg:border-t-0">
-                  <div className="h-full min-h-[220px] overflow-y-auto">
+                <div
+                  className={cn(
+                    'min-h-[360px] bg-background px-3.5 py-3 lg:block lg:min-h-[440px] lg:border-l lg:border-border',
+                    editorMode === 'write' && 'hidden',
+                  )}
+                >
+                  <div className="h-full min-h-[336px] overflow-y-auto">
                     {field.value ? (
                       <MarkdownContent content={field.value} />
                     ) : (
@@ -124,29 +160,5 @@ export function ArticleMarkdownEditor({
         </FormItem>
       )}
     />
-  )
-}
-
-function EditorButton({
-  children,
-  disabled,
-  onClick,
-  title,
-}: {
-  children: ReactNode
-  disabled?: boolean
-  onClick: () => void
-  title: string
-}) {
-  return (
-    <button
-      type="button"
-      title={title}
-      onClick={onClick}
-      disabled={disabled}
-      className="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-transparent text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
-    >
-      {children}
-    </button>
   )
 }


### PR DESCRIPTION
## Summary
모바일 아티클 작성 화면에서 에디터 툴바와 이미지 추가가 안정적으로 동작하도록 개선합니다.

## 원인
모바일 Safari 계열에서 `display:none` 파일 입력을 자바스크립트로 클릭하는 방식이 파일 선택기를 열지 못할 수 있었고, 32px 도구 버튼과 작성/미리보기 동시 배치가 터치 조작에 불리했습니다.

## 변경
- 이미지 추가를 실제 파일 입력이 터치 영역을 직접 받는 네이티브 방식으로 변경
- 모바일 도구 버튼을 44px 터치 크기로 확대
- 모바일에서 작성/미리보기 전환 모드 제공, 데스크톱은 기존 2열 유지
- iOS 입력 확대 방지를 위한 모바일 textarea 16px 적용
- 마크다운 삽입 및 모바일 동작 회귀 테스트 추가

## Test plan
- [x] `pnpm test -- --run` (16 files, 27 tests)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 변경 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 운영 `/articles/new` 응답 및 배포 번들 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)