### PR TITLE
✨ 동적 sitemap 인덱스 분할

### DIFF
--- a/docs/superpowers/plans/2026-07-26-sitemap-index.md
+++ b/docs/superpowers/plans/2026-07-26-sitemap-index.md
@@ -1,0 +1,100 @@
+# Sitemap Index Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 50-item sitemap with a dynamic index and paginated child sitemaps that include every public article and match.
+
+**Architecture:** Pure helpers discover page numbers from `hasNext` and map domain entities to sitemap fields. App Router handlers compose those helpers with existing repositories and `next-sitemap` XML response builders.
+
+**Tech Stack:** Next.js 13 App Router, TypeScript, next-sitemap, Vitest
+
+## Global Constraints
+
+- Keep every modified or new handwritten file at 200 lines or fewer.
+- Reuse repositories from server route handlers.
+- Do not add backend APIs or dependencies.
+- Keep `https://bollae.kr/sitemap.xml` as the only sitemap entry in robots.txt.
+
+---
+
+### Task 1: Sitemap helpers
+
+**Files:**
+- Create: `src/lib/sitemap/sitemap.ts`
+- Test: `src/lib/sitemap/sitemap.test.ts`
+
+**Interfaces:**
+- Produces: `discoverSitemapPages(fetchPage)`, field mapping helpers, and child sitemap URL builders.
+
+- [ ] **Step 1: Write failing tests**
+
+Cover multi-page discovery, stop conditions, canonical URLs, and real update
+dates.
+
+- [ ] **Step 2: Verify the tests fail**
+
+Run `pnpm exec vitest run src/lib/sitemap/sitemap.test.ts`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Use `SITEMAP_PAGE_SIZE = 100`, follow `hasNext`, and return
+`ISitemapField[]` for each domain.
+
+- [ ] **Step 4: Verify the tests pass**
+
+Run `pnpm exec vitest run src/lib/sitemap/sitemap.test.ts`.
+
+### Task 2: Sitemap route handlers
+
+**Files:**
+- Modify: `src/app/(root)/(routes)/sitemap.xml/route.ts`
+- Create: `src/app/(root)/(routes)/sitemaps/static.xml/route.ts`
+- Create: `src/app/(root)/(routes)/sitemaps/movies.xml/route.ts`
+- Create: `src/app/(root)/(routes)/sitemaps/articles/[page]/route.ts`
+- Create: `src/app/(root)/(routes)/sitemaps/matches/[page]/route.ts`
+
+**Interfaces:**
+- Consumes: Task 1 sitemap helpers.
+- Produces: sitemap index XML and child sitemap XML responses.
+
+- [ ] **Step 1: Add route contract tests**
+
+Assert the source contracts use `getServerSideSitemapIndex`, page validation,
+and paginated repository calls.
+
+- [ ] **Step 2: Verify the route tests fail**
+
+Run the focused sitemap tests.
+
+- [ ] **Step 3: Implement route handlers**
+
+Build the root index from independent page discovery calls and use
+`getServerSideSitemap` for child routes.
+
+- [ ] **Step 4: Verify focused tests pass**
+
+Run all sitemap tests.
+
+### Task 3: Verification and delivery
+
+**Files:**
+- Modify after deployment: `/Users/gimsihun/Documents/drunkenmovie/.claude/worklog.md`
+
+- [ ] **Step 1: Run automated verification**
+
+Run `pnpm exec vitest run`, `pnpm lint`, and `pnpm build`.
+
+- [ ] **Step 2: Check file size and formatting**
+
+Run `wc -l` on changed source files and `git diff --check`.
+
+- [ ] **Step 3: Commit, create PR, and deploy**
+
+Push the feature branch, merge through the repository's available PR flow, and
+wait for the deployment workflow.
+
+- [ ] **Step 4: Verify production XML**
+
+Confirm the root response is a sitemap index and every listed child sitemap
+returns valid XML containing expected production URLs.
+

