### PR TITLE
💄 아티클 댓글 입력창 위치 정리

### DIFF
--- a/src/app/(root)/(routes)/articles/[id]/page.tsx
+++ b/src/app/(root)/(routes)/articles/[id]/page.tsx
@@ -51,7 +51,7 @@ const Page: FunctionComponent<PageProps> = async ({ params: { id } }) => {
           dangerouslySetInnerHTML={{ __html: serializeJsonLd(value) }}
         />
       ))}
-      <div className="relative flex flex-col bg-background pb-[140px] lg:pb-6 text-foreground">
+      <div className="relative flex flex-col bg-background pb-6 text-foreground">
         <ModifyCommentModalContextProvider>
           <ModifyArticleModalContextProvider>
             <ArticleDataSection data={data} />

--- a/src/app/(root)/(routes)/articles/[id]/sections/active-section.tsx
+++ b/src/app/(root)/(routes)/articles/[id]/sections/active-section.tsx
@@ -15,7 +15,7 @@ const ActiveSection: FunctionComponent<ActiveSectionProps> = ({
   return (
     <div
       className={cn(
-        'fixed bottom-[calc(4rem+env(safe-area-inset-bottom)+0.5rem)] z-40 w-full max-w-[460px] border-t border-border bg-background/95 px-3 py-2 backdrop-blur-md lg:bottom-0',
+        'mt-4 border-t border-border bg-background px-4 py-4',
         className,
       )}
     >

--- a/src/app/(root)/(routes)/articles/article-view-ui.test.ts
+++ b/src/app/(root)/(routes)/articles/article-view-ui.test.ts
@@ -23,3 +23,14 @@ describe('article view count UI', () => {
     expect(detail).toContain('initialCount={data.viewCount}')
   })
 })
+
+describe('article comment layout', () => {
+  it('keeps the comment form in the document flow', () => {
+    const activeSection = read('./[id]/sections/active-section.tsx')
+    const detailPage = read('./[id]/page.tsx')
+
+    expect(activeSection).not.toContain("'fixed bottom-")
+    expect(activeSection).toContain("'mt-4 border-t")
+    expect(detailPage).not.toContain('pb-[140px]')
+  })
+})


### PR DESCRIPTION
## Summary
아티클 상세의 댓글 입력창을 댓글 목록 바로 아래 문서 흐름에 배치합니다.

## 원인
댓글 입력창이 viewport 하단에 fixed로 고정되고 페이지에 140px 보정 여백이 있어, 댓글이 없을 때 댓글 제목과 입력창 사이가 크게 비었습니다.

## 변경
- 댓글 입력창의 fixed/bottom/z-index/backdrop 스타일 제거
- 아티클 상세의 고정 입력창용 하단 여백 제거
- 문서 흐름 배치를 보장하는 회귀 테스트 추가

## Test plan
- [x] `pnpm exec vitest run src/app/(root)/(routes)/articles/article-view-ui.test.ts`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)