### PR TITLE
🐛 계정 데스크탑 레이아웃 밀림 수정

### DIFF
--- a/docs/superpowers/plans/2026-08-10-account-desktop-layout.md
+++ b/docs/superpowers/plans/2026-08-10-account-desktop-layout.md
@@ -1,0 +1,50 @@
+# Account Desktop Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Keep the account page centered in the desktop content pane without a nested side rail.
+
+**Architecture:** Recompose the existing account sections in a single min-width-safe column. Reuse every existing section and change only responsive layout classes.
+
+**Tech Stack:** Next.js 13, React, Tailwind CSS, Vitest
+
+## Global Constraints
+
+- Keep every modified file at 200 lines or fewer.
+- Preserve existing account actions and mobile ordering.
+
+---
+
+### Task 1: Remove the nested account rail
+
+**Files:**
+- Modify: src/app/(root)/account/account-community-summary.test.ts
+- Modify: src/app/(root)/account/page.tsx
+- Modify: src/app/(root)/account/sections/profile-section.tsx
+- Modify: src/app/(root)/account/sections/account-section.tsx
+
+**Interfaces:**
+- Consumes: existing ProfileSection, CommunitySummarySection, and AccountSection
+- Produces: a single-column account workspace with no desktop horizontal overflow
+
+- [ ] **Step 1: Write a failing source contract**
+
+Assert that the page no longer contains the nested 200px desktop grid and that
+profile/account sections remain horizontal and full-width on desktop.
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run the account community summary Vitest file.
+
+- [ ] **Step 3: Implement the layout**
+
+Use a min-width-safe full-width column, remove desktop vertical profile classes,
+and keep account action groups inside the center pane width.
+
+- [ ] **Step 4: Verify GREEN and build**
+
+Run the focused test, lint, and production build.
+
+- [ ] **Step 5: Check file sizes and commit**
+
+Run wc -l on every modified file and commit the feature branch.

--- a/docs/superpowers/specs/2026-08-10-account-desktop-layout-design.md
+++ b/docs/superpowers/specs/2026-08-10-account-desktop-layout-design.md
@@ -1,0 +1,27 @@
+# Account desktop layout
+
+## Goal
+
+Prevent the account page's local profile and account rail from pushing the
+activity workspace sideways inside the existing three-column desktop shell.
+
+## Layout
+
+- Keep the global desktop navigation and right matching sidebar unchanged.
+- Render the account page as one full-width column inside the center pane.
+- Use a horizontal profile header on desktop as well as mobile.
+- Place the activity summary and selected feed immediately below the profile.
+- Place shortcuts and destructive account actions below the activity feed.
+
+## Constraints
+
+- Preserve all profile editing, activity filtering, deletion, sign-out, and
+  account withdrawal behavior.
+- Do not introduce page-level horizontal scrolling.
+- Keep the existing mobile order and compact activity navigation.
+
+## Verification
+
+- A source contract rejects the nested 200px account grid and desktop-only
+  vertical profile treatment.
+- Frontend tests, lint, build, and desktop viewport inspection pass.

--- a/src/app/(root)/account/account-community-summary.test.ts
+++ b/src/app/(root)/account/account-community-summary.test.ts
@@ -45,12 +45,17 @@ describe('account community summary', () => {
     expect(panel).toContain('더 보기')
   })
 
