### PR TITLE
🐛 평점 저장 후 영화 평균 즉시 갱신

### DIFF
--- a/src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
@@ -14,7 +14,8 @@ interface DescriptionSectionProps {
 const DescriptionSection: FunctionComponent<DescriptionSectionProps> = ({
   id,
 }) => {
-  const { data, isLoading, error } = useGetMovieDetail(id)
+  const { data, isLoading, error, mutate: refreshMovie } =
+    useGetMovieDetail(id)
   const { setOpen, setSrc, setTitle } = useVodModalContext()
 
   if (isLoading)
@@ -36,7 +37,11 @@ const DescriptionSection: FunctionComponent<DescriptionSectionProps> = ({
   return (
     <>
       <MovieVodModal />
-      <DmMovieDetail movie={data} onVodClick={handleVodClick} />
+      <DmMovieDetail
+        movie={data}
+        onVodClick={handleVodClick}
+        onScoreSaved={refreshMovie}
+      />
       <DirectorFilmographySection movie={data} />
     </>
   )

--- a/src/components/dm/dm-movie-detail.tsx
+++ b/src/components/dm/dm-movie-detail.tsx
@@ -14,6 +14,7 @@ interface DmMovieDetailProps {
   averageScore?: number | null
   scoreCount?: number | null
   onVodClick?: () => void
+  onScoreSaved?: () => unknown | Promise<unknown>
 }
 
 export function DmMovieDetail({
@@ -21,6 +22,7 @@ export function DmMovieDetail({
   averageScore,
   scoreCount,
   onVodClick,
+  onScoreSaved,
 }: DmMovieDetailProps) {
   const palette = paletteForMovie(movie.id, movie.title)
   const rating = averageScore ?? movie.averageScore ?? 0
@@ -89,7 +91,10 @@ export function DmMovieDetail({
           </div>
           <div className="h-full w-px self-stretch bg-border" aria-hidden />
           <div className="flex-1">
-            <RatingInput movieCd={Number(movie.id)} />
+            <RatingInput
+              movieCd={Number(movie.id)}
+              onScoreSaved={onScoreSaved}
+            />
           </div>
         </div>
 

--- a/src/components/dm/rating-input-refresh.test.ts
+++ b/src/components/dm/rating-input-refresh.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it, vi } from 'vitest'
+import { refreshScoreViews } from './rating-input-refresh'
+
+const ratingInputPath = fileURLToPath(
+  new URL('./rating-input.tsx', import.meta.url),
+)
+const movieDetailPath = fileURLToPath(
+  new URL('./dm-movie-detail.tsx', import.meta.url),
+)
+const descriptionPath = fileURLToPath(
+  new URL(
+    '../../app/(root)/(routes)/movie/[id]/sections/description-section.tsx',
+    import.meta.url,
+  ),
+)
+
+describe('rating refresh', () => {
+  it('refreshes both the personal score and movie aggregate', async () => {
+    const refreshMyScore = vi.fn().mockResolvedValue(undefined)
+    const refreshMovie = vi.fn().mockResolvedValue(undefined)
+
+    await refreshScoreViews(refreshMyScore, refreshMovie)
+
+    expect(refreshMyScore).toHaveBeenCalledOnce()
+    expect(refreshMovie).toHaveBeenCalledOnce()
+  })
+
+  it('wires the movie detail refresh callback to the rating input', () => {
+    const ratingInput = readFileSync(ratingInputPath, 'utf8')
+    const movieDetail = readFileSync(movieDetailPath, 'utf8')
+    const description = readFileSync(descriptionPath, 'utf8')
+
+    expect(ratingInput).toContain('refreshScoreViews(mutate, onScoreSaved)')
+    expect(movieDetail).toContain('onScoreSaved={onScoreSaved}')
+    expect(description).toContain('onScoreSaved={refreshMovie}')
+  })
+})

--- a/src/components/dm/rating-input-refresh.ts
+++ b/src/components/dm/rating-input-refresh.ts
@@ -1,0 +1,8 @@
+type RefreshScore = () => unknown | Promise<unknown>
+
+export async function refreshScoreViews(
+  refreshMyScore: RefreshScore,
+  refreshMovie?: RefreshScore,
+) {
+  await Promise.all([refreshMyScore(), refreshMovie?.()])
+}

--- a/src/components/dm/rating-input.tsx
+++ b/src/components/dm/rating-input.tsx
@@ -2,12 +2,14 @@
 
 import { useGetScore } from '@/app/(root)/(routes)/movie/[id]/hooks/use-get-score'
 import { useRouter } from 'next/navigation'
+import { refreshScoreViews } from './rating-input-refresh'
 
 interface RatingInputProps {
   movieCd: number
+  onScoreSaved?: () => unknown | Promise<unknown>
 }
 
-export function RatingInput({ movieCd }: RatingInputProps) {
+export function RatingInput({ movieCd, onScoreSaved }: RatingInputProps) {
   const { data, isAuthenticated, mutate } = useGetScore(movieCd)
   const router = useRouter()
   const myScore = data?.score ?? 0
@@ -28,7 +30,7 @@ export function RatingInput({ movieCd }: RatingInputProps) {
         body: JSON.stringify({ score }),
       })
       if (!res.ok) throw new Error('업데이트 실패')
-      mutate()
+      await refreshScoreViews(mutate, onScoreSaved)
     } catch {
       mutate()
     }


### PR DESCRIPTION
## Summary
영화 상세에서 평점을 저장한 직후 평균 점수와 참여 인원이 바로 반영되도록 수정합니다.

## 원인
평점 저장 뒤 개인 평점 SWR 캐시만 재검증하고 영화 상세 캐시는 갱신하지 않아 집계값이 이전 상태로 남았습니다.

## 변경
- 평점 저장 성공 시 개인 평점과 영화 상세 캐시를 함께 재검증
- 상세 화면에서 평점 컴포넌트까지 재검증 콜백 전달
- 동시 갱신 및 화면 연결 회귀 테스트 추가

## Test plan
- [x] `pnpm exec vitest run` (34 tests)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정·신규 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)