### PR TITLE
🐛 아티클 이미지 포맷·오류 처리 개선

### DIFF
--- a/src/components/app/article-image-file.test.ts
+++ b/src/components/app/article-image-file.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ARTICLE_IMAGE_MAX_BYTES,
+  getArticleImageUploadError,
+  prepareArticleImage,
+} from './article-image-file'
+
+describe('prepareArticleImage', () => {
+  it('keeps an animated GIF unchanged', async () => {
+    const gif = new File(['gif89a'], 'reaction.gif', { type: 'image/gif' })
+    const convertHeic = vi.fn()
+
+    const result = await prepareArticleImage(gif, convertHeic)
+
+    expect(result).toBe(gif)
+    expect(convertHeic).not.toHaveBeenCalled()
+  })
+
+  it('converts an iPhone HEIC file even when its MIME type is empty', async () => {
+    const heic = new File(['heic'], 'IMG_0001.HEIC')
+    const jpeg = new File(['jpeg'], 'IMG_0001.jpg', { type: 'image/jpeg' })
+    const convertHeic = vi.fn().mockResolvedValue(jpeg)
+
+    await expect(prepareArticleImage(heic, convertHeic)).resolves.toBe(jpeg)
+    expect(convertHeic).toHaveBeenCalledWith(heic)
+  })
+
+  it('rejects files larger than the upload limit', async () => {
+    const oversized = {
+      name: 'large.gif',
+      type: 'image/gif',
+      size: ARTICLE_IMAGE_MAX_BYTES + 1,
+    } as File
+
+    await expect(prepareArticleImage(oversized, vi.fn())).rejects.toThrow(
+      '20MB 이하',
+    )
+  })
+
+  it('rejects image formats that browsers cannot display', async () => {
+    const raw = new File(['raw'], 'IMG_0002.DNG', {
+      type: 'image/x-adobe-dng',
+    })
+
+    await expect(prepareArticleImage(raw, vi.fn())).rejects.toThrow(
+      '지원하지 않는 이미지 형식',
+    )
+  })
+
+  it('explains a reverse-proxy size rejection', () => {
+    expect(getArticleImageUploadError(413)).toBe(
+      '이미지는 20MB 이하만 업로드할 수 있어요.',
+    )
+  })
+})

--- a/src/components/app/article-image-file.ts
+++ b/src/components/app/article-image-file.ts
@@ -1,0 +1,82 @@
+export const ARTICLE_IMAGE_MAX_BYTES = 20 * 1024 * 1024
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  avif: 'image/avif',
+  gif: 'image/gif',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+}
+
+type HeicConverter = (_file: File) => Promise<File>
+
+export async function prepareArticleImage(
+  file: File,
+  convertHeic: HeicConverter = convertHeicToJpeg,
+): Promise<File> {
+  validateSize(file)
+  const extension = getExtension(file.name)
+
+  if (isHeic(file, extension)) {
+    const converted = await convertHeic(file)
+    validateSize(converted)
+    return converted
+  }
+
+  const inferredType = MIME_BY_EXTENSION[extension]
+  const genericType = !file.type || file.type === 'application/octet-stream'
+  const supportedType = Object.values(MIME_BY_EXTENSION).includes(file.type)
+
+  if (!supportedType && !(genericType && inferredType)) {
+    throw new Error('지원하지 않는 이미지 형식이에요.')
+  }
+
+  return genericType && inferredType
+    ? new File([file], file.name, { type: inferredType })
+    : file
+}
+
+export function getArticleImageUploadError(
+  status: number,
+  message?: string,
+): string {
+  if (status === 413) return '이미지는 20MB 이하만 업로드할 수 있어요.'
+  if (status === 401) return '로그인 후 이미지를 추가해주세요.'
+  return message || '이미지 업로드에 실패했어요.'
+}
+
+async function convertHeicToJpeg(file: File): Promise<File> {
+  try {
+    const { default: heic2any } = await import('heic2any')
+    const result = await heic2any({
+      blob: file,
+      toType: 'image/jpeg',
+      quality: 0.85,
+    })
+    const blob = Array.isArray(result) ? result[0] : result
+    const name = file.name.replace(/\.(heic|heif)$/i, '') || 'image'
+    return new File([blob], `${name}.jpg`, { type: 'image/jpeg' })
+  } catch {
+    throw new Error('아이폰 사진을 변환하지 못했어요. 다른 사진을 선택해주세요.')
+  }
+}
+
+function validateSize(file: Pick<File, 'size'>) {
+  if (file.size > ARTICLE_IMAGE_MAX_BYTES) {
+    throw new Error('이미지는 20MB 이하만 업로드할 수 있어요.')
+  }
+}
+
+function getExtension(name: string): string {
+  return name.split('.').pop()?.toLowerCase() ?? ''
+}
+
+function isHeic(file: File, extension: string): boolean {
+  return (
+    extension === 'heic' ||
+    extension === 'heif' ||
+    file.type.includes('heic') ||
+    file.type.includes('heif')
+  )
+}