--- a/docs/superpowers/plans/2026-07-26-sitemap-index.md
+++ b/docs/superpowers/plans/2026-07-26-sitemap-index.md
@@ -97,4 +97,3 @@ wait for the deployment workflow.
 
 Confirm the root response is a sitemap index and every listed child sitemap
 returns valid XML containing expected production URLs.
-

--- a/docs/superpowers/specs/2026-07-26-sitemap-index-design.md
+++ b/docs/superpowers/specs/2026-07-26-sitemap-index-design.md
@@ -1,0 +1,46 @@
+# Sitemap Index Design
+
+## Goal
+
+Remove the latest-50-content limit from `sitemap.xml` and expose every public
+article and match through paginated child sitemaps.
+
+## Architecture
+
+- `https://bollae.kr/sitemap.xml` becomes a sitemap index.
+- Static pages and the current movie collection each use one child sitemap.
+- Articles and matches use page-based child sitemaps with 100 URLs per page.
+- The index follows each public list API's `hasNext` value to discover every
+  available page without requiring a new backend count endpoint.
+- Each child route fetches only its own page and returns canonical absolute
+  URLs with the content's real `updatedAt` value.
+
+## Routes
+
+| Route | Responsibility |
+| --- | --- |
+| `/sitemap.xml` | List all child sitemap URLs |
+| `/sitemaps/static.xml` | Public static routes |
+| `/sitemaps/movies.xml` | Current public movie detail routes |
+| `/sitemaps/articles/:page` | One page of article detail routes |
+| `/sitemaps/matches/:page` | One page of match detail routes |
+
+XML responses do not require an `.xml` suffix, so dynamic page routes use a
+plain numeric final segment.
+
+## Failure Handling
+
+- Article and match page discovery fail independently.
+- A failed source is omitted from the index while healthy sources remain
+  available.
+- Invalid or non-positive page parameters return HTTP 404.
+- Empty child sitemap pages return a valid empty sitemap.
+
+## Testing
+
+- Verify page discovery continues beyond the former first page limit.
+- Verify discovery stops when `hasNext` becomes false.
+- Verify article, match, movie, and static URL field mapping.
+- Verify the sitemap index contains every discovered child page.
+- Run the full test suite, lint, production build, and 200-line checks.
+

--- a/docs/superpowers/specs/2026-07-26-sitemap-index-design.md
+++ b/docs/superpowers/specs/2026-07-26-sitemap-index-design.md
@@ -43,4 +43,3 @@ plain numeric final segment.
 - Verify article, match, movie, and static URL field mapping.
 - Verify the sitemap index contains every discovered child page.
 - Run the full test suite, lint, production build, and 200-line checks.
-

--- a/src/app/(root)/(routes)/sitemap-routes.test.ts
+++ b/src/app/(root)/(routes)/sitemap-routes.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readRoute = (routePath: string) =>
+  fs.readFileSync(path.join(process.cwd(), routePath), 'utf8')
+
+describe('sitemap route contracts', () => {
+  it('serves sitemap.xml as an index with independently discovered pages', () => {
+    const source = readRoute(
+      'src/app/(root)/(routes)/sitemap.xml/route.ts',
+    )
+
+    expect(source).toContain('getServerSideSitemapIndex')
+    expect(source).toContain('discoverSitemapPages')
+    expect(source).toContain('Promise.all')
+    expect(source).not.toContain('listArticles(1, 50)')
+  })
+
+  it('serves paginated article and match child sitemaps', () => {
+    const articleSource = readRoute(
+      'src/app/(root)/(routes)/sitemaps/articles/[page]/route.ts',
+    )
+    const matchSource = readRoute(
+      'src/app/(root)/(routes)/sitemaps/matches/[page]/route.ts',
+    )
+
+    expect(articleSource).toMatch(
+      /listArticles\(\s*page,\s*SITEMAP_PAGE_SIZE,\s*\)/,
+    )
+    expect(matchSource).toMatch(
+      /getMatchPosts\(\s*page,\s*SITEMAP_PAGE_SIZE,\s*\)/,
+    )
+    expect(articleSource).toContain('parseSitemapPage')
+    expect(matchSource).toContain('parseSitemapPage')
+  })
+})

