### PR TITLE
🐛 검색엔진 크롤링 신호 정리

### DIFF
--- a/docs/superpowers/plans/2026-08-10-search-indexing-signals.md
+++ b/docs/superpowers/plans/2026-08-10-search-indexing-signals.md
@@ -1,0 +1,114 @@
+# Search Indexing Signals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 검색엔진이 공개 페이지를 일관되게 크롤링하고 전체 영화 상세 URL을 발견할 수 있도록 SEO 신호를 바로잡는다.
+
+**Architecture:** 홈의 TOP 10 영화 API는 유지하고, 백엔드에 사이트맵 전용 경량 gRPC/REST 조회를 추가한다. 프론트 사이트맵은 이 API의 `movieCd`, `updatedAt`만 사용하며 robots와 구조화 데이터의 충돌 신호를 제거한다.
+
+**Tech Stack:** NestJS 10, gRPC/Protocol Buffers, Prisma, Next.js 13 Metadata Routes, Vitest
+
+## Global Constraints
+
+- 공개 페이지 조회에 인증을 요구하지 않는다.
+- 수정 파일은 공백과 주석을 포함해 200줄 이하로 유지한다.
+- 기존 `/movie` TOP 10 응답 계약은 변경하지 않는다.
+
+---
+
+### Task 1: 전체 영화 사이트맵 API
+
+**Files:**
+
+- Modify: `proto/movie.proto`
+- Modify: `apps/movie/src/movie-read.service.ts`
+- Modify: `apps/movie/src/movie.controller.ts`
+- Modify: `apps/api-gateway/src/movie/movie.service.ts`
+- Modify: `apps/api-gateway/src/movie/movie.controller.ts`
+- Test: `apps/movie/src/movie-read.service.spec.ts`
+
+**Interfaces:**
+
+- Produces: `GET /movie/sitemap` -> `{ movies: Array<{ movieCd: number; updatedAt: string }> }`
+
+- [ ] **Step 1: Write the failing service test**
+
+Prisma가 전체 영화에서 `movieCd`, `updatedAt`만 최신 수정순으로 조회하고 반환하는지 검증한다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- movie-read.service.spec.ts --runInBand`
+Expected: FAIL because `getMovieSitemapEntries` does not exist.
+
+- [ ] **Step 3: Implement the minimal API path**
+
+`GetMovieSitemapEntries` RPC와 경량 응답 메시지를 추가하고 movie-service, API Gateway를 연결한다.
+
+- [ ] **Step 4: Generate protobuf code and verify**
+
+Run: `make generate_grpc_code`
+Run: `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
+Run: `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
+
+### Task 2: 프론트 검색 신호 정리
+
+**Files:**
+
+- Create: `src/app/robots.test.ts`
+- Create: `src/app/site-metadata.test.ts`
+- Modify: `src/app/robots.ts`
+- Modify: `src/app/site-metadata.ts`
+- Modify: `src/config/movie-api-endpoint.ts`
+- Modify: `src/app/(root)/(routes)/sitemaps/movies.xml/route.ts`
+- Modify: `src/lib/sitemap/sitemap.test.ts`
+
+**Interfaces:**
+
+- Consumes: `GET /movie/sitemap`
+- Produces: 공개 채팅 허용 robots 규칙과 전체 영화 URL 사이트맵
+
+- [ ] **Step 1: Write failing tests**
+
+`/chat/public`이 허용되고 `/chat/`은 계속 차단되는지, 존재하지 않는 검색 액션이 제거되는지, 경량 영화 엔트리가 사이트맵 URL로 변환되는지 검증한다.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/app/robots.test.ts src/app/site-metadata.test.ts src/lib/sitemap/sitemap.test.ts`
+Expected: FAIL on the three missing behaviors.
+
+- [ ] **Step 3: Implement the minimal frontend changes**
+
+robots allow 규칙, JSON-LD, 영화 사이트맵 데이터 소스를 수정한다.
+
+- [ ] **Step 4: Verify frontend**
+
+Run: `pnpm vitest run`
+Run: `pnpm lint`
+Run: `pnpm build`
+
+### Task 3: Release and production verification
+
+**Files:**
+
+- Modify after deployment: `.claude/worklog.md`
+
+- [ ] **Step 1: Check modified file sizes**
+
+Run: `wc -l <all modified source and test files>`
+Expected: every non-generated file is at most 200 lines.
+
+- [ ] **Step 2: Merge backend and frontend feature PRs into develop**
+
+PR body includes Summary, 원인, 변경, Test plan.
+
+- [ ] **Step 3: Merge develop release PRs into master and watch Actions**
+
+Expected: backend and frontend deployment workflows complete successfully.
+
+- [ ] **Step 4: Verify production SEO endpoints**
+
+Check `/robots.txt`, `/sitemap.xml`, `/sitemaps/movies.xml`, and `/articles/5` metadata/SSR content.
+
+- [ ] **Step 5: Record deployment**
+
+Append PR numbers, Actions results, and production checks to `.claude/worklog.md`.

