### PR TITLE
✨ 매칭 작성·목록 경험 개선

### DIFF
--- a/src/app/(root)/(routes)/match/sections/match-form-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-form-section.tsx
@@ -15,12 +15,8 @@ const MatchFormSection: FunctionComponent<MatchFormSectionProps> = ({
   initialData,
 }) => {
   return (
-    <MatchPostFormProvider>
-      <MatchPostForm
-        onSubmit={onSubmit}
-        onCancel={onCancel}
-        initialData={initialData}
-      />
+    <MatchPostFormProvider initialData={initialData}>
+      <MatchPostForm onSubmit={onSubmit} onCancel={onCancel} />
     </MatchPostFormProvider>
   )
 }

--- a/src/components/dm/dm-match-ticket-poster.test.ts
+++ b/src/components/dm/dm-match-ticket-poster.test.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('DmMatchTicket poster', () => {
+  it('매칭 응답의 영화 포스터 URL을 카드에 전달한다', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src/components/dm/dm-match-ticket.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain('imageUrl={match.moviePoster}')
+  })
+})

--- a/src/components/dm/dm-match-ticket.tsx
+++ b/src/components/dm/dm-match-ticket.tsx
@@ -40,7 +40,12 @@ export function DmMatchTicket({ match }: DmMatchTicketProps) {
       <div className="flex gap-3">
         {/* movie poster */}
         <div className="w-[50px] shrink-0">
-          <Poster title={match.movieTitle} palette={palette} rounded="md" />
+          <Poster
+            title={match.movieTitle}
+            palette={palette}
+            imageUrl={match.moviePoster}
+            rounded="md"
+          />
         </div>
 
         {/* body */}
@@ -50,12 +55,14 @@ export function DmMatchTicket({ match }: DmMatchTicketProps) {
             <span className="font-mono text-[11px] text-muted-foreground">
               {month}.{day}({dow}) {time}
             </span>
-            <span className={cn(
-              'ml-auto shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px] font-medium',
-              schedule.isPast || isFull
-                ? 'bg-muted text-muted-foreground'
-                : 'border border-primary/30 text-primary',
-            )}>
+            <span
+              className={cn(
+                'ml-auto shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px] font-medium',
+                schedule.isPast || isFull
+                  ? 'bg-muted text-muted-foreground'
+                  : 'border border-primary/30 text-primary',
+              )}
+            >
               {schedule.label}
             </span>
           </div>
@@ -75,11 +82,20 @@ export function DmMatchTicket({ match }: DmMatchTicketProps) {
             <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-secondary text-[10px] font-bold text-foreground">
               {initial}
             </div>
-            <span className="text-[11px] text-muted-foreground">{match.author}</span>
+            <span className="text-[11px] text-muted-foreground">
+              {match.author}
+            </span>
             <span className="ml-auto font-mono text-[11px] text-muted-foreground">
-              <span className={isFull ? 'text-muted-foreground' : 'text-foreground font-medium'}>
+              <span
+                className={
+                  isFull
+                    ? 'text-muted-foreground'
+                    : 'font-medium text-foreground'
+                }
+              >
                 {match.currentParticipants}
-              </span>/{match.maxParticipants}명
+              </span>
+              /{match.maxParticipants}명
             </span>
           </div>
         </div>

--- a/src/components/form/match/hooks/match-post-form-context.tsx
+++ b/src/components/form/match/hooks/match-post-form-context.tsx
@@ -4,13 +4,15 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { createContext, useContext } from 'react'
 import * as z from 'zod'
+import { CreateMatchPostRequest } from '@/lib/type'
+import { getMatchPostFormDefaults } from '../match-post-form-defaults'
 
 const formSchema = z.object({
   title: z.string().min(1, {
     message: '제목은 최소 2자 이상 입력해주세요.',
   }),
-  content: z.string().min(1, {
-    message: '내용은 최소 5자 이상 입력해주세요.',
+  content: z.string().max(500, {
+    message: '설명은 최대 500자까지 입력할 수 있어요.',
   }),
   movieTitle: z.string().min(1, {
     message: '영화 제목을 입력해주세요.',
@@ -32,19 +34,11 @@ const formSchema = z.object({
   }),
 })
 
-const useMatchPostForm = () => {
+const useMatchPostForm = (initialData?: Partial<CreateMatchPostRequest>) => {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     mode: 'onTouched',
-    defaultValues: {
-      title: '자동 생성',
-      content: '자동 생성',
-      movieTitle: '',
-      theaterName: '상영관 미정',
-      showTime: '',
-      maxParticipants: 1,
-      location: '',
-    },
+    defaultValues: getMatchPostFormDefaults(initialData),
   })
 
   return {
@@ -66,10 +60,12 @@ export const useMatchPostFormContext = () => {
 
 export const MatchPostFormProvider = ({
   children,
+  initialData,
 }: {
   children: React.ReactNode
+  initialData?: Partial<CreateMatchPostRequest>
 }) => {
-  const { form } = useMatchPostForm()
+  const { form } = useMatchPostForm(initialData)
   return (
     <MatchPostFormContext.Provider
       value={{

--- a/src/components/form/match/match-post-form-defaults.test.ts
+++ b/src/components/form/match/match-post-form-defaults.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { getMatchPostFormDefaults } from './match-post-form-defaults'
+
+describe('getMatchPostFormDefaults', () => {
+  it('수정할 매칭 정보를 첫 렌더 기본값에 병합한다', () => {
+    const defaults = getMatchPostFormDefaults({
+      movieTitle: '군체',
+      content: '조용히 영화만 봐요.',
+      maxParticipants: 4,
+    })
+
+    expect(defaults.movieTitle).toBe('군체')
+    expect(defaults.content).toBe('조용히 영화만 봐요.')
+    expect(defaults.maxParticipants).toBe(4)
+    expect(defaults.location).toBe('')
+  })
+})

--- a/src/components/form/match/match-post-form-defaults.ts
+++ b/src/components/form/match/match-post-form-defaults.ts
@@ -1,0 +1,17 @@
+import { CreateMatchPostRequest } from '@/lib/type'
+
+const baseDefaults: CreateMatchPostRequest = {
+  title: '자동 생성',
+  content: '',
+  movieTitle: '',
+  theaterName: '상영관 미정',
+  showTime: '',
+  maxParticipants: 1,
+  location: '',
+}
+
+export function getMatchPostFormDefaults(
+  initialData?: Partial<CreateMatchPostRequest>,
+): CreateMatchPostRequest {
+  return { ...baseDefaults, ...initialData }
+}

--- a/src/components/form/match/match-post-form-step.tsx
+++ b/src/components/form/match/match-post-form-step.tsx
@@ -1,0 +1,132 @@
+import { CreateMatchPostRequest } from '@/lib/type'
+import { CalendarDays } from 'lucide-react'
+import { UseFormReturn } from 'react-hook-form'
+import { MovieSuggestionChips } from './movie-suggestion-chips'
+
+export type MatchFormStep =
+  | 'movieTitle'
+  | 'showTime'
+  | 'location'
+  | 'maxParticipants'
+  | 'confirm'
+
+interface MatchPostFormStepProps {
+  field: MatchFormStep
+  form: UseFormReturn<CreateMatchPostRequest>
+  summary: string[][]
+}
+
+const inputCls =
+  'w-full rounded-xl border border-border bg-secondary px-4 py-4 text-[18px] font-semibold text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none'
+
+export function MatchPostFormStep({
+  field,
+  form,
+  summary,
+}: MatchPostFormStepProps) {
+  if (field === 'confirm') {
+    return (
+      <div className="space-y-5">
+        <div className="space-y-3">
+          {summary.map(([label, value]) => (
+            <div
+              key={label}
+              className="flex items-center justify-between rounded-xl bg-secondary px-4 py-4"
+            >
+              <span className="text-[13px] text-muted-foreground">{label}</span>
+              <span className="text-right text-[15px] font-bold text-foreground">
+                {value}
+              </span>
+            </div>
+          ))}
+        </div>
+        <label className="block">
+          <span className="mb-2 block text-[13px] font-semibold text-foreground">
+            설명 (선택)
+          </span>
+          <textarea
+            value={form.watch('content')}
+            onChange={(event) => form.setValue('content', event.target.value)}
+            maxLength={500}
+            rows={4}
+            placeholder="같이 볼 사람에게 알려둘 내용을 적어주세요."
+            className={`${inputCls} resize-none text-[15px] font-normal`}
+          />
+          <span className="mt-1 block text-right text-[11px] text-muted-foreground">
+            {form.watch('content').length}/500
+          </span>
+        </label>
+      </div>
+    )
+  }
+
+  if (field === 'maxParticipants') {
+    return (
+      <div className="grid grid-cols-2 gap-3">
+        {[1, 2, 3, 4, 5, 6].map((count) => {
+          const selected = form.watch('maxParticipants') === count
+          return (
+            <button
+              key={count}
+              type="button"
+              onClick={() =>
+                form.setValue('maxParticipants', count, {
+                  shouldValidate: true,
+                })
+              }
+              className={`rounded-xl border px-4 py-5 text-[18px] font-bold ${
+                selected
+                  ? 'border-primary bg-primary text-white'
+                  : 'border-border bg-secondary text-foreground'
+              }`}
+            >
+              {count}명
+            </button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  const isSchedule = field === 'showTime'
+  const placeholder =
+    field === 'movieTitle' ? '영화 제목' : '예: 강남, 홍대, 잠실'
+
+  return (
+    <div>
+      <div className={isSchedule ? 'relative' : undefined}>
+        <input
+          type={isSchedule ? 'datetime-local' : 'text'}
+          value={form.watch(field) as string}
+          onChange={(event) =>
+            form.setValue(field, event.target.value, { shouldValidate: true })
+          }
+          placeholder={placeholder}
+          className={`${inputCls} ${
+            isSchedule
+              ? 'pr-12 [color-scheme:light] dark:[color-scheme:dark] [&::-webkit-calendar-picker-indicator]:absolute [&::-webkit-calendar-picker-indicator]:inset-0 [&::-webkit-calendar-picker-indicator]:h-full [&::-webkit-calendar-picker-indicator]:w-full [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-0'
+              : ''
+          }`}
+        />
+        {isSchedule && (
+          <CalendarDays
+            aria-hidden="true"
+            className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-foreground"
+            size={22}
+          />
+        )}
+      </div>
+      <p className="mt-3 text-[13px] text-destructive">
+        {form.formState.errors[field]?.message as string}
+      </p>
+      {field === 'movieTitle' && (
+        <MovieSuggestionChips
+          selectedTitle={form.watch('movieTitle')}
+          onSelect={(title) =>
+            form.setValue('movieTitle', title, { shouldValidate: true })
+          }
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/form/match/match-post-form-ui.test.ts
+++ b/src/components/form/match/match-post-form-ui.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    'src/components/form/match/match-post-form-step.tsx',
+  ),
+  'utf8',
+)
+
+describe('match post form UI contract', () => {
+  it('마지막 단계에 선택 설명 입력을 제공한다', () => {
+    expect(source).toContain('설명 (선택)')
+    expect(source).toContain("form.setValue('content'")
+  })
+
+  it('일정 입력에 밝은 화면에서도 보이는 달력 아이콘을 제공한다', () => {
+    expect(source).toContain('CalendarDays')
+    expect(source).toContain('[color-scheme:light]')
+    expect(source).toContain('dark:[color-scheme:dark]')
+  })
+})

--- a/src/components/form/match/match-post-form-utils.test.ts
+++ b/src/components/form/match/match-post-form-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { buildMatchPayload } from './match-post-form-utils'
+
+const baseData = {
+  title: '자동 생성',
+  content: '',
+  movieTitle: '모아나',
+  theaterName: '상영관 미정',
+  showTime: '2026-07-20T19:00',
+  maxParticipants: 3,
+  location: '강남',
+}
+
+describe('buildMatchPayload', () => {
+  it('입력한 선택 설명을 매칭 내용으로 보존한다', () => {
+    const result = buildMatchPayload({
+      ...baseData,
+      content: '영화 보고 근처에서 감상도 나눠요.',
+    })
+
+    expect(result.content).toBe('영화 보고 근처에서 감상도 나눠요.')
+  })
+
+  it('설명이 비어 있으면 기본 안내 문구를 만든다', () => {
+    const result = buildMatchPayload(baseData)
+
+    expect(result.content).toBe('강남에서 3명이 함께 볼 영화 약속입니다.')
+  })
+})

--- a/src/components/form/match/match-post-form-utils.ts
+++ b/src/components/form/match/match-post-form-utils.ts
@@ -6,10 +6,12 @@ export function buildMatchPayload(
   const movie = data.movieTitle.trim()
   const place = data.location.trim()
   const people = data.maxParticipants
+  const description = data.content.trim()
   return {
     ...data,
     title: `${movie} 같이 볼 사람 구해요`,
-    content: `${place}에서 ${people}명이 함께 볼 영화 약속입니다.`,
+    content:
+      description || `${place}에서 ${people}명이 함께 볼 영화 약속입니다.`,
     theaterName: place,
   }
 }

--- a/src/components/form/match/match-post-form.tsx
+++ b/src/components/form/match/match-post-form.tsx
@@ -3,15 +3,14 @@
 import { Form } from '@/components/ui/form'
 import { CreateMatchPostRequest } from '@/lib/type'
 import { ArrowLeft, ArrowRight, Check } from 'lucide-react'
-import { FunctionComponent, useEffect, useMemo, useState } from 'react'
+import { FunctionComponent, useMemo, useState } from 'react'
 import { useMatchPostFormContext } from './hooks/match-post-form-context'
 import { buildMatchPayload, formatMatchDateTime } from './match-post-form-utils'
-import { MovieSuggestionChips } from './movie-suggestion-chips'
+import { MatchPostFormStep } from './match-post-form-step'
 
 interface MatchPostFormProps {
   onSubmit: (_data: CreateMatchPostRequest) => Promise<void>
   onCancel: () => void
-  initialData?: Partial<CreateMatchPostRequest>
 }
 
 const steps = [
@@ -22,26 +21,13 @@ const steps = [
   { field: 'confirm', label: '확인', title: '이대로 매치를 만들까요?' },
 ] as const
 
-const inputCls =
-  'w-full rounded-xl border border-border bg-secondary px-4 py-4 text-[18px] font-semibold text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none'
-
 const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
   onSubmit,
   onCancel,
-  initialData,
 }) => {
   const { form } = useMatchPostFormContext()
   const [step, setStep] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
-
-  useEffect(() => {
-    if (!initialData) return
-    Object.entries(initialData).forEach(([key, value]) => {
-      if (value !== undefined) {
-        form.setValue(key as keyof CreateMatchPostRequest, value as any)
-      }
-    })
-  }, [form, initialData])
 
   const values = form.watch()
   const current = steps[step]
@@ -93,7 +79,13 @@ const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
           {current.title}
         </h2>
 
-        <div className="flex-1">{renderStep(current.field, form, summary)}</div>
+        <div className="flex-1">
+          <MatchPostFormStep
+            field={current.field}
+            form={form}
+            summary={summary}
+          />
+        </div>
 
         <div className="sticky bottom-0 flex gap-2 border-t border-border bg-background/95 py-3 backdrop-blur">
           <button
@@ -124,76 +116,6 @@ const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
         </div>
       </form>
     </Form>
-  )
-}
-
-function renderStep(field: (typeof steps)[number]['field'], form: any, summary: string[][]) {
-  if (field === 'confirm') {
-    return (
-      <div className="space-y-3">
-        {summary.map(([label, value]) => (
-          <div
-            key={label}
-            className="flex items-center justify-between rounded-xl bg-secondary px-4 py-4"
-          >
-            <span className="text-[13px] text-muted-foreground">{label}</span>
-            <span className="text-right text-[15px] font-bold text-foreground">{value}</span>
-          </div>
-        ))}
-      </div>
-    )
-  }
-
-  if (field === 'maxParticipants') {
-    return (
-      <div className="grid grid-cols-2 gap-3">
-        {[1, 2, 3, 4, 5, 6].map((count) => {
-          const selected = form.watch('maxParticipants') === count
-          return (
-            <button
-              key={count}
-              type="button"
-              onClick={() =>
-                form.setValue('maxParticipants', count, { shouldValidate: true })
-              }
-              className={`rounded-xl border px-4 py-5 text-[18px] font-bold ${
-                selected
-                  ? 'border-primary bg-primary text-white'
-                  : 'border-border bg-secondary text-foreground'
-              }`}
-            >
-              {count}명
-            </button>
-          )
-        })}
-      </div>
-    )
-  }
-
-  const type = field === 'showTime' ? 'datetime-local' : 'text'
-  const placeholder = field === 'movieTitle' ? '영화 제목' : '예: 강남, 홍대, 잠실'
-
-  return (
-    <div>
-      <input
-        type={type}
-        value={form.watch(field) as string}
-        onChange={(event) => form.setValue(field, event.target.value, { shouldValidate: true })}
-        placeholder={placeholder}
-        className={`${inputCls} ${field === 'showTime' ? '[color-scheme:dark]' : ''}`}
-      />
-      <p className="mt-3 text-[13px] text-destructive">
-        {form.formState.errors[field]?.message as string}
-      </p>
-      {field === 'movieTitle' && (
-        <MovieSuggestionChips
-          selectedTitle={form.watch('movieTitle') as string}
-          onSelect={(title) =>
-            form.setValue('movieTitle', title, { shouldValidate: true })
-          }
-        />
-      )}
-    </div>
   )
 }
 

--- a/src/lib/type/match.ts
+++ b/src/lib/type/match.ts
@@ -13,6 +13,7 @@ export interface MatchPost {
   gender: Gender
   content: string
   movieTitle: string
+  moviePoster?: string
   theaterName: string
   showTime: string
   maxParticipants: number


### PR DESCRIPTION
## Summary
매칭 작성 마지막 단계에 선택 설명을 추가하고 수정 폼 초기값·일정 달력 표시를 안정화합니다. 매칭 목록은 백엔드가 제공하는 영화 포스터를 표시합니다.

## 원인
- 수정 데이터가 렌더 후 `setValue`로 주입되어 첫 단계에서 값 표시가 지연됨
- 밝은 화면에서도 날짜 입력에 `color-scheme: dark`가 강제됨
- 매칭 응답과 카드 사이에 포스터 URL 계약이 없었음

## 변경
- 최종 확인 단계에 500자 선택 설명 입력 추가
- 폼 Provider 기본값에 수정 데이터를 동기 병합
- 밝은/어두운 테마 대응 달력 아이콘 및 전체 입력 클릭 영역 제공
- `moviePoster` 타입과 매칭 카드 포스터 연결

## Test plan
- [x] `pnpm exec vitest run` 관련 6개 테스트
- [x] `pnpm lint`
- [x] 환경변수 주입 후 `pnpm build`
- [x] 수정/신규 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)