--- a/src/app/(root)/(routes)/sitemap.xml/route.ts
+++ b/src/app/(root)/(routes)/sitemap.xml/route.ts
@@ -1,93 +1,34 @@
-import { MovieRepository } from '@/modules/movie/movie-repository'
 import { ArticleRepository } from '@/modules/article/article-repository'
 import { MatchPostRepository } from '@/modules/match/match-post-repository'
-import { ISitemapField } from 'next-sitemap'
-import { getServerSideSitemap } from 'next-sitemap'
+import {
+  buildIndexUrls,
+  discoverSitemapPages,
+} from '@/lib/sitemap/sitemap'
+import { getServerSideSitemapIndex } from 'next-sitemap'
 
 export const dynamic = 'force-dynamic'
 
-const SITE_URL = 'https://bollae.kr'
+const cacheHeaders = {
+  'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+}
 
-export async function GET(): Promise<ReturnType<typeof getServerSideSitemap>> {
-  const movies = await new MovieRepository().getMovie().catch(() => [])
+export async function GET() {
+  const articleRepository = new ArticleRepository()
+  const matchRepository = new MatchPostRepository()
 
-  const { articles } = await new ArticleRepository()
-    .listArticles(1, 50)
-    .catch(() => ({ articles: [], hasNext: false }))
+  const [articlePages, matchPages] = await Promise.all([
+    discoverSitemapPages(async (page, pageSize) => {
+      const result = await articleRepository.listArticles(page, pageSize)
+      return { itemCount: result.articles.length, hasNext: result.hasNext }
+    }).catch(() => []),
+    discoverSitemapPages(async (page, pageSize) => {
+      const result = await matchRepository.getMatchPosts(page, pageSize)
+      return { itemCount: result.matchPosts.length, hasNext: result.hasNext }
+    }).catch(() => []),
+  ])
 
-  const { matchPosts: matches } = await new MatchPostRepository()
-    .getMatchPosts(1, 50)
-    .catch(() => ({ matchPosts: [], hasNext: false }))
-
-  const fields: ISitemapField[] = []
-
-  // 영화 상세 페이지
-  if (movies && Array.isArray(movies)) {
-    fields.push(
-      ...movies.map((movie) => ({
-        loc: `${SITE_URL}/movie/${movie.id}`,
-        lastmod: movie.updatedAt?.toISOString?.() || new Date().toISOString(),
-        changefreq: 'daily' as const,
-        priority: 0.8,
-      })),
-    )
-  }
-
-  // 게시글 상세 페이지
-  if (articles && Array.isArray(articles)) {
-    fields.push(
-      ...articles.map((article) => ({
-        loc: `${SITE_URL}/articles/${article.id}`,
-        lastmod: article.updatedAt
-          ? new Date(article.updatedAt).toISOString()
-          : new Date().toISOString(),
-        changefreq: 'daily' as const,
-        priority: 0.6,
-      })),
-    )
-  }
-
-  // 매치 상세 페이지
-  if (matches && Array.isArray(matches)) {
-    fields.push(
-      ...matches.map((match) => ({
-        loc: `${SITE_URL}/match/${match.id}`,
-        lastmod: match.updatedAt
-          ? new Date(match.updatedAt).toISOString()
-          : new Date().toISOString(),
-        changefreq: 'weekly' as const,
-        priority: 0.5,
-      })),
-    )
-  }
-
-  // 주요 루트 경로
-  fields.push(
-    {
-      loc: `${SITE_URL}/`,
-      lastmod: new Date().toISOString(),
-      changefreq: 'daily' as const,
-      priority: 1.0,
-    },
-    {
-      loc: `${SITE_URL}/articles`,
-      lastmod: new Date().toISOString(),
-      changefreq: 'daily' as const,
-      priority: 0.9,
-    },
-    {
-      loc: `${SITE_URL}/account`,
-      lastmod: new Date().toISOString(),
-      changefreq: 'daily' as const,
-      priority: 0.5,
-    },
-    {
-      loc: `${SITE_URL}/match`,
-      lastmod: new Date().toISOString(),
-      changefreq: 'daily' as const,
-      priority: 0.7,
-    },
+  return getServerSideSitemapIndex(
+    buildIndexUrls(articlePages, matchPages),
+    cacheHeaders,
   )
-
-  return getServerSideSitemap(fields)
 }

--- a/src/app/(root)/(routes)/sitemaps/articles/[page]/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/articles/[page]/route.ts
@@ -1,0 +1,28 @@
+import {
+  buildArticleFields,
+  parseSitemapPage,
+  SITEMAP_PAGE_SIZE,
+} from '@/lib/sitemap/sitemap'
+import { ArticleRepository } from '@/modules/article/article-repository'
+import { getServerSideSitemap } from 'next-sitemap'
+
+interface RouteContext {
+  params: { page: string }
+}
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const page = parseSitemapPage(params.page)
+  if (!page) return new Response('Not Found', { status: 404 })
+
+  const { articles } = await new ArticleRepository().listArticles(
+    page,
+    SITEMAP_PAGE_SIZE,
+  )
+
+  return getServerSideSitemap(buildArticleFields(articles), {
+    'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+  })
+}
+

--- a/src/app/(root)/(routes)/sitemaps/articles/[page]/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/articles/[page]/route.ts
@@ -25,4 +25,3 @@ export async function GET(_request: Request, { params }: RouteContext) {
     'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
   })
 }
-

--- a/src/app/(root)/(routes)/sitemaps/matches/[page]/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/matches/[page]/route.ts
@@ -1,0 +1,28 @@
+import {
+  buildMatchFields,
+  parseSitemapPage,
+  SITEMAP_PAGE_SIZE,
+} from '@/lib/sitemap/sitemap'
+import { MatchPostRepository } from '@/modules/match/match-post-repository'
+import { getServerSideSitemap } from 'next-sitemap'
+
+interface RouteContext {
+  params: { page: string }
+}
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const page = parseSitemapPage(params.page)
+  if (!page) return new Response('Not Found', { status: 404 })
+
+  const { matchPosts } = await new MatchPostRepository().getMatchPosts(
+    page,
+    SITEMAP_PAGE_SIZE,
+  )
+
+  return getServerSideSitemap(buildMatchFields(matchPosts), {
+    'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+  })
+}
+

--- a/src/app/(root)/(routes)/sitemaps/matches/[page]/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/matches/[page]/route.ts
@@ -25,4 +25,3 @@ export async function GET(_request: Request, { params }: RouteContext) {
     'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
   })
 }
-

--- a/src/app/(root)/(routes)/sitemaps/movies.xml/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/movies.xml/route.ts
@@ -11,4 +11,3 @@ export async function GET() {
     'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
   })
 }
