### PR TITLE
✨ 마이페이지 커뮤니티 활동 요약

### DIFF
--- a/src/app/(root)/account/account-community-summary.test.ts
+++ b/src/app/(root)/account/account-community-summary.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const read = (relativePath: string) =>
+  readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8')
+
+describe('account community summary', () => {
+  it('shows the four useful community activity metrics', () => {
+    const page = read('./page.tsx')
+    const section = read('./sections/community-summary-section.tsx')
+
+    expect(page).toContain('<CommunitySummarySection />')
+    expect(section).toContain('작성 댓글')
+    expect(section).toContain('영화 평가')
+    expect(section).toContain('작성 게시글')
+    expect(section).toContain('받은 좋아요')
+  })
+
+  it('loads the summary through an authenticated BFF route', () => {
+    const route = read('../../api/user/activity-summary/route.ts')
+    const datasource = read(
+      '../../../modules/user-activity/user-activity-datasource.ts',
+    )
+
+    expect(route).toContain('getAuthTokenFromRequest(request)')
+    expect(route).toContain('Authorization: `Bearer ${token}`')
+    expect(datasource).toContain('UserActivityClientApiEndpoint.getSummary()')
+  })
+
+  it('does not show the unsupported notification settings menu', () => {
+    const accountSection = read('./sections/account-section.tsx')
+
+    expect(accountSection).not.toContain('알림 설정')
+  })
+
+  it('offers a retry when the summary cannot be loaded', () => {
+    const section = read('./sections/community-summary-section.tsx')
+
+    expect(section).toContain('활동 정보를 불러오지 못했어요.')
+    expect(section).toContain('mutate()')
+  })
+})

--- a/src/app/(root)/account/page.tsx
+++ b/src/app/(root)/account/page.tsx
@@ -2,12 +2,14 @@ import { FunctionComponent } from 'react'
 import AccountSection from './sections/account-section'
 import ProfileSection from './sections/profile-section'
 import { UpdateProfileModalContextProvider } from './hooks/use-update-profile-modal-context'