--- a/src/components/app/article-markdown-editor.tsx
+++ b/src/components/app/article-markdown-editor.tsx
@@ -13,6 +13,10 @@ import { Bold, ImagePlus, Italic, List } from 'lucide-react'
 import { useId, useRef, useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import { EditorButton, ModeButton } from './article-markdown-editor-controls'
+import {
+  getArticleImageUploadError,
+  prepareArticleImage,
+} from './article-image-file'
 import { insertMarkdownText } from './article-markdown-editor-utils'
 
 interface ArticleMarkdownEditorProps {
@@ -47,12 +51,15 @@ export function ArticleMarkdownEditor({
   }
 
   const uploadImage = async (file: File) => {
+    const uploadFile = await prepareArticleImage(file)
     const body = new FormData()
-    body.append('file', file)
+    body.append('file', uploadFile)
     const res = await fetch('/api/article/image', { method: 'POST', body })
     const data = await res.json().catch(() => null)
-    if (!res.ok || !data?.url) throw new Error('이미지 업로드 실패')
-    insertText(`\n\n![${file.name}](${data.url})\n`)
+    if (!res.ok || !data?.url) {
+      throw new Error(getArticleImageUploadError(res.status, data?.message))
+    }
+    insertText(`\n\n![${uploadFile.name}](${data.url})\n`)
   }
 
   return (
@@ -87,7 +94,7 @@ export function ArticleMarkdownEditor({
                 <input
                   id={fileInputId}
                   type="file"
-                  accept="image/*"
+                  accept="image/jpeg,image/png,image/gif,image/webp,image/avif,image/heic,image/heif,.jpg,.jpeg,.png,.gif,.webp,.avif,.heic,.heif"
                   disabled={uploading}
                   aria-label="이미지 추가"
                   className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
@@ -99,8 +106,12 @@ export function ArticleMarkdownEditor({
                       setUploading(true)
                       await uploadImage(file)
                       showToast('이미지를 추가했습니다.')
-                    } catch {
-                      showToast('이미지 업로드에 실패했습니다.')
+                    } catch (error) {
+                      showToast(
+                        error instanceof Error
+                          ? error.message
+                          : '이미지 업로드에 실패했어요.',
+                      )
                     } finally {
                       setUploading(false)
                     }


### PR DESCRIPTION
## Summary
모바일 아티클 에디터에서 GIF와 아이폰 사진을 안정적으로 선택·업로드하도록 파일 정규화와 오류 안내를 추가합니다.

## 원인
GIF 등 1MB 초과 파일은 Nginx 413이 일반 실패로만 보였고, HEIC/HEIF는 원본 업로드에 성공해도 브라우저가 게시글에서 표시하지 못했습니다. iPhone 파일은 MIME이 비어 오는 경우도 있었습니다.

## 변경
- GIF·JPEG·PNG·WebP·AVIF는 원본 유지
- HEIC/HEIF 및 sequence 파일은 업로드 전 JPEG 변환
- MIME이 비어 있는 모바일 파일을 확장자로 정규화
- 20MB 초과, 413, 미지원 형식, 변환 실패 사유 안내
- 모바일 파일 선택 accept 목록 명시

## Test plan
- [x] Frontend Vitest 17 files, 32 tests 통과
- [x] `pnpm lint` (신규 경고 없음)
- [x] `pnpm build`
- [x] 변경 파일 200줄 상한 및 `git diff --check`
- [ ] 백엔드 PR #115 배포 후 master 머지·운영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)