### PR TITLE
✨ 아티클 조회수 표시 추가

### DIFF
--- a/src/app/(root)/(routes)/articles/[id]/components/article-view-count.tsx
+++ b/src/app/(root)/(routes)/articles/[id]/components/article-view-count.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { ArticleViewClientApiEndpoint } from '@/config/article-view-client-api-endpoint'
+import { Eye } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+interface ArticleViewCountProps {
+  articleId: string
+  initialCount: number
+}
+
+export const ArticleViewCount = ({
+  articleId,
+  initialCount,
+}: ArticleViewCountProps) => {
+  const [viewCount, setViewCount] = useState(initialCount)
+
+  useEffect(() => {
+    let active = true
+    const recordView = async () => {
+      try {
+        const response = await fetch(
+          ArticleViewClientApiEndpoint.record(Number(articleId)),
+          { method: 'POST' },
+        )
+        if (!response.ok) return
+        const result = await response.json()
+        if (active && typeof result.viewCount === 'number') {
+          setViewCount(result.viewCount)
+        }
+      } catch {
+        // 조회 기록 실패는 콘텐츠 열람을 방해하지 않는다.
+      }
+    }
+    void recordView()
+    return () => {
+      active = false
+    }
+  }, [articleId])
+
+  return (
+    <span className="flex items-center gap-1" aria-label={`조회 ${viewCount}`}>
+      <Eye className="h-3 w-3" />
+      {viewCount}
+    </span>
+  )
+}

--- a/src/app/(root)/(routes)/articles/[id]/sections/article-data-section.tsx
+++ b/src/app/(root)/(routes)/articles/[id]/sections/article-data-section.tsx
@@ -9,6 +9,7 @@ import { Pencil, Trash2 } from 'lucide-react'
 import { useDeleteArticle } from '../../new/hooks/use-delete-article'
 import { ModifyArticleModal } from '../components/modify-article-modal'
 import { useModifyArticleModalContext } from '../hooks/use-modify-article-context'
