### PR TITLE
💄 계정 활동 화면 정보 구조 개선

### DIFF
--- a/docs/superpowers/plans/2026-08-04-account-dashboard-polish.md
+++ b/docs/superpowers/plans/2026-08-04-account-dashboard-polish.md
@@ -1,0 +1,8 @@
+# Account dashboard polish implementation plan
+
+1. Add failing backend tests for combined movie/article comments and summary totals.
+2. Extract comment activity queries into a focused service and return target metadata.
+3. Add failing frontend contracts for comment routing/deletion, poster rendering, likes, and layout.
+4. Update activity entities, datasource, rows, tabs, profile and account page composition.
+5. Run focused tests, lint, builds, line-count checks, and responsive visual verification.
+6. Merge backend before frontend, watch Actions, and verify production routes/UI.

--- a/docs/superpowers/specs/2026-08-04-account-dashboard-polish-design.md
+++ b/docs/superpowers/specs/2026-08-04-account-dashboard-polish-design.md
@@ -1,0 +1,32 @@
+# Account dashboard polish
+
+## Goal
+
+Make `/account` feel like a film profile rather than a settings form, while fixing
+missing movie comments, broken rating posters, and unclear received-like counts.
+
+## Layout
+
+- Mobile: profile header, one-line activity tabs, selected activity feed, account actions.
+- Desktop: narrow profile/account rail and a wider activity feed.
+- Activity tabs use icons, counts, and an underline instead of boxed 2x2 cards or a filled black state.
+- The selected feed has a clear title and total count. Rows use film posters where relevant and compact metadata.
+
+## Data
+
+- `comments` combines movie `Comment` and `articleComments`, newest first.
+- Each comment carries its target type, target id, and target title so navigation and deletion use the correct endpoint.
+- The summary comment count includes both sources.
+- Received-like rows surface the like count as a dedicated badge.
+
+## Reliability
+
+- Rating posters reuse the app's poster renderer, avoiding host restrictions from direct `next/image` usage.
+- Existing authentication and soft-delete behavior remain unchanged.
+- Empty, loading, retry, pagination, and delete-confirmation states remain available.
+
+## Verification
+
+- Backend tests cover merged ordering, pagination, and combined count.
+- Frontend tests cover target routing, delete endpoint selection, prominent likes, and the responsive dashboard structure.
+- Validate mobile and desktop screenshots without page-level horizontal scrolling.

--- a/src/app/(root)/account/account-community-summary.test.ts
+++ b/src/app/(root)/account/account-community-summary.test.ts
@@ -17,13 +17,15 @@ describe('account community summary', () => {
     expect(section).toContain('받은 좋아요')
   })
 
