### PR TITLE
🚀 Release: 사용자 이미지 로딩 스켈레톤

### DIFF
--- a/docs/superpowers/plans/2026-08-10-loading-media-skeletons.md
+++ b/docs/superpowers/plans/2026-08-10-loading-media-skeletons.md
@@ -1,0 +1,8 @@
+# Loading media skeletons implementation plan
+
+1. Add a failing contract test for pending avatar data and image-download states.
+2. Make `DmUserAvatar` render a circular skeleton until user data and the selected image finish loading.
+3. Keep the real missing/broken-image fallback only after loading has completed.
+4. Audit every avatar and poster consumer so route/data loading states do not render placeholder media.
+5. Run focused tests, the full test suite, lint, build, and the 200-line limit check.
+6. Verify representative desktop/mobile pages, merge the PR, and watch the production deployment.

--- a/src/app/(root)/(routes)/profile/[nickname]/page.tsx
+++ b/src/app/(root)/(routes)/profile/[nickname]/page.tsx
@@ -1,5 +1,5 @@
-import { UserRound } from 'lucide-react'
 import { notFound } from 'next/navigation'
+import { DmUserAvatar } from '@/components/dm'
 import { UsersRepository } from '@/modules/users/users-repository'
 
 interface ProfilePageProps {
@@ -32,25 +32,15 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   const profile = await getProfile(params.nickname)
   if (!profile) notFound()
 
-  const initial = profile.nickname.trim().charAt(0).toUpperCase()
-
   return (
     <main className="mx-auto flex min-h-[calc(100dvh-10rem)] w-full max-w-[42rem] flex-col px-5 py-8">
       <section className="flex flex-1 flex-col items-center justify-center text-center">
-        <div className="flex h-28 w-28 items-center justify-center overflow-hidden rounded-full border border-border bg-secondary text-3xl font-bold text-muted-foreground">
-          {profile.image ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={profile.image}
-              alt=""
-              className="h-full w-full object-cover"
-            />
-          ) : initial ? (
-            initial
-          ) : (
-            <UserRound className="h-10 w-10" />
-          )}
-        </div>
+        <DmUserAvatar
+          name={profile.nickname}
+          image={profile.image}
+          className="h-28 w-28"
+          fallbackClassName="text-3xl"
+        />
         <h1 className="mt-5 text-2xl font-bold">{profile.nickname}</h1>
         <p className="mt-2 text-sm text-muted-foreground">
           볼래에서 같이 영화 볼 사람을 찾고 있어요.

--- a/src/components/dm/dm-user-avatar-state.ts
+++ b/src/components/dm/dm-user-avatar-state.ts
@@ -1,0 +1,25 @@
+export type AvatarImageStatus = 'idle' | 'loading' | 'loaded' | 'error'
+
+export interface AvatarImageState {
+  src: string
+  status: AvatarImageStatus
+}
+
+export function isAvatarDataPending(
+  isLoading: boolean | undefined,
+  name: string | null | undefined,
+  image: string | null | undefined,
+) {
+  return isLoading ?? (name === undefined && image === undefined)
+}
+
+export function isAvatarImagePending(
+  imageSrc: string,
+  imageState: AvatarImageState,
+) {
+  return (
+    imageState.src !== imageSrc ||
+    imageState.status === 'idle' ||
+    imageState.status === 'loading'
+  )
+}

--- a/src/components/dm/dm-user-avatar.test.ts
+++ b/src/components/dm/dm-user-avatar.test.ts
@@ -1,8 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_PROFILE_IMAGE_URL,
   resolveUserAvatarImage,
 } from '../../lib/utils/user-avatar'
+import {
+  isAvatarDataPending,
+  isAvatarImagePending,
+} from './dm-user-avatar-state'
 
 describe('resolveUserAvatarImage', () => {
   it('uses the default image when a legacy user has no profile image', () => {
@@ -15,5 +21,63 @@ describe('resolveUserAvatarImage', () => {
     expect(resolveUserAvatarImage('https://example.com/profile.png')).toBe(
       'https://example.com/profile.png',
     )
+  })
+})
+
+describe('DmUserAvatar loading UI', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('./dm-user-avatar.tsx', import.meta.url)),
+    'utf8',
+  )
+
+  it('shows a skeleton while user data is pending', () => {
+    expect(source).toContain('isLoading')
+    expect(source).toContain('isAvatarDataPending(isLoading, name, image)')
+    expect(source).toContain('<Skeleton')
+  })
+
+  it('distinguishes pending data from a loaded user without an image', () => {
+    expect(isAvatarDataPending(undefined, undefined, undefined)).toBe(true)
+    expect(isAvatarDataPending(undefined, '볼래', null)).toBe(false)
+    expect(isAvatarDataPending(false, undefined, undefined)).toBe(false)
+    expect(isAvatarDataPending(true, '볼래', 'profile.png')).toBe(true)
+  })
+
+  it('keeps the skeleton until the profile image finishes loading', () => {
+    expect(source).toContain('onLoadingStatusChange')
+    expect(source).toContain('isAvatarImagePending(imageSrc, imageState)')
+  })
+
+  it('handles image loading, failure, and source changes', () => {
+    expect(
+      isAvatarImagePending('a.png', { src: 'a.png', status: 'idle' }),
+    ).toBe(true)
+    expect(
+      isAvatarImagePending('a.png', { src: 'a.png', status: 'loading' }),
+    ).toBe(true)
+    expect(
+      isAvatarImagePending('a.png', { src: 'a.png', status: 'loaded' }),
+    ).toBe(false)
+    expect(
+      isAvatarImagePending('a.png', { src: 'a.png', status: 'error' }),
+    ).toBe(false)
+    expect(
+      isAvatarImagePending('b.png', { src: 'a.png', status: 'loaded' }),
+    ).toBe(true)
+  })
+
+  it('is also used by the public profile page', () => {
+    const profilePage = readFileSync(
+      fileURLToPath(
+        new URL(
+          '../../app/(root)/(routes)/profile/[nickname]/page.tsx',
+          import.meta.url,
+        ),
+      ),
+      'utf8',
+    )
+
+    expect(profilePage).toContain('<DmUserAvatar')
+    expect(profilePage).not.toContain('<img')
   })
 })

