### PR TITLE
✨ 공개 채팅 sitemap 등록

### DIFF
--- a/src/lib/sitemap/sitemap.test.ts
+++ b/src/lib/sitemap/sitemap.test.ts
@@ -95,6 +95,7 @@ describe('sitemap helpers', () => {
       'https://bollae.kr/',
       'https://bollae.kr/articles',
       'https://bollae.kr/match',
+      'https://bollae.kr/chat/public',
     ])
     expect(parseSitemapPage('2')).toBe(2)
     expect(parseSitemapPage('0')).toBeNull()

--- a/src/lib/sitemap/sitemap.ts
+++ b/src/lib/sitemap/sitemap.ts
@@ -91,6 +91,11 @@ export function buildStaticFields(): ISitemapField[] {
       changefreq: 'daily',
       priority: 0.7,
     },
+    {
+      loc: `${SITE_URL}/chat/public`,
+      changefreq: 'daily',
+      priority: 0.6,
+    },
   ]
 }
 


### PR DESCRIPTION
## Summary
공개 채팅 진입 페이지를 정적 sitemap에 추가합니다.

## 변경
- `/sitemaps/static.xml`에 `https://bollae.kr/chat/public` 등록
- 일일 변경 주기와 우선순위 0.6 적용
- 정적 sitemap 회귀 테스트 보강

## Test plan
- [x] `pnpm exec vitest run` (29 files, 63 tests)
- [x] `pnpm lint` (errors 0, existing warnings only)
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 및 `git diff --check`
- [ ] master 머지 후 배포 확인
- [ ] 운영 정적 sitemap에서 공개 채팅 URL 확인

🤖 Generated with [Codex](https://openai.com/codex/)