-

--- a/src/app/(root)/(routes)/sitemaps/movies.xml/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/movies.xml/route.ts
@@ -1,0 +1,14 @@
+import { buildMovieFields } from '@/lib/sitemap/sitemap'
+import { MovieRepository } from '@/modules/movie/movie-repository'
+import { getServerSideSitemap } from 'next-sitemap'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const movies = await new MovieRepository().getMovie().catch(() => [])
+
+  return getServerSideSitemap(buildMovieFields(movies), {
+    'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+  })
+}
+

--- a/src/app/(root)/(routes)/sitemaps/static.xml/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/static.xml/route.ts
@@ -1,0 +1,11 @@
+import { buildStaticFields } from '@/lib/sitemap/sitemap'
+import { getServerSideSitemap } from 'next-sitemap'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  return getServerSideSitemap(buildStaticFields(), {
+    'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+  })
+}
+

--- a/src/app/(root)/(routes)/sitemaps/static.xml/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/static.xml/route.ts
@@ -8,4 +8,3 @@ export async function GET() {
     'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
   })
 }
-

--- a/src/lib/sitemap/sitemap.test.ts
+++ b/src/lib/sitemap/sitemap.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildArticleFields,
+  buildIndexUrls,
+  buildMatchFields,
+  buildMovieFields,
+  buildStaticFields,
+  discoverSitemapPages,
+  parseSitemapPage,
+  SITEMAP_PAGE_SIZE,
+} from './sitemap'
+
+describe('sitemap helpers', () => {
+  it('discovers every populated page until hasNext becomes false', async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({ itemCount: 100, hasNext: true })
+      .mockResolvedValueOnce({ itemCount: 100, hasNext: true })
+      .mockResolvedValueOnce({ itemCount: 5, hasNext: false })
+
+    await expect(discoverSitemapPages(fetchPage)).resolves.toEqual([1, 2, 3])
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 1, SITEMAP_PAGE_SIZE)
+    expect(fetchPage).toHaveBeenNthCalledWith(3, 3, SITEMAP_PAGE_SIZE)
+  })
+
+  it('omits an empty source and stops inconsistent empty pagination', async () => {
+    await expect(
+      discoverSitemapPages(async () => ({ itemCount: 0, hasNext: true })),
+    ).resolves.toEqual([])
+  })
+
+  it('builds the sitemap index from discovered content pages', () => {
+    expect(buildIndexUrls([1, 2], [1])).toEqual([
+      'https://bollae.kr/sitemaps/static.xml',
+      'https://bollae.kr/sitemaps/movies.xml',
+      'https://bollae.kr/sitemaps/articles/1',
+      'https://bollae.kr/sitemaps/articles/2',
+      'https://bollae.kr/sitemaps/matches/1',
+    ])
+  })
+
+  it('maps public content to canonical detail URLs and update dates', () => {
+    expect(
+      buildArticleFields([
+        {
+          id: '51',
+          createdAt: '2026-07-01T00:00:00.000Z',
+          updatedAt: '2026-07-02T00:00:00.000Z',
+        },
+      ] as any),
+    ).toEqual([
+      {
+        loc: 'https://bollae.kr/articles/51',
+        lastmod: '2026-07-02T00:00:00.000Z',
+        changefreq: 'daily',
+        priority: 0.6,
+      },
+    ])
+
+    expect(
+      buildMatchFields([
+        {
+          id: 'match-1',
+          createdAt: '2026-07-03T00:00:00.000Z',
+        },
+      ] as any),
+    ).toEqual([
+      {
+        loc: 'https://bollae.kr/match/match-1',
+        lastmod: '2026-07-03T00:00:00.000Z',
+        changefreq: 'weekly',
+        priority: 0.5,
+      },
+    ])
+
+    expect(
+      buildMovieFields([
+        {
+          id: 20259946,
+          updatedAt: new Date('2026-07-04T00:00:00.000Z'),
+        },
+      ] as any),
+    ).toEqual([
+      {
+        loc: 'https://bollae.kr/movie/20259946',
+        lastmod: '2026-07-04T00:00:00.000Z',
+        changefreq: 'daily',
+        priority: 0.8,
+      },
+    ])
+  })
+
+  it('includes only public static routes and validates page parameters', () => {
+    expect(buildStaticFields().map((field) => field.loc)).toEqual([
+      'https://bollae.kr/',
+      'https://bollae.kr/articles',
+      'https://bollae.kr/match',
+    ])
+    expect(parseSitemapPage('2')).toBe(2)
+    expect(parseSitemapPage('0')).toBeNull()
+    expect(parseSitemapPage('1.5')).toBeNull()
+    expect(parseSitemapPage('abc')).toBeNull()
+  })
+})
+

