### PR TITLE
🐛 채팅 목록 상대방 프로필 선택 수정

### DIFF
--- a/src/app/(root)/(routes)/chat/components/chat-room-list.tsx
+++ b/src/app/(root)/(routes)/chat/components/chat-room-list.tsx
@@ -1,6 +1,10 @@
 'use client'
 
 import type { ChatRoomEntity } from '@/modules/chat/chat.entity'
+import {
+  findChatCounterpart,
+  getChatRoomDisplayName,
+} from '@/modules/chat/chat-profile'
 import Link from 'next/link'
 import { useSession } from 'next-auth/react'
 import useSWR from 'swr'
@@ -27,13 +31,21 @@ function parseRoom(room: ChatRoomEntity, currentUserId: number) {
   if (!matchId && room.roomName.startsWith('Match Chat - ')) {
     matchId = room.roomName.replace('Match Chat - ', '')
   }
-  const targetUserId = room.memberIds.find((id) => id !== currentUserId) ?? null
-  const targetProfile = room.memberProfiles?.find(
-    (profile) => profile.userId !== currentUserId,
-  )
+  const counterpart =
+    room.type === 'direct'
+      ? findChatCounterpart(room, currentUserId)
+      : undefined
+  const targetUserId = counterpart?.userId ?? null
+  const targetProfile = counterpart?.profile
   const timeStr = formatRoomTime(room.lastMessageAt || room.updatedAt)
-  const title = room.matchTitle || (matchId ? '매칭 채팅' : room.roomName)
-  const preview = room.lastMessage || '아직 주고받은 메시지가 없어요'
+  const contextTitle =
+    room.matchTitle || (matchId ? '매칭 채팅' : room.roomName)
+  const title = getChatRoomDisplayName(room, currentUserId) || contextTitle
+  const lastMessage = room.lastMessage || '아직 주고받은 메시지가 없어요'
+  const preview =
+    room.type === 'direct' && room.matchTitle
+      ? `${room.matchTitle} · ${lastMessage}`
+      : lastMessage
 
   return { matchId, targetUserId, targetProfile, timeStr, title, preview }
 }
@@ -78,13 +90,7 @@ function RoomRow({
             </span>
           )}
         </div>
-        <div className="mt-0.5 flex items-center gap-1.5 text-[12px] text-muted-foreground">
-          {targetProfile?.nickname && (
-            <span className="max-w-[34%] truncate">
-              {targetProfile.nickname}
-            </span>
-          )}
-          {targetProfile?.nickname && <span aria-hidden="true">·</span>}
+        <div className="mt-0.5 flex items-center text-[12px] text-muted-foreground">
           <span className="truncate">{preview}</span>
         </div>
       </div>

--- a/src/modules/chat/chat-mapper.test.ts
+++ b/src/modules/chat/chat-mapper.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { convertApiResponseToChatRoomEntity } from './chat-mapper'
+
+describe('convertApiResponseToChatRoomEntity', () => {
+  it('normalizes member ids from a JSON response', () => {
+    const room = convertApiResponseToChatRoomEntity({
+      id: 'room-1',
+      name: '채팅방',
+      type: 'direct',
+      memberIds: ['4', '7'],
+      memberProfiles: [
+        { userId: '4', nickname: '나', image: 'me.png' },
+        { userId: '7', nickname: '상대방', image: 'target.png' },
+      ],
+      createdAt: '2026-07-19',
+      updatedAt: '2026-07-19',
+    })
+
+    expect(room.memberIds).toEqual([4, 7])
+    expect(room.memberProfiles?.map((profile) => profile.userId)).toEqual([
+      4, 7,
+    ])
+  })
+})