-  it('uses a responsive profile rail and activity workspace', () => {
+  it('uses the full center pane without a nested desktop rail', () => {
     const page = read('./page.tsx')
+    const profile = read('./sections/profile-section.tsx')
+    const account = read('./sections/account-section.tsx')
 
-    expect(page).toContain('xl:grid-cols-[200px_minmax(0,1fr)]')
-    expect(page).toContain('<aside')
-    expect(page).toContain('<section')
+    expect(page).toContain('min-w-0')
+    expect(page).toContain('w-full')
+    expect(page).not.toContain('xl:grid-cols-[200px_minmax(0,1fr)]')
+    expect(page).not.toContain('<aside')
+    expect(profile).not.toContain('xl:flex-col')
+    expect(account).not.toContain('xl:mt-6 xl:px-0')
   })
 
   it('loads the summary through an authenticated BFF route', () => {

--- a/src/app/(root)/account/page.tsx
+++ b/src/app/(root)/account/page.tsx
@@ -8,16 +8,12 @@ const Page: FunctionComponent = () => {
   return (
     <main className="min-h-page pb-8">
       <UpdateProfileModalContextProvider>
-        <div className="xl:grid xl:grid-cols-[200px_minmax(0,1fr)] xl:gap-6 xl:px-6 xl:py-7">
-          <aside className="xl:col-start-1 xl:row-start-1">
-            <ProfileSection />
-          </aside>
-          <section className="min-w-0 xl:col-start-2 xl:row-span-2 xl:row-start-1">
+        <div className="w-full min-w-0 xl:px-6 xl:py-7">
+          <ProfileSection />
+          <section className="min-w-0 xl:mt-5">
             <CommunitySummarySection />
           </section>
-          <aside className="xl:col-start-1 xl:row-start-2">
-            <AccountSection />
-          </aside>
+          <AccountSection />
         </div>
       </UpdateProfileModalContextProvider>
     </main>

--- a/src/app/(root)/account/sections/account-section.tsx
+++ b/src/app/(root)/account/sections/account-section.tsx
@@ -82,7 +82,7 @@ const AccountSection: FunctionComponent = () => {
   }
 
   return (
-    <section className="border-t border-border px-4 py-5 xl:mt-6 xl:px-0">
+    <section className="grid gap-5 border-t border-border px-4 py-5 xl:grid-cols-2 xl:px-0 xl:pt-6">
       <div>
         <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
           바로가기
@@ -94,7 +94,7 @@ const AccountSection: FunctionComponent = () => {
         </div>
       </div>
 
-      <div className="pt-5">
+      <div>
         <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
           계정 관리
         </p>

--- a/src/app/(root)/account/sections/profile-section.tsx
+++ b/src/app/(root)/account/sections/profile-section.tsx
@@ -13,9 +13,9 @@ const ProfileSection: FunctionComponent = () => {
   const user = data?.user
 
   return (
-    <section className="border-b border-border px-4 py-6 xl:border-0 xl:px-0 xl:py-0">
+    <section className="border-b border-border px-4 py-6 xl:px-0 xl:py-5">
       <UpdateProfileModal />
-      <div className="relative flex items-center gap-4 xl:flex-col xl:items-start">
+      <div className="flex min-w-0 items-center gap-4">
         <DmUserAvatar
           name={user?.nickname}
           image={user?.image}
@@ -35,7 +35,7 @@ const ProfileSection: FunctionComponent = () => {
           onClick={() => setOpen(true)}
           aria-label="프로필 편집"
           title="프로필 편집"
-          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-accent hover:text-foreground xl:absolute xl:right-0 xl:top-0"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-accent hover:text-foreground"
         >
           <Pencil className="h-4 w-4" />
         </button>


### PR DESCRIPTION
## Summary
계정 화면 내부의 중첩 데스크탑 사이드 레일을 제거해 중앙 콘텐츠가 옆으로 밀리는 현상을 수정합니다.

## 원인
전역 3열 셸 안에서 계정 페이지가 다시 200px 로컬 레일을 생성해 실제 콘텐츠 폭을 이중으로 줄이고 있었습니다.

## 변경
- 프로필, 커뮤니티 활동, 계정 메뉴를 단일 콘텐츠 흐름으로 재배치
- 데스크탑 계정 메뉴를 2열 하단 영역으로 정리
- 레이아웃 회귀 테스트 추가

## Test plan
- [x] 계정 레이아웃 Vitest 7건
- [x] `pnpm lint`
- [x] 환경변수 주입 후 `pnpm build`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)