--- a/src/lib/sitemap/sitemap.test.ts
+++ b/src/lib/sitemap/sitemap.test.ts
@@ -102,4 +102,3 @@ describe('sitemap helpers', () => {
     expect(parseSitemapPage('abc')).toBeNull()
   })
 })
-

--- a/src/lib/sitemap/sitemap.ts
+++ b/src/lib/sitemap/sitemap.ts
@@ -1,0 +1,102 @@
+import type { Article, MatchPost } from '@/lib/type'
+import type { Movie } from '@/modules/movie/movie.entity'
+import type { ISitemapField } from 'next-sitemap'
+
+export const SITE_URL = 'https://bollae.kr'
+export const SITEMAP_PAGE_SIZE = 100
+
+interface SitemapPageResult {
+  itemCount: number
+  hasNext: boolean
+}
+
+type SitemapPageFetcher = (
+  _page: number,
+  _pageSize: number,
+) => Promise<SitemapPageResult>
+
+export async function discoverSitemapPages(
+  fetchPage: SitemapPageFetcher,
+): Promise<number[]> {
+  const pages: number[] = []
+  let page = 1
+
+  while (true) {
+    const result = await fetchPage(page, SITEMAP_PAGE_SIZE)
+    if (result.itemCount < 1) break
+
+    pages.push(page)
+    if (!result.hasNext) break
+    page += 1
+  }
+
+  return pages
+}
+
+export function buildIndexUrls(
+  articlePages: number[],
+  matchPages: number[],
+): string[] {
+  return [
+    `${SITE_URL}/sitemaps/static.xml`,
+    `${SITE_URL}/sitemaps/movies.xml`,
+    ...articlePages.map(
+      (page) => `${SITE_URL}/sitemaps/articles/${page}`,
+    ),
+    ...matchPages.map((page) => `${SITE_URL}/sitemaps/matches/${page}`),
+  ]
+}
+
+export function buildArticleFields(articles: Article[]): ISitemapField[] {
+  return articles.map((article) => ({
+    loc: `${SITE_URL}/articles/${article.id}`,
+    lastmod: article.updatedAt ?? article.createdAt,
+    changefreq: 'daily',
+    priority: 0.6,
+  }))
+}
+
+export function buildMatchFields(matches: MatchPost[]): ISitemapField[] {
+  return matches.map((match) => ({
+    loc: `${SITE_URL}/match/${match.id}`,
+    lastmod: match.updatedAt ?? match.createdAt,
+    changefreq: 'weekly',
+    priority: 0.5,
+  }))
+}
+
+export function buildMovieFields(movies: Movie[]): ISitemapField[] {
+  return movies.map((movie) => ({
+    loc: `${SITE_URL}/movie/${movie.id}`,
+    lastmod: movie.updatedAt.toISOString(),
+    changefreq: 'daily',
+    priority: 0.8,
+  }))
+}
+
+export function buildStaticFields(): ISitemapField[] {
+  return [
+    {
+      loc: `${SITE_URL}/`,
+      changefreq: 'daily',
+      priority: 1,
+    },
+    {
+      loc: `${SITE_URL}/articles`,
+      changefreq: 'daily',
+      priority: 0.9,
+    },
+    {
+      loc: `${SITE_URL}/match`,
+      changefreq: 'daily',
+      priority: 0.7,
+    },
+  ]
+}
+
+export function parseSitemapPage(value: string): number | null {
+  if (!/^[1-9]\d*$/.test(value)) return null
+
+  const page = Number(value)
+  return Number.isSafeInteger(page) ? page : null
+}


### PR DESCRIPTION
## Summary
최신 50개만 포함하던 단일 sitemap을 동적 sitemap index와 콘텐츠별 하위 sitemap으로 전환합니다.

## 원인
기존 `/sitemap.xml`이 아티클과 매칭을 각각 첫 페이지 50개만 조회해, 콘텐츠가 늘어나면 과거 상세 URL이 sitemap에서 누락됩니다.

## 변경
- `/sitemap.xml`을 sitemap index로 변경
- 정적·영화·아티클·매칭 하위 sitemap 분리
- 아티클과 매칭은 100개 단위로 `hasNext`를 따라 전체 페이지 자동 발견
- 비공개 `/account` 경로를 sitemap에서 제거
- 실제 `updatedAt` 기반 `lastmod`와 캐시 헤더 적용

## Test plan
- [x] `pnpm exec vitest run` (29 files, 63 tests)
- [x] `pnpm lint` (errors 0, existing warnings only)
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 및 `git diff --check`
- [x] 로컬 production HTTP에서 index/child XML 및 invalid page 404 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 운영 `/sitemap.xml`과 하위 sitemap 확인

🤖 Generated with [Codex](https://openai.com/codex/)