--- a/src/app/(root)/(routes)/sitemaps/movies.xml/route.test.ts
+++ b/src/app/(root)/(routes)/sitemaps/movies.xml/route.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getMovieSitemapEntries } from '@/modules/movie/movie-sitemap-datasource'
+import { GET } from './route'
+
+vi.mock('@/lib/sitemap/sitemap', () => ({
+  buildMovieFields: vi.fn(() => []),
+}))
+vi.mock('@/modules/movie/movie-sitemap-datasource', () => ({
+  getMovieSitemapEntries: vi.fn(),
+}))
+vi.mock('next-sitemap', () => ({
+  getServerSideSitemap: vi.fn(),
+}))
+
+describe('movie sitemap route', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('propagates backend failures instead of caching an empty sitemap', async () => {
+    vi.mocked(getMovieSitemapEntries).mockRejectedValue(
+      new Error('backend unavailable'),
+    )
+
+    await expect(GET()).rejects.toThrow('backend unavailable')
+  })
+})

--- a/src/app/(root)/(routes)/sitemaps/movies.xml/route.ts
+++ b/src/app/(root)/(routes)/sitemaps/movies.xml/route.ts
@@ -1,11 +1,11 @@
 import { buildMovieFields } from '@/lib/sitemap/sitemap'
-import { MovieRepository } from '@/modules/movie/movie-repository'
+import { getMovieSitemapEntries } from '@/modules/movie/movie-sitemap-datasource'
 import { getServerSideSitemap } from 'next-sitemap'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  const movies = await new MovieRepository().getMovie().catch(() => [])
