### PR TITLE
🐛 매칭 생성 5단계 제출 가드 추가

### DIFF
--- a/src/components/form/match/match-post-form-ui.test.ts
+++ b/src/components/form/match/match-post-form-ui.test.ts
@@ -10,6 +10,11 @@ const source = fs.readFileSync(
   'utf8',
 )
 
+const formSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/components/form/match/match-post-form.tsx'),
+  'utf8',
+)
+
 describe('match post form UI contract', () => {
   it('마지막 단계에 선택 설명 입력을 제공한다', () => {
     expect(source).toContain('설명 (선택)')
@@ -20,5 +25,12 @@ describe('match post form UI contract', () => {
     expect(source).toContain('CalendarDays')
     expect(source).toContain('[color-scheme:light]')
     expect(source).toContain('dark:[color-scheme:dark]')
+  })
+
+  it('마지막 단계 전 submit 이벤트는 생성 대신 다음 단계로 이동한다', () => {
+    expect(formSource).toContain('onSubmit={handleFormSubmit}')
+    expect(formSource).toContain('if (!isLast)')
+    expect(formSource).toContain('event.preventDefault()')
+    expect(formSource).toContain("label: '설명'")
   })
 })

--- a/src/components/form/match/match-post-form.tsx
+++ b/src/components/form/match/match-post-form.tsx
@@ -3,7 +3,7 @@
 import { Form } from '@/components/ui/form'
 import { CreateMatchPostRequest } from '@/lib/type'
 import { ArrowLeft, ArrowRight, Check } from 'lucide-react'
-import { FunctionComponent, useMemo, useState } from 'react'
+import { FormEvent, FunctionComponent, useMemo, useState } from 'react'
 import { useMatchPostFormContext } from './hooks/match-post-form-context'
 import { buildMatchPayload, formatMatchDateTime } from './match-post-form-utils'
 import { MatchPostFormStep } from './match-post-form-step'
@@ -18,7 +18,7 @@ const steps = [
   { field: 'showTime', label: '일정', title: '언제 볼까요?' },
   { field: 'location', label: '장소', title: '어디서 만날까요?' },
   { field: 'maxParticipants', label: '인원', title: '몇 명이 함께 볼까요?' },
-  { field: 'confirm', label: '확인', title: '이대로 매치를 만들까요?' },
+  { field: 'confirm', label: '설명', title: '더 전하고 싶은 말이 있나요?' },
 ] as const
 
 const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
@@ -59,10 +59,19 @@ const MatchPostForm: FunctionComponent<MatchPostFormProps> = ({
     }
   })
 
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (!isLast) {
+      event.preventDefault()
+      void goNext()
+      return
+    }
+    void submit(event)
+  }
+
   return (
     <Form {...form}>
       <form
-        onSubmit={submit}
+        onSubmit={handleFormSubmit}
         className="mx-auto flex min-h-[calc(100dvh-220px)] max-w-[520px] flex-col"
       >
         <div className="mb-8 h-1.5 overflow-hidden rounded-full bg-secondary">


### PR DESCRIPTION
## Summary
매칭 생성 중 4단계에서 발생하는 submit 이벤트가 API 생성으로 이어지지 않고 5단계 선택 설명 화면으로 이동하도록 보장합니다.

## 원인
폼의 `onSubmit`이 현재 단계와 무관하게 항상 생성 요청을 실행해 모바일 키보드 완료나 브라우저 기본 submit이 4단계에서 발생하면 마지막 단계를 건너뛸 수 있었습니다.

## 변경
- 마지막 단계 이전 submit은 `preventDefault` 후 다음 단계 이동
- 5단계 라벨과 제목을 선택 설명 화면으로 명확화
- 제출 단계 가드 회귀 테스트 추가

## Test plan
- [x] 관련 Vitest 7개
- [x] `pnpm lint`
- [x] 프로덕션 `pnpm build`
- [x] 수정 파일 200줄 상한 및 `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)