--- a/src/components/dm/dm-user-avatar.tsx
+++ b/src/components/dm/dm-user-avatar.tsx
@@ -3,10 +3,18 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import { resolveUserAvatarImage } from '@/lib/utils/user-avatar'
+import { useState } from 'react'
+import type { AvatarImageState } from './dm-user-avatar-state'
+import {
+  isAvatarDataPending,
+  isAvatarImagePending,
+} from './dm-user-avatar-state'
+import { Skeleton } from './skeleton'
 
 interface DmUserAvatarProps {
   name?: string | null
   image?: string | null
+  isLoading?: boolean
   className?: string
   fallbackClassName?: string
 }
@@ -14,19 +22,44 @@ interface DmUserAvatarProps {
 export function DmUserAvatar({
   name,
   image,
+  isLoading,
   className,
   fallbackClassName,
 }: DmUserAvatarProps) {
-  const initial = name?.trim().charAt(0).toUpperCase() || '?'
   const imageSrc = resolveUserAvatarImage(image)
+  const [imageState, setImageState] = useState<AvatarImageState>({
+    src: imageSrc,
+    status: 'idle',
+  })
+  const isUserPending = isAvatarDataPending(isLoading, name, image)
+
+  if (isUserPending) {
+    return (
+      <Skeleton
+        role="status"
+        aria-busy="true"
+        aria-label="프로필 이미지 로딩 중"
+        className={cn('h-8 w-8 shrink-0 rounded-full', className)}
+      />
+    )
+  }
+
+  const initial = name?.trim().charAt(0).toUpperCase() || '?'
+  const isImagePending = isAvatarImagePending(imageSrc, imageState)
 
   return (
-    <Avatar className={cn('h-8 w-8 border border-border', className)}>
+    <Avatar
+      aria-busy={isImagePending}
+      className={cn('h-8 w-8 border border-border', className)}
+    >
       <AvatarImage
         src={imageSrc}
         alt={`${name || '사용자'} 프로필`}
         className="object-cover"
         referrerPolicy="no-referrer"
+        onLoadingStatusChange={(status) =>
+          setImageState({ src: imageSrc, status })
+        }
       />
       <AvatarFallback
         delayMs={0}
@@ -35,7 +68,11 @@ export function DmUserAvatar({
           fallbackClassName,
         )}
       >
-        {initial}
+        {isImagePending ? (
+          <Skeleton aria-hidden="true" className="h-full w-full rounded-full" />
+        ) : (
+          initial
+        )}
       </AvatarFallback>
     </Avatar>
   )

--- a/src/components/dm/skeleton.tsx
+++ b/src/components/dm/skeleton.tsx
@@ -1,16 +1,13 @@
 import { cn } from '@/lib/utils'
+import type { HTMLAttributes } from 'react'
 
-interface SkeletonProps {
-  className?: string
-}
+type SkeletonProps = HTMLAttributes<HTMLDivElement>
 
-export function Skeleton({ className }: SkeletonProps) {
+export function Skeleton({ className, ...props }: SkeletonProps) {
   return (
     <div
-      className={cn(
-        'animate-pulse rounded-none bg-secondary',
-        className,
-      )}
+      {...props}
+      className={cn('animate-pulse rounded-none bg-secondary', className)}
     />
   )
 }


### PR DESCRIPTION
## Summary
사용자 이미지 로딩 스켈레톤 통일 변경을 프로덕션에 배포합니다.

## 변경
- PR #456 — 사용자 데이터·이미지 로딩 중 공통 스켈레톤 표시
- 공개 프로필의 공통 아바타 통합

## Test plan
- [x] `pnpm exec vitest run` (34 files, 87 tests)
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 운영 페이지 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)