+  const movies = await getMovieSitemapEntries()
 
   return getServerSideSitemap(buildMovieFields(movies), {
     'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',

--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import robots from './robots'
+
+describe('robots metadata', () => {
+  it('allows public chat while private chat remains blocked', () => {
+    const metadata = robots()
+    const rule = Array.isArray(metadata.rules)
+      ? metadata.rules[0]
+      : metadata.rules
+
+    expect(rule.allow).toContain('/chat/public')
+    expect(rule.disallow).toContain('/chat/')
+    expect(metadata.sitemap).toBe('https://bollae.kr/sitemap.xml')
+  })
+})

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: '*',
-        allow: '/',
+        allow: ['/', '/chat/public'],
         disallow: [
           '/account/',
           '/api/',

--- a/src/app/site-metadata.test.ts
+++ b/src/app/site-metadata.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { siteJsonLd } from './site-metadata'
+
+describe('site structured data', () => {
+  it('does not advertise a search route that does not exist', () => {
+    expect(siteJsonLd).not.toHaveProperty('potentialAction')
+  })
+})

--- a/src/app/site-metadata.ts
+++ b/src/app/site-metadata.ts
@@ -48,7 +48,8 @@ export const siteMetadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: '볼래 | 같이 볼 사람을 찾는 영화 매칭',
-    description: '볼래에서 오늘 같이 볼 사람을 찾고, 최신 영화 리뷰와 평점을 확인하세요.',
+    description:
+      '볼래에서 오늘 같이 볼 사람을 찾고, 최신 영화 리뷰와 평점을 확인하세요.',
     images: ['/images/og-image.png'],
   },
   viewport: {
@@ -67,15 +68,8 @@ export const siteJsonLd = {
   name: '볼래',
   alternateName: ['bollae', '같이 볼래'],
   url: SITE_URL,
-  description: '볼래에서 오늘 같이 볼 사람을 찾고, 최신 영화 리뷰와 평점을 확인하세요.',
-  potentialAction: {
-    '@type': 'SearchAction',
-    target: {
-      '@type': 'EntryPoint',
-      urlTemplate: `${SITE_URL}/search?q={search_term_string}`,
-    },
-    'query-input': 'required name=search_term_string',
-  },
+  description:
+    '볼래에서 오늘 같이 볼 사람을 찾고, 최신 영화 리뷰와 평점을 확인하세요.',
   mainEntity: {
     '@type': 'Organization',
     name: '볼래',

--- a/src/config/movie-api-endpoint.ts
+++ b/src/config/movie-api-endpoint.ts
@@ -7,12 +7,9 @@ const serverBase =
 
 export const MovieBackEndApiEndpoint = {
   getMovie: () => `${serverBase}/movie`,
+  getMovieSitemapEntries: () => `${serverBase}/movie/sitemap`,
   getMovieDetail: (movieCd: string) => `${serverBase}/movie/${movieCd}`,
-  getMoviesByDirector: (
-    name: string,
-    excludeMovieCd: number,
-    limit: number,
-  ) =>
+  getMoviesByDirector: (name: string, excludeMovieCd: number, limit: number) =>
     queryString.stringifyUrl(
       {
         url: `${serverBase}/movie/director`,
@@ -40,11 +37,7 @@ export const MovieClientApiEndpoint = {
       },
       { skipEmptyString: true, skipNull: true },
     ),
-  getMoviesByDirector: (
-    name: string,
-    excludeMovieCd: number,
-    limit: number,
-  ) =>
+  getMoviesByDirector: (name: string, excludeMovieCd: number, limit: number) =>
     queryString.stringifyUrl(
       {
         url: '/api/movie/director',

--- a/src/lib/sitemap/sitemap.test.ts
+++ b/src/lib/sitemap/sitemap.test.ts
@@ -76,10 +76,10 @@ describe('sitemap helpers', () => {
     expect(
       buildMovieFields([
         {
-          id: 20259946,
-          updatedAt: new Date('2026-07-04T00:00:00.000Z'),
+          movieCd: 20259946,
+          updatedAt: '2026-07-04T00:00:00.000Z',
         },
-      ] as any),
+      ]),
     ).toEqual([
       {
         loc: 'https://bollae.kr/movie/20259946',

--- a/src/lib/sitemap/sitemap.ts
+++ b/src/lib/sitemap/sitemap.ts
@@ -1,5 +1,5 @@
 import type { Article, MatchPost } from '@/lib/type'
-import type { Movie } from '@/modules/movie/movie.entity'
+import type { MovieSitemapEntry } from '@/modules/movie/movie-sitemap-datasource'
 import type { ISitemapField } from 'next-sitemap'
 
 export const SITE_URL = 'https://bollae.kr'
@@ -40,9 +40,7 @@ export function buildIndexUrls(
   return [
     `${SITE_URL}/sitemaps/static.xml`,
     `${SITE_URL}/sitemaps/movies.xml`,
-    ...articlePages.map(
-      (page) => `${SITE_URL}/sitemaps/articles/${page}`,
-    ),
+    ...articlePages.map((page) => `${SITE_URL}/sitemaps/articles/${page}`),
     ...matchPages.map((page) => `${SITE_URL}/sitemaps/matches/${page}`),
   ]
 }
@@ -65,10 +63,10 @@ export function buildMatchFields(matches: MatchPost[]): ISitemapField[] {
   }))
 }
 
-export function buildMovieFields(movies: Movie[]): ISitemapField[] {
+export function buildMovieFields(movies: MovieSitemapEntry[]): ISitemapField[] {
   return movies.map((movie) => ({
-    loc: `${SITE_URL}/movie/${movie.id}`,
-    lastmod: movie.updatedAt.toISOString(),
+    loc: `${SITE_URL}/movie/${movie.movieCd}`,
+    lastmod: movie.updatedAt,
     changefreq: 'daily',
     priority: 0.8,
   }))

--- a/src/modules/movie/movie-sitemap-datasource.ts
+++ b/src/modules/movie/movie-sitemap-datasource.ts
@@ -1,0 +1,23 @@
+import { MovieBackEndApiEndpoint } from '@/config/movie-api-endpoint'
+
+export interface MovieSitemapEntry {
+  movieCd: number
+  updatedAt: string
+}
+
+interface MovieSitemapResponse {
+  movies?: MovieSitemapEntry[]
+}
+
+export async function getMovieSitemapEntries(): Promise<MovieSitemapEntry[]> {
+  const response = await fetch(
+    MovieBackEndApiEndpoint.getMovieSitemapEntries(),
+    { cache: 'no-cache' },
+  )
+  if (!response.ok) {
+    throw new Error('영화 사이트맵 데이터를 받아 올 수 없습니다.')
+  }
+
+  const data = (await response.json()) as MovieSitemapResponse
+  return Array.isArray(data.movies) ? data.movies : []
+}


### PR DESCRIPTION
## Summary
공개 페이지의 robots·구조화 데이터·사이트맵 신호를 일치시키고 전체 영화 상세 URL을 노출합니다.

## 원인
공개 채팅은 사이트맵에 있으나 robots에서 차단됐고, 영화 사이트맵은 TOP 10 API를 재사용해 10개만 노출했습니다. 존재하지 않는 `/search`도 SearchAction으로 선언돼 있었습니다.

## 변경
- `/chat/public` robots 명시 허용
- 미구현 `/search` SearchAction 제거
- 경량 `GET /movie/sitemap` 기반 전체 영화 사이트맵 생성
- 백엔드 장애 시 빈 200 사이트맵을 캐시하지 않고 오류 전파
- 회귀 테스트와 구현 계획 문서 추가

## Test plan
- [x] Vitest 37개 파일, 90개 테스트 통과
- [x] `pnpm lint` 통과 (기존 경고만 존재)
- [x] 테스트 환경변수 기준 `pnpm build` 통과
- [x] 수정/신규 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)