+import CommunitySummarySection from './sections/community-summary-section'
 
 const Page: FunctionComponent = () => {
   return (
     <main className="min-h-page pb-5">
       <UpdateProfileModalContextProvider>
         <ProfileSection />
+        <CommunitySummarySection />
         <AccountSection />
       </UpdateProfileModalContextProvider>
     </main>

--- a/src/app/(root)/account/sections/account-section.tsx
+++ b/src/app/(root)/account/sections/account-section.tsx
@@ -11,7 +11,6 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
-import { AppPath } from '@/config/app-path'
 import { signOut } from 'next-auth/react'
 import Link from 'next/link'
 import { FunctionComponent, useState } from 'react'
@@ -28,29 +27,48 @@ function MenuRow({ item, isLast }: { item: MenuItem; isLast: boolean }) {
     <div
       className={`flex w-full items-center px-4 py-3.5 text-left transition-colors hover:bg-accent ${!isLast ? 'border-b border-border' : ''}`}
     >
-      <span className={`text-[14px] ${item.destructive ? 'text-destructive' : 'text-foreground'}`}>
+      <span
+        className={`text-[14px] ${item.destructive ? 'text-destructive' : 'text-foreground'}`}
+      >
         {item.label}
       </span>
       {!item.destructive && (
         <svg
-          width="7" height="12" viewBox="0 0 8 14"
-          aria-hidden className="ml-auto text-muted-foreground"
+          width="7"
+          height="12"
+          viewBox="0 0 8 14"
+          aria-hidden
+          className="ml-auto text-muted-foreground"
         >
-          <path d="M1 1l6 6-6 6" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+          <path
+            d="M1 1l6 6-6 6"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       )}
     </div>
   )
   if (item.href) return <Link href={item.href}>{inner}</Link>
-  return <button type="button" onClick={item.onClick} className="block w-full">{inner}</button>
+  return (
+    <button type="button" onClick={item.onClick} className="block w-full">
+      {inner}
+    </button>
+  )
 }
 
 const AccountSection: FunctionComponent = () => {
   const [isDeleting, setIsDeleting] = useState(false)
   const items: MenuItem[] = [
     { label: '내 매칭', href: '/match/my-matches' },
-    { label: '알림 설정', href: AppPath.settings() },
-    { label: '로그아웃', onClick: () => signOut({ callbackUrl: '/' }), destructive: true },
+    {
+      label: '로그아웃',
+      onClick: () => signOut({ callbackUrl: '/' }),
+      destructive: true,
+    },
   ]
 
   const handleDeleteAccount = async () => {
@@ -74,12 +92,16 @@ const AccountSection: FunctionComponent = () => {
   return (
     <section>
       <div className="flex items-center border-b border-border px-4 py-3.5">
-        <h1 className="text-[18px] font-bold tracking-tight text-foreground">계정</h1>
+        <h1 className="text-[18px] font-bold tracking-tight text-foreground">
+          계정
+        </h1>
       </div>
 
       <div className="px-4 pt-4">
-        <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">활동</p>
-        <div className="rounded-lg border border-border bg-card overflow-hidden">
+        <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
+          활동
+        </p>
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
           {items.map((it, i) => (
             <MenuRow key={it.label} item={it} isLast={i === items.length - 1} />
           ))}
@@ -87,8 +109,10 @@ const AccountSection: FunctionComponent = () => {
       </div>
 
       <div className="px-4 pt-4">
-        <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">계정 관리</p>
-        <div className="rounded-lg border border-border bg-card overflow-hidden">
+        <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
+          계정 관리
+        </p>
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <button
@@ -106,7 +130,9 @@ const AccountSection: FunctionComponent = () => {
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
-                <AlertDialogCancel disabled={isDeleting}>취소</AlertDialogCancel>
+                <AlertDialogCancel disabled={isDeleting}>
+                  취소
+                </AlertDialogCancel>
                 <AlertDialogAction
                   disabled={isDeleting}
                   onClick={(event) => {

--- a/src/app/(root)/account/sections/community-summary-section.tsx
+++ b/src/app/(root)/account/sections/community-summary-section.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { FileText, Heart, MessageCircle, RefreshCw, Star } from 'lucide-react'
+import Link from 'next/link'
+import useSWR from 'swr'
+import {
+  UserActivityRepository,
+  UserActivityRequestError,
+} from '@/modules/user-activity'
+
+const repository = new UserActivityRepository()
+
+const metrics = [
+  { key: 'articleCommentCount', label: '작성 댓글', icon: MessageCircle },
+  { key: 'movieRatingCount', label: '영화 평가', icon: Star },
+  { key: 'articleCount', label: '작성 게시글', icon: FileText },
+  { key: 'receivedLikeCount', label: '받은 좋아요', icon: Heart },
+] as const
+
+export default function CommunitySummarySection() {
+  const { data, error, isLoading, mutate } = useSWR(
+    'account-community-summary',
+    () => repository.getSummary(),
+    { revalidateOnFocus: false },
+  )
+  const isUnauthorized =
+    error instanceof UserActivityRequestError && error.status === 401
+
+  return (
+    <section className="border-b border-border px-4 py-5">
+      <h2 className="mb-3 text-[18px] font-bold tracking-tight text-foreground">
+        나의 커뮤니티
+      </h2>
+      <div className="grid grid-cols-2 overflow-hidden rounded-lg border border-border bg-card">
+        {metrics.map(({ key, label, icon: Icon }, index) => (
+          <div
+            key={key}
+            className={`min-w-0 p-4 ${
+              index % 2 === 0 ? 'border-r border-border' : ''
+            } ${index < 2 ? 'border-b border-border' : ''}`}
+          >
+            <Icon className="mb-3 h-4 w-4 text-muted-foreground" />
+            <div className="font-mono text-[26px] font-bold leading-none text-foreground">
+              {isLoading ? (
+                <span className="inline-block h-6 w-10 animate-pulse rounded bg-secondary" />
+              ) : error || !data ? (
+                '—'
+              ) : (
+                (data?.[key] ?? 0).toLocaleString('ko-KR')
+              )}
+            </div>
+            <p className="mt-2 text-[12px] text-muted-foreground">{label}</p>
+          </div>
+        ))}
+      </div>
+      {error && (
+        <div
+          role="alert"
+          className="mt-3 flex items-center justify-between gap-3 border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] text-destructive"
+        >
+          <span>
+            {isUnauthorized
+              ? '세션이 만료됐어요.'
+              : '활동 정보를 불러오지 못했어요.'}
+          </span>
+          {isUnauthorized ? (
+            <Link
+              href="/login?callbackUrl=%2Faccount"
+              className="shrink-0 font-semibold underline underline-offset-2"
+            >
+              다시 로그인
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => mutate()}
+              aria-label="활동 정보 다시 불러오기"
+              title="다시 불러오기"
+              className="shrink-0 p-1 hover:text-foreground"
+            >
+              <RefreshCw className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/app/api/user/activity-summary/route.test.ts
+++ b/src/app/api/user/activity-summary/route.test.ts
@@ -1,0 +1,68 @@
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from './route'
+
+vi.mock('@/lib/utils/getToken', () => ({ getAuthTokenFromRequest: vi.fn() }))
+
+const mockAuthToken = vi.mocked(getAuthTokenFromRequest)
+
+describe('user activity summary BFF', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns 401 without a current token', async () => {
+    mockAuthToken.mockResolvedValue(undefined)
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/user/activity-summary'),
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  it('forwards the current token and upstream response', async () => {
+    mockAuthToken.mockResolvedValue('oauth-token')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ articleCount: 2 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/user/activity-summary'),
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/user/activity-summary'),
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer oauth-token' },
+      }),
+    )
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ articleCount: 2 })
+  })
+
+  it('preserves an expired-token response from the backend', async () => {
+    mockAuthToken.mockResolvedValue('expired-token')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: '로그인이 필요합니다.' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    )
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/user/activity-summary'),
+    )
+
+    expect(response.status).toBe(401)
+  })
+})

--- a/src/app/api/user/activity-summary/route.ts
+++ b/src/app/api/user/activity-summary/route.ts
@@ -1,0 +1,29 @@
+import { getAuthTokenFromRequest } from '@/lib/utils/getToken'
+import { NextRequest, NextResponse } from 'next/server'
+import { UserActivityBackEndApiEndpoint } from '../../../../config/user-activity-backend-api-endpoint'
+
+export async function GET(request: NextRequest) {
+  const token = await getAuthTokenFromRequest(request)
+  if (!token) {
+    return NextResponse.json(
+      { message: '로그인이 필요합니다.' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    const response = await fetch(UserActivityBackEndApiEndpoint.getSummary(), {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    })
+    const body = await response.json().catch(() => ({
+      message: '커뮤니티 활동을 불러오지 못했습니다.',
+    }))
+    return NextResponse.json(body, { status: response.status })
+  } catch {
+    return NextResponse.json(
+      { message: '커뮤니티 활동을 불러오지 못했습니다.' },
+      { status: 502 },
+    )
+  }
+}

--- a/src/config/user-activity-backend-api-endpoint.ts
+++ b/src/config/user-activity-backend-api-endpoint.ts
@@ -1,0 +1,8 @@
+const base =
+  process.env.SERVER_API ||
+  process.env.NEXT_PUBLIC_SERVER_API ||
+  'http://127.0.0.1:3030'
+
+export const UserActivityBackEndApiEndpoint = {
+  getSummary: () => `${base}/user/activity-summary`,
+}

--- a/src/config/user-activity-client-api-endpoint.ts
+++ b/src/config/user-activity-client-api-endpoint.ts
@@ -1,0 +1,3 @@
+export const UserActivityClientApiEndpoint = {
+  getSummary: () => '/api/user/activity-summary',
+}

--- a/src/modules/user-activity/index.ts
+++ b/src/modules/user-activity/index.ts
@@ -1,0 +1,2 @@
+export * from './user-activity-entity'
+export * from './user-activity-repository'

--- a/src/modules/user-activity/user-activity-datasource.ts
+++ b/src/modules/user-activity/user-activity-datasource.ts
@@ -1,0 +1,17 @@
+import { UserActivityClientApiEndpoint } from '@/config/user-activity-client-api-endpoint'
+import {
+  UserActivityRequestError,
+  type UserActivitySummary,
+} from './user-activity-entity'
+
+export class UserActivityDatasource {
+  async getSummary(): Promise<UserActivitySummary> {
+    const response = await fetch(UserActivityClientApiEndpoint.getSummary(), {
+      cache: 'no-store',
+    })
+    if (!response.ok) {
+      throw new UserActivityRequestError(response.status)
+    }
+    return response.json()
+  }
+}

--- a/src/modules/user-activity/user-activity-entity.ts
+++ b/src/modules/user-activity/user-activity-entity.ts
@@ -1,0 +1,15 @@
+export interface UserActivitySummary {
+  articleCommentCount: number
+  movieRatingCount: number
+  articleCount: number
+  receivedLikeCount: number
+}
+
+export class UserActivityRequestError extends Error {
+  readonly status: number
+
+  constructor(status: number) {
+    super('커뮤니티 활동을 불러오지 못했습니다.')
+    this.status = status
+  }
+}

--- a/src/modules/user-activity/user-activity-repository.ts
+++ b/src/modules/user-activity/user-activity-repository.ts
@@ -1,0 +1,9 @@
+import { UserActivityDatasource } from './user-activity-datasource'
+
+export class UserActivityRepository {
+  private readonly datasource = new UserActivityDatasource()
+
+  getSummary() {
+    return this.datasource.getSummary()
+  }
+}


### PR DESCRIPTION
## Summary
마이페이지 첫 화면에서 커뮤니티 활동을 숫자로 바로 확인할 수 있게 합니다.

## 변경
- 작성 댓글·영화 평가·작성 게시글·받은 좋아요 2x2 요약 패널 추가
- 인증 BFF와 user-activity 모듈 추가
- 만료 세션 재로그인, 일시 오류 재시도 상태 제공
- 미지원 알림 설정 메뉴 제거

## Test plan
- [x] Vitest 7 tests
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 수정·신규 파일 200줄 상한 확인
- [x] 코드 리뷰 Critical/Important 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)