### PR TITLE
🐛 아티클 공개 경로 인증 회귀 수정

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -3,6 +3,18 @@ import { NextRequest } from 'next/server'
 import { middleware } from './middleware'
 
 describe('article viewer middleware', () => {
+  it.each(['/articles', '/articles/new'])(
+    'keeps the public article route %s accessible',
+    (pathname) => {
+      const request = new NextRequest(`https://bollae.kr${pathname}`)
+
+      const response = middleware(request)
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('location')).toBeNull()
+    },
+  )
+
   it('sets the anonymous viewer cookie before rendering an article detail', () => {
     const request = new NextRequest('https://bollae.kr/articles/4')
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,9 +6,10 @@ import {
 } from './lib/article-viewer-cookie'
 
 export function middleware(req: NextRequest) {
-  if (/^\/articles\/\d+$/.test(req.nextUrl.pathname)) {
+  if (req.nextUrl.pathname.startsWith('/articles')) {
     const response = NextResponse.next()
-    if (!req.cookies.has(ARTICLE_VIEWER_COOKIE)) {
+    const isArticleDetail = /^\/articles\/\d+$/.test(req.nextUrl.pathname)
+    if (isArticleDetail && !req.cookies.has(ARTICLE_VIEWER_COOKIE)) {
       response.cookies.set(
         ARTICLE_VIEWER_COOKIE,
         globalThis.crypto.randomUUID(),


### PR DESCRIPTION
## Summary
- 조회수 쿠키용 middleware matcher가 `/articles`, `/articles/new`를 인증 경로로 오인하던 문제 수정
- 숫자 상세 경로에서만 익명 조회 쿠키를 선발급
- 공개 아티클 경로 회귀 테스트 추가

## Test plan
- [x] middleware RED 테스트에서 목록/작성 경로 307 재현
- [x] 관련 Vitest 11개 통과
- [x] `pnpm lint` (기존 경고만 존재)
- [x] `pnpm build`
- [ ] 배포 후 `/articles`, `/articles/new` 공개 접근 확인

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>