-  it('uses a one-line four-column activity navigation without a heading', () => {
+  it('uses a one-line tab navigation with a restrained active state', () => {
     const section = read('./sections/community-summary-section.tsx')
     const navigation = read('./components/activity/activity-summary-nav.tsx')
 
     expect(section).not.toContain('나의 커뮤니티')
     expect(navigation).toContain('grid-cols-4')
     expect(navigation).toContain('aria-pressed')
+    expect(navigation).toContain('border-b-2')
+    expect(navigation).not.toContain('bg-foreground text-background')
   })
 
   it('renders linked activity rows and delete controls', () => {
@@ -32,9 +34,23 @@ describe('account community summary', () => {
 
     expect(item).toContain('/articles/${item.articleId}')
     expect(item).toContain('/movie/${item.movieCd}')
+    expect(item).toContain("item.targetType === 'movie'")
+    expect(item).toContain('targetTitle')
+    expect(item).toContain('Poster')
+    expect(item).not.toContain("from 'next/image'")
+    expect(item).toContain('좋아요 {item.likeCount}')
+    expect(item).toContain('rounded-full')
     expect(item).toContain('삭제')
     expect(panel).toContain('ActivityDeleteDialog')
     expect(panel).toContain('더 보기')
+  })
+
+  it('uses a responsive profile rail and activity workspace', () => {
+    const page = read('./page.tsx')
+
+    expect(page).toContain('xl:grid-cols-[200px_minmax(0,1fr)]')
+    expect(page).toContain('<aside')
+    expect(page).toContain('<section')
   })
 
   it('loads the summary through an authenticated BFF route', () => {

--- a/src/app/(root)/account/components/activity/activity-list-item.tsx
+++ b/src/app/(root)/account/components/activity/activity-list-item.tsx
@@ -1,9 +1,16 @@
+import { Poster, paletteForMovie } from '@/components/dm'
 import {
   DeletableActivityItem,
   UserActivityItem,
 } from '@/modules/user-activity'
-import { ChevronRight, Film, Heart, Star, Trash2 } from 'lucide-react'
-import Image from 'next/image'
+import {
+  ChevronRight,
+  FileText,
+  Heart,
+  MessageCircle,
+  Star,
+  Trash2,
+} from 'lucide-react'
 import Link from 'next/link'
 
 const formatDate = (value: string) =>
@@ -14,64 +21,90 @@ const formatDate = (value: string) =>
 const isDeletable = (item: UserActivityItem): item is DeletableActivityItem =>
   item.type !== 'like'
 
+const getHref = (item: UserActivityItem) => {
+  if (item.type === 'rating') return `/movie/${item.movieCd}`
+  if (item.type === 'comment') {
+    return item.targetType === 'movie'
+      ? `/movie/${item.targetId}`
+      : `/articles/${item.targetId}`
+  }
+  return `/articles/${item.articleId}`
+}
+
 interface Props {
   item: UserActivityItem
   onDelete: (_item: DeletableActivityItem) => void
 }
 
 export default function ActivityListItem({ item, onDelete }: Props) {
-  const href =
-    item.type === 'rating'
-      ? `/movie/${item.movieCd}`
-      : `/articles/${item.articleId}`
+  const title =
+    item.type === 'comment'
+      ? item.targetTitle
+      : item.type === 'rating'
+        ? item.movieTitle
+        : item.title
+  const timestamp = item.type === 'rating' ? item.ratedAt : item.createdAt
 
   return (
-    <div className="flex min-h-[78px] items-center gap-3 border-b border-border px-4 py-3 last:border-b-0">
-      <Link href={href} className="flex min-w-0 flex-1 items-center gap-3">
-        {item.type === 'rating' && (
-          <div className="relative h-14 w-10 shrink-0 overflow-hidden bg-secondary">
-            {item.poster ? (
-              <Image
-                src={item.poster}
-                alt={`${item.movieTitle} 포스터`}
-                fill
-                sizes="40px"
-                className="object-cover"
-              />
+    <div className="flex min-h-[88px] items-center gap-3 border-b border-border py-3.5 last:border-b-0">
+      <Link
+        href={getHref(item)}
+        className="flex min-w-0 flex-1 items-center gap-3"
+      >
+        {item.type === 'rating' ? (
+          <div className="w-12 shrink-0">
+            <Poster
+              title={item.movieTitle}
+              imageUrl={item.poster}
+              palette={paletteForMovie(item.movieCd)}
+              className="w-12"
+            />
+          </div>
+        ) : (
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-secondary text-muted-foreground">
+            {item.type === 'comment' ? (
+              <MessageCircle className="h-4 w-4" />
+            ) : item.type === 'like' ? (
+              <Heart className="h-4 w-4" />
             ) : (
-              <Film className="absolute inset-0 m-auto h-4 w-4 text-muted-foreground" />
+              <FileText className="h-4 w-4" />
             )}
           </div>
         )}
         <div className="min-w-0 flex-1">
-          <p className="flex items-center gap-1 truncate text-[13px] font-semibold text-foreground">
-            {item.type === 'comment' ? item.articleTitle : null}
-            {item.type === 'rating' ? item.movieTitle : null}
-            {item.type === 'article' || item.type === 'like'
-              ? item.title
-              : null}
+          <p className="flex items-center gap-1 truncate text-[14px] font-semibold text-foreground">
+            {title}
             <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           </p>
           {item.type === 'comment' && (
-            <p className="mt-1 truncate text-[13px] text-muted-foreground">
-              &ldquo;{item.content}&rdquo;
-            </p>
+            <>
+              <span className="mt-1 block text-[10px] font-medium text-muted-foreground">
+                {item.targetType === 'movie' ? '영화 댓글' : '게시글 댓글'}
+              </span>
+              <p className="mt-0.5 truncate text-[13px] text-muted-foreground">
+                &ldquo;{item.content}&rdquo;
+              </p>
+            </>
           )}
           {item.type === 'rating' && (
-            <p className="mt-1 flex items-center gap-1 text-[13px] text-muted-foreground">
+            <p className="mt-1 flex items-center gap-1 text-[13px] font-medium text-foreground">
               <Star className="h-3.5 w-3.5 fill-current" /> {item.score}점
             </p>
           )}
-          {(item.type === 'article' || item.type === 'like') && (
-            <p className="mt-1 flex items-center gap-1 text-[12px] text-muted-foreground">
-              <Heart className="h-3.5 w-3.5" /> 좋아요 {item.likeCount}
-              {item.type === 'article' && ` · 댓글 ${item.commentCount}`}
+          {item.type === 'article' && (
+            <p className="mt-1 text-[12px] text-muted-foreground">
+              좋아요 {item.likeCount} · 댓글 {item.commentCount}
             </p>
           )}
           <p className="mt-1 font-mono text-[10px] text-muted-foreground">
-            {formatDate(item.type === 'rating' ? item.ratedAt : item.createdAt)}
+            {formatDate(timestamp)}
           </p>
         </div>
+        {item.type === 'like' && (
+          <span className="flex shrink-0 items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 font-mono text-[12px] font-bold text-primary">
+            <Heart className="h-3 w-3 fill-current" /> 좋아요 {item.likeCount}
+          </span>
+        )}
       </Link>
       {isDeletable(item) && (
         <button

--- a/src/app/(root)/account/components/activity/activity-list-panel.tsx
+++ b/src/app/(root)/account/components/activity/activity-list-panel.tsx
@@ -15,6 +15,13 @@ const emptyMessages: Record<UserActivityType, string> = {
   likes: '아직 받은 좋아요가 없어요.',
 }
 
+const titles: Record<UserActivityType, string> = {
+  comments: '내가 쓴 댓글',
+  ratings: '내 영화 평가',
+  articles: '내 게시글',
+  likes: '좋아요 받은 게시글',
+}
+
 interface Props {
   type: UserActivityType
   onDeleted: () => void
@@ -24,7 +31,15 @@ export default function ActivityListPanel({ type, onDeleted }: Props) {
   const activity = useAccountActivity(type, onDeleted)
 
   return (
-    <div className="border-b border-border bg-card">
+    <div className="bg-background">
+      <div className="flex items-end justify-between border-b border-border px-4 py-4 sm:px-5">
+        <h2 className="text-[17px] font-bold text-foreground">
+          {titles[type]}
+        </h2>
+        <span className="font-mono text-[12px] text-muted-foreground">
+          {activity.totalCount.toLocaleString('ko-KR')}개
+        </span>
+      </div>
       {activity.isLoading ? (
         <div className="space-y-3 px-4 py-4">
           {[0, 1, 2].map((item) => (
@@ -51,12 +66,12 @@ export default function ActivityListPanel({ type, onDeleted }: Props) {
           {emptyMessages[type]}
         </p>
       ) : (
-        <div>
+        <div className="px-4 sm:px-5">
           {activity.items.map((item) => (
             <ActivityListItem
               key={
                 item.type === 'comment'
-                  ? `comment-${item.id}`
+                  ? `comment-${item.targetType}-${item.id}`
                   : item.type === 'rating'
                     ? `rating-${item.movieCd}`
                     : `${item.type}-${item.articleId}`

--- a/src/app/(root)/account/components/activity/activity-summary-nav.tsx
+++ b/src/app/(root)/account/components/activity/activity-summary-nav.tsx
@@ -1,10 +1,26 @@
 import { UserActivitySummary, UserActivityType } from '@/modules/user-activity'
+import { FileText, Heart, MessageCircle, Star } from 'lucide-react'
 
 const metrics = [
-  { type: 'comments', key: 'articleCommentCount', label: '작성 댓글' },
-  { type: 'ratings', key: 'movieRatingCount', label: '영화 평가' },
-  { type: 'articles', key: 'articleCount', label: '작성 게시글' },
-  { type: 'likes', key: 'receivedLikeCount', label: '받은 좋아요' },
+  {
+    type: 'comments',
+    key: 'articleCommentCount',
+    label: '작성 댓글',
+    icon: MessageCircle,
+  },
+  { type: 'ratings', key: 'movieRatingCount', label: '영화 평가', icon: Star },
+  {
+    type: 'articles',
+    key: 'articleCount',
+    label: '작성 게시글',
+    icon: FileText,
+  },
+  {
+    type: 'likes',
+    key: 'receivedLikeCount',
+    label: '받은 좋아요',
+    icon: Heart,
+  },
 ] as const
 
 interface Props {
@@ -21,8 +37,8 @@ export default function ActivitySummaryNav({
   onSelect,
 }: Props) {
   return (
-    <div className="grid grid-cols-4 border-y border-border bg-background">
-      {metrics.map(({ type, key, label }, index) => {
+    <div className="grid grid-cols-4 border-b border-border bg-background px-2 sm:px-3">
+      {metrics.map(({ type, key, label, icon: Icon }) => {
         const active = selected === type
         return (
           <button
@@ -30,22 +46,21 @@ export default function ActivitySummaryNav({
             type="button"
             aria-pressed={active}
             onClick={() => onSelect(type)}
-            className={`min-w-0 px-1 py-4 text-center transition-colors ${
-              index > 0 ? 'border-l border-border' : ''
-            } ${active ? 'bg-foreground text-background' : 'hover:bg-accent'}`}
+            className={`min-w-0 border-b-2 px-1 py-3 text-center transition-colors ${
+              active
+                ? 'border-foreground text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
           >
-            <span className="block font-mono text-[22px] font-bold leading-none">
+            <span className="flex items-center justify-center gap-1.5 font-mono text-[20px] font-bold leading-none">
+              <Icon className="h-3.5 w-3.5" />
               {isLoading ? (
                 <span className="inline-block h-5 w-7 animate-pulse bg-secondary" />
               ) : (
                 (summary?.[key] ?? 0).toLocaleString('ko-KR')
               )}
             </span>
-            <span
-              className={`mt-2 block truncate text-[11px] sm:text-[12px] ${
-                active ? 'text-background/75' : 'text-muted-foreground'
-              }`}
-            >
+            <span className="mt-1.5 block truncate text-[10px] sm:text-[11px]">
               {label}
             </span>
           </button>

--- a/src/app/(root)/account/hooks/use-account-activity.ts
+++ b/src/app/(root)/account/hooks/use-account-activity.ts
@@ -33,6 +33,7 @@ export function useAccountActivity(
 
   const items = data?.flatMap((page) => page.items) ?? []
   const hasNext = data?.[data.length - 1]?.hasNext ?? false
+  const totalCount = data?.[0]?.totalCount ?? 0
   const isLoadingMore = isLoading || (size > 0 && !data?.[size - 1])
 
   const deleteItem = async () => {
@@ -57,6 +58,7 @@ export function useAccountActivity(
     isLoading,
     isLoadingMore,
     hasNext,
+    totalCount,
     deleteTarget,
     deleteError,
     isDeleting,

--- a/src/app/(root)/account/page.tsx
+++ b/src/app/(root)/account/page.tsx
@@ -6,11 +6,19 @@ import CommunitySummarySection from './sections/community-summary-section'
 
 const Page: FunctionComponent = () => {
   return (
-    <main className="min-h-page pb-5">
+    <main className="min-h-page pb-8">
       <UpdateProfileModalContextProvider>
-        <ProfileSection />
-        <CommunitySummarySection />
-        <AccountSection />
+        <div className="xl:grid xl:grid-cols-[200px_minmax(0,1fr)] xl:gap-6 xl:px-6 xl:py-7">
+          <aside className="xl:col-start-1 xl:row-start-1">
+            <ProfileSection />
+          </aside>
+          <section className="min-w-0 xl:col-start-2 xl:row-span-2 xl:row-start-1">
+            <CommunitySummarySection />
+          </section>
+          <aside className="xl:col-start-1 xl:row-start-2">
+            <AccountSection />
+          </aside>
+        </div>
       </UpdateProfileModalContextProvider>
     </main>
   )

--- a/src/app/(root)/account/sections/account-section.tsx
+++ b/src/app/(root)/account/sections/account-section.tsx
@@ -14,41 +14,32 @@ import {
 import { signOut } from 'next-auth/react'
 import Link from 'next/link'
 import { FunctionComponent, useState } from 'react'
+import { ChevronRight, Clapperboard, LogOut } from 'lucide-react'
 
 interface MenuItem {
   label: string
   href?: string
   onClick?: () => void
   destructive?: boolean
+  icon: typeof Clapperboard
 }
 
 function MenuRow({ item, isLast }: { item: MenuItem; isLast: boolean }) {
+  const Icon = item.icon
   const inner = (
     <div
       className={`flex w-full items-center px-4 py-3.5 text-left transition-colors hover:bg-accent ${!isLast ? 'border-b border-border' : ''}`}
     >
+      <Icon
+        className={`mr-3 h-4 w-4 ${item.destructive ? 'text-destructive' : 'text-muted-foreground'}`}
+      />
       <span
         className={`text-[14px] ${item.destructive ? 'text-destructive' : 'text-foreground'}`}
       >
         {item.label}
       </span>
       {!item.destructive && (
-        <svg
-          width="7"
-          height="12"
-          viewBox="0 0 8 14"
-          aria-hidden
-          className="ml-auto text-muted-foreground"
-        >
-          <path
-            d="M1 1l6 6-6 6"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            fill="none"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
+        <ChevronRight className="ml-auto h-4 w-4 text-muted-foreground" />
       )}
     </div>
   )
@@ -63,11 +54,12 @@ function MenuRow({ item, isLast }: { item: MenuItem; isLast: boolean }) {
 const AccountSection: FunctionComponent = () => {
   const [isDeleting, setIsDeleting] = useState(false)
   const items: MenuItem[] = [
-    { label: '내 매칭', href: '/match/my-matches' },
+    { label: '내 매칭', href: '/match/my-matches', icon: Clapperboard },
     {
       label: '로그아웃',
       onClick: () => signOut({ callbackUrl: '/' }),
       destructive: true,
+      icon: LogOut,
     },
   ]
 
@@ -90,29 +82,23 @@ const AccountSection: FunctionComponent = () => {
   }
 
   return (
-    <section>
-      <div className="flex items-center border-b border-border px-4 py-3.5">
-        <h1 className="text-[18px] font-bold tracking-tight text-foreground">
-          계정
-        </h1>
-      </div>
-
-      <div className="px-4 pt-4">
+    <section className="border-t border-border px-4 py-5 xl:mt-6 xl:px-0">
+      <div>
         <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
-          활동
+          바로가기
         </p>
-        <div className="overflow-hidden rounded-lg border border-border bg-card">
+        <div className="overflow-hidden border-y border-border bg-background">
           {items.map((it, i) => (
             <MenuRow key={it.label} item={it} isLast={i === items.length - 1} />
           ))}
         </div>
       </div>
 
-      <div className="px-4 pt-4">
+      <div className="pt-5">
         <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
           계정 관리
         </p>
-        <div className="overflow-hidden rounded-lg border border-border bg-card">
+        <div className="overflow-hidden border-y border-border bg-background">
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <button

--- a/src/app/(root)/account/sections/community-summary-section.tsx
+++ b/src/app/(root)/account/sections/community-summary-section.tsx
@@ -15,7 +15,7 @@ import ActivitySummaryNav from '../components/activity/activity-summary-nav'
 const repository = new UserActivityRepository()
 
 export default function CommunitySummarySection() {
-  const [selected, setSelected] = useState<UserActivityType | null>(null)
+  const [selected, setSelected] = useState<UserActivityType>('comments')
   const { data, error, isLoading, mutate } = useSWR(
     'account-community-summary',
     () => repository.getSummary(),
@@ -25,12 +25,17 @@ export default function CommunitySummarySection() {
     error instanceof UserActivityRequestError && error.status === 401
 
   return (
-    <section className="py-5">
+    <div className="bg-background xl:overflow-hidden xl:rounded-lg xl:border xl:border-border">
+      <div className="border-b border-border px-4 py-4 sm:px-5">
+        <h1 className="text-[20px] font-bold tracking-tight text-foreground">
+          활동 기록
+        </h1>
+      </div>
       <ActivitySummaryNav
         summary={error ? undefined : data}
         selected={selected}
         isLoading={isLoading}
-        onSelect={(type) => setSelected(selected === type ? null : type)}
+        onSelect={setSelected}
       />
       {error && (
         <div
@@ -62,9 +67,7 @@ export default function CommunitySummarySection() {
           )}
         </div>
       )}
-      {selected && (
-        <ActivityListPanel type={selected} onDeleted={() => mutate()} />
-      )}
-    </section>
+      <ActivityListPanel type={selected} onDeleted={() => mutate()} />
+    </div>
   )
 }

--- a/src/app/(root)/account/sections/profile-section.tsx
+++ b/src/app/(root)/account/sections/profile-section.tsx
@@ -5,6 +5,7 @@ import { FunctionComponent } from 'react'
 import { UpdateProfileModal } from '../components/update-profile-modal'
 import { useUpdateProfileModalContext } from '../hooks/use-update-profile-modal-context'
 import { DmUserAvatar } from '@/components/dm'
+import { Pencil } from 'lucide-react'
 
 const ProfileSection: FunctionComponent = () => {
   const { data } = useSession()
@@ -12,17 +13,17 @@ const ProfileSection: FunctionComponent = () => {
   const user = data?.user
 
   return (
-    <section className="border-b border-border px-4 py-4">
+    <section className="border-b border-border px-4 py-6 xl:border-0 xl:px-0 xl:py-0">
       <UpdateProfileModal />
-      <div className="flex items-center gap-3.5 rounded-lg border border-border bg-card p-4">
+      <div className="relative flex items-center gap-4 xl:flex-col xl:items-start">
         <DmUserAvatar
           name={user?.nickname}
           image={user?.image}
-          className="h-14 w-14"
+          className="h-16 w-16 xl:h-20 xl:w-20"
           fallbackClassName="text-[22px]"
         />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[16px] font-semibold text-foreground">
+          <div className="truncate text-[20px] font-bold tracking-tight text-foreground">
             {user?.nickname ?? '게스트'}
           </div>
           <div className="mt-0.5 truncate font-mono text-[12px] text-muted-foreground">
@@ -32,9 +33,11 @@ const ProfileSection: FunctionComponent = () => {
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="h-8 rounded-md border border-border px-3 text-[12px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="프로필 편집"
+          title="프로필 편집"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-accent hover:text-foreground xl:absolute xl:right-0 xl:top-0"
         >
-          편집
+          <Pencil className="h-4 w-4" />
         </button>
       </div>
     </section>

--- a/src/config/user-activity-client-api-endpoint.ts
+++ b/src/config/user-activity-client-api-endpoint.ts
@@ -3,6 +3,7 @@ export const UserActivityClientApiEndpoint = {
   getActivity: (type: string, page: number, pageSize = 10) =>
     `/api/user/activity/${type}?page=${page}&pageSize=${pageSize}`,
   deleteRating: (movieCd: number) => `/api/user/activity/ratings/${movieCd}`,
+  deleteMovieComment: (commentId: number) => `/api/comment/${commentId}`,
   deleteComment: (commentId: number) => `/api/article/comment/${commentId}`,
   deleteArticle: (articleId: number) => `/api/article/${articleId}`,
 }

--- a/src/modules/user-activity/user-activity-datasource.test.ts
+++ b/src/modules/user-activity/user-activity-datasource.test.ts
@@ -6,6 +6,9 @@ vi.mock('@/config/user-activity-client-api-endpoint', () => ({
     getActivity: (type: string, page: number, pageSize = 10) =>
       `/api/user/activity/${type}?page=${page}&pageSize=${pageSize}`,
     deleteRating: (movieCd: number) => `/api/user/activity/ratings/${movieCd}`,
+    deleteMovieComment: (commentId: number) => `/api/comment/${commentId}`,
+    deleteComment: (commentId: number) => `/api/article/comment/${commentId}`,
+    deleteArticle: (articleId: number) => `/api/article/${articleId}`,
   },
 }))
 
@@ -40,5 +43,45 @@ describe('UserActivityDatasource', () => {
       '/api/user/activity/ratings/20233219',
       { method: 'DELETE' },
     )
+  })
+
+  it('deletes a movie comment through the movie comment BFF', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await new UserActivityDatasource().deleteItem({
+      type: 'comment',
+      id: 12,
+      targetType: 'movie',
+      targetId: 20262770,
+      targetTitle: '신작 영화',
+      content: '영화 댓글',
+      createdAt: '2026-08-04T12:00:00Z',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/comment/12', {
+      method: 'DELETE',
+      body: expect.any(FormData),
+    })
+  })
+
+  it('deletes an article comment through the article comment BFF', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await new UserActivityDatasource().deleteItem({
+      type: 'comment',
+      id: 7,
+      targetType: 'article',
+      targetId: 5,
+      targetTitle: '영화 후기',
+      content: '게시글 댓글',
+      createdAt: '2026-08-03T12:00:00Z',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/article/comment/7', {
+      method: 'DELETE',
+      body: expect.any(FormData),
+    })
   })
 })

--- a/src/modules/user-activity/user-activity-datasource.ts
+++ b/src/modules/user-activity/user-activity-datasource.ts
@@ -33,7 +33,7 @@ export class UserActivityDatasource {
   async deleteItem(item: DeletableActivityItem): Promise<void> {
     if (item.type === 'rating') return this.deleteRating(item.movieCd)
     if (item.type === 'article') return this.deleteArticle(item.articleId)
-    return this.deleteComment(item.id)
+    return this.deleteComment(item.id, item.targetType)
   }
 
   async deleteRating(movieCd: number): Promise<void> {
@@ -52,11 +52,16 @@ export class UserActivityDatasource {
     if (!response.ok) throw new UserActivityRequestError(response.status)
   }
 
-  private async deleteComment(commentId: number): Promise<void> {
+  private async deleteComment(
+    commentId: number,
+    targetType: 'movie' | 'article',
+  ): Promise<void> {
     const form = new FormData()
     form.set('commentId', String(commentId))
     const response = await fetch(
-      UserActivityClientApiEndpoint.deleteComment(commentId),
+      targetType === 'movie'
+        ? UserActivityClientApiEndpoint.deleteMovieComment(commentId)
+        : UserActivityClientApiEndpoint.deleteComment(commentId),
       { method: 'DELETE', body: form },
     )
     if (!response.ok) throw new UserActivityRequestError(response.status)

--- a/src/modules/user-activity/user-activity-entity.ts
+++ b/src/modules/user-activity/user-activity-entity.ts
@@ -10,8 +10,9 @@ export type UserActivityType = 'comments' | 'ratings' | 'articles' | 'likes'
 export interface CommentActivity {
   type: 'comment'
   id: number
-  articleId: number
-  articleTitle: string
+  targetType: 'movie' | 'article'
+  targetId: number
+  targetTitle: string
   content: string
   createdAt: string
 }


### PR DESCRIPTION
## Summary
계정 화면을 활동 목록 중심의 영화 커뮤니티 프로필 화면으로 재구성합니다.

## 원인
기존 2×2 지표 카드와 분리된 목록 구조가 공간을 낭비했고, 평가 포스터·받은 좋아요·영화 댓글 데이터가 올바르게 표현되지 않았습니다.

## 변경
- 활동 지표 4개를 한 줄 탭으로 통합
- 데스크톱 프로필 레일 + 넓은 활동 피드, 모바일 단일 흐름 적용
- S3 포스터를 공통 Poster 컴포넌트로 표시
- 받은 좋아요 목록에 좋아요 수 배지 표시
- 영화·게시글 댓글의 대상 이동 및 삭제 API 분리
- 알림 설정 메뉴 제거 상태 유지

## Test plan
- [x] Vitest 11개 통과
- [x] `pnpm lint` 통과 (기존 경고만 존재)
- [x] `pnpm build` 성공
- [x] 변경 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)