--- a/src/modules/chat/chat-mapper.ts
+++ b/src/modules/chat/chat-mapper.ts
@@ -3,16 +3,26 @@ import type { ChatRoomEntity, ChatMessageEntity } from './chat.entity'
 export function convertApiResponseToChatRoomEntity(
   apiResponse: any,
 ): ChatRoomEntity {
+  const memberIds = Array.isArray(apiResponse.memberIds)
+    ? apiResponse.memberIds.map(Number).filter(Number.isInteger)
+    : []
+  const memberProfiles = Array.isArray(apiResponse.memberProfiles)
+    ? apiResponse.memberProfiles.map((profile: any) => ({
+        ...profile,
+        userId: Number(profile.userId),
+      }))
+    : undefined
+
   return {
     chatRoomId: apiResponse.id,
     roomName: apiResponse.name,
     type: apiResponse.type,
-    memberIds: apiResponse.memberIds,
+    memberIds,
     createdAt: apiResponse.createdAt,
     updatedAt: apiResponse.updatedAt,
     matchPostId: apiResponse.matchPostId || undefined,
     matchTitle: apiResponse.matchTitle || undefined,
-    memberProfiles: apiResponse.memberProfiles || undefined,
+    memberProfiles,
     lastMessage: apiResponse.lastMessage || undefined,
     lastMessageAt: apiResponse.lastMessageAt || undefined,
   }

--- a/src/modules/chat/chat-profile.test.ts
+++ b/src/modules/chat/chat-profile.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { findChatMemberProfile } from './chat-profile'
+import {
+  findChatCounterpart,
+  findChatMemberProfile,
+  getChatRoomDisplayName,
+} from './chat-profile'
 
 describe('findChatMemberProfile', () => {
   it('returns the requested member current profile', () => {
@@ -24,5 +28,49 @@ describe('findChatMemberProfile', () => {
       nickname: '상대방',
       image: 'target.png',
     })
+  })
+
+  it('excludes the current user when response ids use different types', () => {
+    const counterpart = findChatCounterpart(
+      {
+        chatRoomId: 'room-1',
+        roomName: '채팅방',
+        type: 'direct',
+        memberIds: ['4', '7'],
+        memberProfiles: [
+          { userId: '4', nickname: '나', image: 'me.png' },
+          { userId: '7', nickname: '상대방', image: 'target.png' },
+        ],
+        createdAt: '2026-07-19',
+        updatedAt: '2026-07-19',
+      } as any,
+      4,
+    )
+
+    expect(counterpart).toEqual({
+      userId: 7,
+      profile: { userId: '7', nickname: '상대방', image: 'target.png' },
+    })
+  })
+
+  it('uses the counterpart nickname as a direct room display name', () => {
+    const name = getChatRoomDisplayName(
+      {
+        chatRoomId: 'room-1',
+        roomName: '내 닉네임과의 채팅',
+        type: 'direct',
+        memberIds: [4, 7],
+        memberProfiles: [
+          { userId: 4, nickname: '나', image: 'me.png' },
+          { userId: 7, nickname: '상대방', image: 'target.png' },
+        ],
+        matchTitle: '영화 매칭',
+        createdAt: '2026-07-19',
+        updatedAt: '2026-07-19',
+      },
+      4,
+    )
+
+    expect(name).toBe('상대방')
   })
 })

--- a/src/modules/chat/chat-profile.ts
+++ b/src/modules/chat/chat-profile.ts
@@ -4,5 +4,34 @@ export function findChatMemberProfile(
   room: ChatRoomEntity | null | undefined,
   userId: number,
 ): ChatRoomMemberProfileEntity | undefined {
-  return room?.memberProfiles?.find((profile) => profile.userId === userId)
+  return room?.memberProfiles?.find(
+    (profile) => Number(profile.userId) === Number(userId),
+  )
+}
+
+export function findChatCounterpart(
+  room: ChatRoomEntity | null | undefined,
+  currentUserId: number,
+) {
+  const currentId = Number(currentUserId)
+  const userId = room?.memberIds
+    .map(Number)
+    .find((memberId) => memberId !== currentId)
+
+  if (!userId) return undefined
+
+  return {
+    userId,
+    profile: findChatMemberProfile(room, userId),
+  }
+}
+
+export function getChatRoomDisplayName(
+  room: ChatRoomEntity,
+  currentUserId: number,
+) {
+  const fallback = room.matchTitle || room.roomName
+  if (room.type !== 'direct') return fallback
+
+  return findChatCounterpart(room, currentUserId)?.profile?.nickname || fallback
 }


### PR DESCRIPTION
## Summary
1:1 채팅 목록에서 내 닉네임 대신 상대방 닉네임과 프로필을 안정적으로 표시합니다.

## 원인
API의 사용자 ID가 문자열로 직렬화되는 경우 숫자형 세션 ID와 엄격 비교가 실패해 본인 프로필을 상대방으로 선택할 수 있었습니다.

## 변경
- 채팅방 응답의 멤버 ID와 프로필 ID를 숫자로 정규화
- 현재 사용자를 제외한 상대방 선택 로직을 공통 헬퍼로 통합
- 1:1 채팅 목록 첫 줄에 상대방 닉네임 우선 표시
- 매칭 제목과 마지막 메시지는 보조 줄에 유지

## Test plan
- [x] `pnpm exec vitest run` (37 tests)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정·신규 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)