+import { ArticleViewCount } from '../components/article-view-count'
 
 interface ArticleDataSectionProps {
   data: Article
@@ -77,6 +78,8 @@ const ArticleDataSection: FunctionComponent<ArticleDataSectionProps> = ({
         <span>{data.author}</span>
         <span>·</span>
         <span>{dateStr}</span>
+        <span>·</span>
+        <ArticleViewCount articleId={data.id} initialCount={data.viewCount} />
       </div>
 
       <div className="mt-5 border-t border-border pt-5">

--- a/src/app/(root)/(routes)/articles/article-view-ui.test.ts
+++ b/src/app/(root)/(routes)/articles/article-view-ui.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const read = (relativePath: string) =>
+  readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8')
+
+describe('article view count UI', () => {
+  it('records a detail view and updates the displayed count', () => {
+    const source = read('./[id]/components/article-view-count.tsx')
+
+    expect(source).toContain('ArticleViewClientApiEndpoint.record')
+    expect(source).toContain('setViewCount(result.viewCount)')
+  })
+
+  it('shows the count in both the list card and detail metadata', () => {
+    const card = read('./components/article-card.tsx')
+    const detail = read('./[id]/sections/article-data-section.tsx')
+
+    expect(card).toContain('<Eye')
+    expect(card).toContain('{article.viewCount}')
+    expect(detail).toContain('<ArticleViewCount')
+    expect(detail).toContain('initialCount={data.viewCount}')
+  })
+})

--- a/src/app/(root)/(routes)/articles/components/article-card.tsx
+++ b/src/app/(root)/(routes)/articles/components/article-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Article } from '@/lib/type'
-import { MessageCircle, ThumbsDown, ThumbsUp } from 'lucide-react'
+import { Eye, MessageCircle, ThumbsDown, ThumbsUp } from 'lucide-react'
 import Link from 'next/link'
 import { FunctionComponent } from 'react'
 import { useArticleRead } from '../hooks/use-article-read'
@@ -35,10 +35,18 @@ const ArticleCard: FunctionComponent<ArticleCardProps> = ({ article }) => {
       </p>
 
       <div className="mt-2 flex items-center gap-3 font-mono text-[11px] text-muted-foreground">
-        <span>{article.author}</span>
-        <span>·</span>
-        <span>{new Date(article.createdAt).toLocaleDateString()}</span>
-        <div className="ml-auto flex items-center gap-3">
+        <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+          <span className="truncate">{article.author}</span>
+          <span>·</span>
+          <span className="shrink-0">
+            {new Date(article.createdAt).toLocaleDateString()}
+          </span>
+        </div>
+        <div className="ml-auto flex shrink-0 items-center gap-2.5">
+          <span className="flex items-center gap-1">
+            <Eye className="h-3 w-3" />
+            {article.viewCount}
+          </span>
           <span className="flex items-center gap-1">
             <ThumbsUp className="h-3 w-3" />
             {article.likeCount}

--- a/src/app/api/article/[id]/view/route.test.ts
+++ b/src/app/api/article/[id]/view/route.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { ArticleViewRepository } from '@/modules/article/article-view-repository'
+import { POST } from './route'
+
+vi.mock('@/modules/article/article-view-repository', () => ({
+  ArticleViewRepository: vi.fn(),
+}))
+
+const MockArticleViewRepository = vi.mocked(ArticleViewRepository)
+
+describe('article view tracking', () => {
+  const recordArticleView = vi
+    .fn()
+    .mockResolvedValue({ viewCount: 5, counted: true })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockArticleViewRepository.mockImplementation(
+      () => ({ recordArticleView }) as unknown as ArticleViewRepository,
+    )
+  })
+
+  it('creates an anonymous cookie and sends only its SHA-256 digest', async () => {
+    const request = new NextRequest('http://localhost/api/article/4/view', {
+      method: 'POST',
+    })
+
+    const response = await POST(request, { params: { id: '4' } })
+
+    expect(recordArticleView).toHaveBeenCalledWith(
+      '4',
+      expect.stringMatching(/^[a-f0-9]{64}$/),
+    )
+    expect(response.headers.get('set-cookie')).toContain(
+      'bollae_article_viewer=',
+    )
+    expect(await response.json()).toEqual({ viewCount: 5, counted: true })
+  })
+
+  it('reuses the existing anonymous cookie without forwarding its raw value', async () => {
+    const request = new NextRequest('http://localhost/api/article/4/view', {
+      method: 'POST',
+      headers: { cookie: 'bollae_article_viewer=existing-viewer' },
+    })
+
+    await POST(request, { params: { id: '4' } })
+
+    const viewerKey = recordArticleView.mock.calls[0][1]
+    expect(viewerKey).toMatch(/^[a-f0-9]{64}$/)
+    expect(viewerKey).not.toBe('existing-viewer')
+  })
+})

--- a/src/app/api/article/[id]/view/route.ts
+++ b/src/app/api/article/[id]/view/route.ts
@@ -1,0 +1,40 @@
+import { createHash, randomUUID } from 'crypto'
+import {
+  ARTICLE_VIEWER_COOKIE,
+  ARTICLE_VIEWER_COOKIE_MAX_AGE,
+} from '../../../../../lib/article-viewer-cookie'
+import { ArticleViewRepository } from '@/modules/article/article-view-repository'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const POST = async (
+  request: NextRequest,
+  context: { params: { id: string } },
+) => {
+  const existingViewer = request.cookies.get(ARTICLE_VIEWER_COOKIE)?.value
+  const viewer = existingViewer || randomUUID()
+  const viewerKey = createHash('sha256').update(viewer).digest('hex')
+
+  try {
+    const repository = new ArticleViewRepository()
+    const result = await repository.recordArticleView(
+      context.params.id,
+      viewerKey,
+    )
+    const response = NextResponse.json(result)
+    if (!existingViewer) {
+      response.cookies.set(ARTICLE_VIEWER_COOKIE, viewer, {
+        httpOnly: true,
+        maxAge: ARTICLE_VIEWER_COOKIE_MAX_AGE,
+        path: '/',
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+      })
+    }
+    return response
+  } catch {
+    return NextResponse.json(
+      { message: '조회수를 기록하지 못했습니다.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/config/article-view-backend-api-endpoint.ts
+++ b/src/config/article-view-backend-api-endpoint.ts
@@ -1,0 +1,8 @@
+const serverBase =
+  process.env.SERVER_API ||
+  process.env.NEXT_PUBLIC_SERVER_API ||
+  'http://127.0.0.1:3030'
+
+export const ArticleViewBackendApiEndpoint = {
+  record: (articleId: number) => `${serverBase}/article/${articleId}/view`,
+}

--- a/src/config/article-view-client-api-endpoint.ts
+++ b/src/config/article-view-client-api-endpoint.ts
@@ -1,0 +1,3 @@
+export const ArticleViewClientApiEndpoint = {
+  record: (articleId: number) => `/api/article/${articleId}/view`,
+}

--- a/src/lib/article-viewer-cookie.ts
+++ b/src/lib/article-viewer-cookie.ts
@@ -1,0 +1,2 @@
+export const ARTICLE_VIEWER_COOKIE = 'bollae_article_viewer'
+export const ARTICLE_VIEWER_COOKIE_MAX_AGE = 60 * 60 * 24 * 365

--- a/src/lib/type/article.tsx
+++ b/src/lib/type/article.tsx
@@ -7,6 +7,7 @@ export interface Article {
   likeCount: number
   dislikeCount: number
   commentCount: number
+  viewCount: number
   createdAt: string
   updatedAt?: string
   deletedAt?: string

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { NextRequest } from 'next/server'
+import { middleware } from './middleware'
+
+describe('article viewer middleware', () => {
+  it('sets the anonymous viewer cookie before rendering an article detail', () => {
+    const request = new NextRequest('https://bollae.kr/articles/4')
+
+    const response = middleware(request)
+
+    expect(response.headers.get('set-cookie')).toContain(
+      'bollae_article_viewer=',
+    )
+  })
+
+  it('does not replace an existing anonymous viewer cookie', () => {
+    const request = new NextRequest('https://bollae.kr/articles/4', {
+      headers: { cookie: 'bollae_article_viewer=existing-viewer' },
+    })
+
+    const response = middleware(request)
+
+    expect(response.headers.get('set-cookie')).toBeNull()
+  })
+
+  it('keeps authentication redirects for protected routes', () => {
+    const request = new NextRequest('https://bollae.kr/account')
+
+    const response = middleware(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toContain('/login?callbackUrl=')
+  })
+})

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,29 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import {
+  ARTICLE_VIEWER_COOKIE,
+  ARTICLE_VIEWER_COOKIE_MAX_AGE,
+} from './lib/article-viewer-cookie'
 
 export function middleware(req: NextRequest) {
+  if (/^\/articles\/\d+$/.test(req.nextUrl.pathname)) {
+    const response = NextResponse.next()
+    if (!req.cookies.has(ARTICLE_VIEWER_COOKIE)) {
+      response.cookies.set(
+        ARTICLE_VIEWER_COOKIE,
+        globalThis.crypto.randomUUID(),
+        {
+          httpOnly: true,
+          maxAge: ARTICLE_VIEWER_COOKIE_MAX_AGE,
+          path: '/',
+          sameSite: 'lax',
+          secure: req.nextUrl.protocol === 'https:',
+        },
+      )
+    }
+    return response
+  }
+
   // NextAuth 세션 쿠키 존재만 확인 (JWT 검증은 API 레벨에서 이미 수행됨)
   // HTTP/HTTPS 양쪽 쿠키 이름 모두 체크
   const token =
@@ -22,5 +44,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/account/:path*', '/analytics', '/match/new'],
+  matcher: ['/account/:path*', '/analytics', '/match/new', '/articles/:path*'],
 }

--- a/src/modules/article/article-datasource.ts
+++ b/src/modules/article/article-datasource.ts
@@ -46,6 +46,7 @@ export class ArticleDatasource {
       | 'likeCount'
       | 'dislikeCount'
       | 'commentCount'
+      | 'viewCount'
       | 'author'
       | 'userno'
       | 'createdAt'

--- a/src/modules/article/article-repository.ts
+++ b/src/modules/article/article-repository.ts
@@ -44,6 +44,7 @@ export class ArticleRepository {
       | 'likeCount'
       | 'dislikeCount'
       | 'commentCount'
+      | 'viewCount'
       | 'author'
       | 'userno'
       | 'createdAt'
@@ -74,6 +75,7 @@ export class ArticleRepository {
       likeCount: unknown.likeCount,
       dislikeCount: unknown.dislikeCount,
       commentCount: unknown.commentCount,
+      viewCount: unknown.viewCount,
       createdAt: unknown.createdAt,
       updatedAt: unknown.updatedAt,
       deletedAt: unknown.deletedAt,

--- a/src/modules/article/article-view-datasource.ts
+++ b/src/modules/article/article-view-datasource.ts
@@ -1,0 +1,17 @@
+import { ArticleViewBackendApiEndpoint } from '@/config/article-view-backend-api-endpoint'
+
+export class ArticleViewDatasource {
+  async recordArticleView(articleId: string, viewerKey: string) {
+    const response = await fetch(
+      ArticleViewBackendApiEndpoint.record(Number(articleId)),
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ viewerKey }),
+        cache: 'no-cache',
+      },
+    )
+    if (!response.ok) throw new Error('조회수를 기록할 수 없습니다.')
+    return response.json()
+  }
+}

--- a/src/modules/article/article-view-repository.ts
+++ b/src/modules/article/article-view-repository.ts
@@ -1,0 +1,21 @@
+import { ArticleViewResult, isArticleViewResult } from './article.entity'
+import { ArticleViewDatasource } from './article-view-datasource'
+
+export class ArticleViewRepository {
+  private readonly datasource: ArticleViewDatasource
+
+  constructor(datasource = new ArticleViewDatasource()) {
+    this.datasource = datasource
+  }
+
+  async recordArticleView(
+    articleId: string,
+    viewerKey: string,
+  ): Promise<ArticleViewResult> {
+    const result = await this.datasource.recordArticleView(articleId, viewerKey)
+    if (!isArticleViewResult(result)) {
+      throw new Error('올바르지 않은 조회수 응답입니다.')
+    }
+    return result
+  }
+}

--- a/src/modules/article/article.entity.ts
+++ b/src/modules/article/article.entity.ts
@@ -1,4 +1,16 @@
 import { Article, Reply } from '@/lib/type'
+
+export interface ArticleViewResult {
+  viewCount: number
+  counted: boolean
+}
+
+export const isArticleViewResult = (value: any): value is ArticleViewResult =>
+  value !== null &&
+  typeof value === 'object' &&
+  typeof value.viewCount === 'number' &&
+  typeof value.counted === 'boolean'
+
 export function isArticle(arg: any): arg is Article {
   return (
     arg !== null &&
@@ -10,7 +22,8 @@ export function isArticle(arg: any): arg is Article {
     typeof arg.userno === 'number' &&
     typeof arg.likeCount === 'number' &&
     typeof arg.dislikeCount === 'number' &&
-    typeof arg.commentCount === 'number'
+    typeof arg.commentCount === 'number' &&
+    typeof arg.viewCount === 'number'
   )
 }
 

--- a/src/modules/article/index.ts
+++ b/src/modules/article/index.ts
@@ -1,3 +1,5 @@
 export * from './article.entity'
 export * from './article-datasource'
 export * from './article-repository'
+export * from './article-view-datasource'
+export * from './article-view-repository'


### PR DESCRIPTION
## Summary
아티클 목록과 상세에 조회수를 표시하고 브라우저별 KST 하루 1회만 기록합니다.

## 원인
상세 페이지 조회와 별도인 안전한 집계 경로와 익명 브라우저 식별 수단이 없었습니다.

## 변경
- 상세 HTML 응답 middleware에서 HTTP-only 익명 쿠키 선발급
- BFF에서 쿠키 원문 대신 SHA-256 해시만 백엔드로 전달
- 목록 카드와 상세 메타데이터에 조회수 표시
- 최초 동시 탭 방문 중복 방지 및 모바일 카드 폭 정리

## Test plan
- [x] Vitest 9개
- [x] pnpm lint
- [x] pnpm build
- [x] 수정·신규 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)