### PR TITLE
🚀 Release: 계정 레이아웃·주연 배우 카드

### DIFF
--- a/docs/superpowers/plans/2026-08-10-account-desktop-layout.md
+++ b/docs/superpowers/plans/2026-08-10-account-desktop-layout.md
@@ -1,0 +1,50 @@
+# Account Desktop Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Keep the account page centered in the desktop content pane without a nested side rail.
+
+**Architecture:** Recompose the existing account sections in a single min-width-safe column. Reuse every existing section and change only responsive layout classes.
+
+**Tech Stack:** Next.js 13, React, Tailwind CSS, Vitest
+
+## Global Constraints
+
+- Keep every modified file at 200 lines or fewer.
+- Preserve existing account actions and mobile ordering.
+
+---
+
+### Task 1: Remove the nested account rail
+
+**Files:**
+- Modify: src/app/(root)/account/account-community-summary.test.ts
+- Modify: src/app/(root)/account/page.tsx
+- Modify: src/app/(root)/account/sections/profile-section.tsx
+- Modify: src/app/(root)/account/sections/account-section.tsx
+
+**Interfaces:**
+- Consumes: existing ProfileSection, CommunitySummarySection, and AccountSection
+- Produces: a single-column account workspace with no desktop horizontal overflow
+
+- [ ] **Step 1: Write a failing source contract**
+
+Assert that the page no longer contains the nested 200px desktop grid and that
+profile/account sections remain horizontal and full-width on desktop.
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run the account community summary Vitest file.
+
+- [ ] **Step 3: Implement the layout**
+
+Use a min-width-safe full-width column, remove desktop vertical profile classes,
+and keep account action groups inside the center pane width.
+
+- [ ] **Step 4: Verify GREEN and build**
+
+Run the focused test, lint, and production build.
+
+- [ ] **Step 5: Check file sizes and commit**
+
+Run wc -l on every modified file and commit the feature branch.

--- a/docs/superpowers/plans/2026-08-10-movie-cast-cards.md
+++ b/docs/superpowers/plans/2026-08-10-movie-cast-cards.md
@@ -1,0 +1,59 @@
+# Movie Cast Cards Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Add cached leading-cast data and portrait cards to every movie detail page.
+
+**Architecture:** The movie service owns TMDB credit enrichment and persistence. The existing detail response carries a bounded actors array so the frontend only maps and renders server-provided data.
+
+**Tech Stack:** NestJS 10, Prisma MySQL, gRPC, Next.js 13, React, Tailwind CSS, Jest, Vitest
+
+## Global Constraints
+
+- Return at most eight actors.
+- Hide the UI for empty results and do not fail movie detail on enrichment errors.
+- Keep every manually maintained file at 200 lines or fewer.
+
+---
+
+### Task 1: Persist and expose movie cast
+
+**Files:**
+- Modify: prisma/mysql.schema.prisma
+- Create: prisma/migrations/20260810000000_add_movie_actors/migration.sql
+- Modify: proto/movie.proto
+- Modify: libs/common/src/protobuf/movie.ts
+- Modify: apps/movie/src/movie-metadata.client.ts
+- Create: apps/movie/src/movie-cast.service.ts
+- Create: apps/movie/src/movie-cast.service.spec.ts
+- Modify: apps/movie/src/movie-read.service.ts
+- Modify: apps/movie/src/movie.module.ts
+- Modify: apps/movie/src/movie.formatter.ts
+
+**Interfaces:**
+- Produces: MovieActorData and MovieData.actors with id, name, character, profileUrl, and sortOrder
+
+- [ ] **Step 1: Write failing cast service and formatter tests**
+- [ ] **Step 2: Run Jest and confirm missing cast behavior fails**
+- [ ] **Step 3: Add schema, migration, TMDB mapping, and resilient cache service**
+- [ ] **Step 4: Generate protobuf and Prisma clients, then run Jest and TypeScript**
+- [ ] **Step 5: Check file sizes and commit**
+
+### Task 2: Render cast portrait cards
+
+**Files:**
+- Modify: src/modules/movie/movie.entity.ts
+- Modify: src/modules/movie/movie-datasource.ts
+- Create: src/app/(root)/(routes)/movie/[id]/sections/movie-cast-section.tsx
+- Create: src/app/(root)/(routes)/movie/[id]/sections/movie-cast-section.test.ts
+- Modify: src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
+
+**Interfaces:**
+- Consumes: Movie.actors
+- Produces: bounded horizontal leading-cast section
+
+- [ ] **Step 1: Write failing entity and UI source contracts**
+- [ ] **Step 2: Run Vitest and confirm RED**
+- [ ] **Step 3: Map actors and implement the responsive card section**
+- [ ] **Step 4: Run Vitest, lint, and production build**
+- [ ] **Step 5: Check file sizes and commit**

--- a/docs/superpowers/specs/2026-08-10-account-desktop-layout-design.md
+++ b/docs/superpowers/specs/2026-08-10-account-desktop-layout-design.md
@@ -1,0 +1,27 @@
+# Account desktop layout
+
+## Goal
+
+Prevent the account page's local profile and account rail from pushing the
+activity workspace sideways inside the existing three-column desktop shell.
+
+## Layout
+
+- Keep the global desktop navigation and right matching sidebar unchanged.
+- Render the account page as one full-width column inside the center pane.
+- Use a horizontal profile header on desktop as well as mobile.
+- Place the activity summary and selected feed immediately below the profile.
+- Place shortcuts and destructive account actions below the activity feed.
+
+## Constraints
+
+- Preserve all profile editing, activity filtering, deletion, sign-out, and
+  account withdrawal behavior.
+- Do not introduce page-level horizontal scrolling.
+- Keep the existing mobile order and compact activity navigation.
+
+## Verification
+
+- A source contract rejects the nested 200px account grid and desktop-only
+  vertical profile treatment.
+- Frontend tests, lint, build, and desktop viewport inspection pass.

--- a/docs/superpowers/specs/2026-08-10-movie-cast-cards-design.md
+++ b/docs/superpowers/specs/2026-08-10-movie-cast-cards-design.md
@@ -1,0 +1,33 @@
+# Movie cast cards
+
+## Goal
+
+Show the leading cast on movie detail pages with a face, name, and role while
+keeping repeat requests fast and resilient to external API failures.
+
+## Data
+
+- Store up to eight TMDB cast members per movie in a MovieActor table.
+- Persist TMDB person id, Korean display name, character, profile URL, and order.
+- Include actors in the existing movie detail gRPC and REST response.
+- On a cache miss, fetch credits once through the movie service, persist them,
+  and return the resulting cast. External failures return an empty cast.
+
+## UI
+
+- Place a cast section after the synopsis and before director filmography.
+- Render portrait cards in a contained horizontal scroller.
+- Each card shows a 2:3 face crop, actor name, and character when available.
+- Hide the section when no valid actors exist; use neutral skeletons while loading.
+
+## Reliability
+
+- Keep TMDB credentials server-only.
+- Never fail the movie detail request solely because cast enrichment failed.
+- Limit the response and rendered cards to eight.
+
+## Verification
+
+- Backend tests cover TMDB mapping, persistence ordering, cache hits, and failure fallback.
+- Frontend tests cover response mapping, section visibility, labels, and overflow containment.
+- Type checks, lint, builds, 200-line limits, and responsive screenshots pass.

--- a/src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/description-section.tsx
@@ -6,6 +6,7 @@ import MovieVodModal from '../components/movie-vod-modal'
 import { useGetMovieDetail } from '../hooks/use-get-movie-detail'
 import { useVodModalContext } from '../hooks/use-vod-modal-context'
 import { DirectorFilmographySection } from './director-filmography-section'
+import { MovieCastSection } from './movie-cast-section'
 
 interface DescriptionSectionProps {
   id: string
@@ -42,6 +43,7 @@ const DescriptionSection: FunctionComponent<DescriptionSectionProps> = ({
         onVodClick={handleVodClick}
         onScoreSaved={refreshMovie}
       />
+      <MovieCastSection actors={data.actors} />
       <DirectorFilmographySection movie={data} />
     </>
   )

--- a/src/app/(root)/(routes)/movie/[id]/sections/movie-cast-section.test.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/movie-cast-section.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { MovieCastSection } from './movie-cast-section'
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} />
+  ),
+}))
+vi.mock('@/components/dm/section-head', () => ({
+  SectionHead: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}))
+
+describe('MovieCastSection', () => {
+  it('shows actor portrait, name, and character', () => {
+    const html = renderToStaticMarkup(
+      <MovieCastSection
+        actors={[
+          {
+            id: 6193,
+            name: '맷 데이먼',
+            character: '오디세우스',
+            profileUrl: 'https://image.tmdb.org/t/p/w342/matt.jpg',
+            sortOrder: 0,
+          },
+        ]}
+      />,
+    )
+
+    expect(html).toContain('주연 배우')
+    expect(html).toContain('맷 데이먼')
+    expect(html).toContain('오디세우스')
+    expect(html).toContain('/matt.jpg')
+  })
+
+  it('does not render an empty section', () => {
+    expect(renderToStaticMarkup(<MovieCastSection actors={[]} />)).toBe('')
+  })
+})

--- a/src/app/(root)/(routes)/movie/[id]/sections/movie-cast-section.tsx
+++ b/src/app/(root)/(routes)/movie/[id]/sections/movie-cast-section.tsx
@@ -1,0 +1,51 @@
+import { MovieActor } from '@/modules/movie/movie.entity'
+import Image from 'next/image'
+import { SectionHead } from '@/components/dm/section-head'
+import React from 'react'
+
+interface MovieCastSectionProps {
+  actors: MovieActor[]
+}
+
+function ActorCard({ actor }: { actor: MovieActor }) {
+  return (
+    <article className="w-[112px] shrink-0 overflow-hidden rounded-lg border border-border bg-card">
+      <div className="relative aspect-[2/3] w-full bg-muted">
+        <Image
+          src={actor.profileUrl}
+          alt={`${actor.name} 배우 프로필`}
+          fill
+          sizes="112px"
+          className="object-cover"
+        />
+      </div>
+      <div className="min-h-[64px] px-2 py-2">
+        <h3 className="truncate text-[13px] font-semibold text-foreground">
+          {actor.name}
+        </h3>
+        {actor.character && (
+          <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-muted-foreground">
+            {actor.character}
+          </p>
+        )}
+      </div>
+    </article>
+  )
+}
+
+export function MovieCastSection({ actors }: MovieCastSectionProps) {
+  if (actors.length === 0) return null
+
+  return (
+    <section className="px-4 pb-5">
+      <SectionHead>주연 배우</SectionHead>
+      <div className="-mx-4 overflow-x-auto overscroll-x-contain px-4 pb-1">
+        <div className="flex w-max gap-3 pr-4">
+          {actors.map((actor) => (
+            <ActorCard key={actor.id} actor={actor} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/(root)/account/account-community-summary.test.ts
+++ b/src/app/(root)/account/account-community-summary.test.ts
@@ -45,12 +45,17 @@ describe('account community summary', () => {
     expect(panel).toContain('더 보기')
   })
 
-  it('uses a responsive profile rail and activity workspace', () => {
+  it('uses the full center pane without a nested desktop rail', () => {
     const page = read('./page.tsx')
+    const profile = read('./sections/profile-section.tsx')
+    const account = read('./sections/account-section.tsx')
 
-    expect(page).toContain('xl:grid-cols-[200px_minmax(0,1fr)]')
-    expect(page).toContain('<aside')
-    expect(page).toContain('<section')
+    expect(page).toContain('min-w-0')
+    expect(page).toContain('w-full')
+    expect(page).not.toContain('xl:grid-cols-[200px_minmax(0,1fr)]')
+    expect(page).not.toContain('<aside')
+    expect(profile).not.toContain('xl:flex-col')
+    expect(account).not.toContain('xl:mt-6 xl:px-0')
   })
 
   it('loads the summary through an authenticated BFF route', () => {

--- a/src/app/(root)/account/page.tsx
+++ b/src/app/(root)/account/page.tsx
@@ -8,16 +8,12 @@ const Page: FunctionComponent = () => {
   return (
     <main className="min-h-page pb-8">
       <UpdateProfileModalContextProvider>
-        <div className="xl:grid xl:grid-cols-[200px_minmax(0,1fr)] xl:gap-6 xl:px-6 xl:py-7">
-          <aside className="xl:col-start-1 xl:row-start-1">
-            <ProfileSection />
-          </aside>
-          <section className="min-w-0 xl:col-start-2 xl:row-span-2 xl:row-start-1">
+        <div className="w-full min-w-0 xl:px-6 xl:py-7">
+          <ProfileSection />
+          <section className="min-w-0 xl:mt-5">
             <CommunitySummarySection />
           </section>
-          <aside className="xl:col-start-1 xl:row-start-2">
-            <AccountSection />
-          </aside>
+          <AccountSection />
         </div>
       </UpdateProfileModalContextProvider>
     </main>

--- a/src/app/(root)/account/sections/account-section.tsx
+++ b/src/app/(root)/account/sections/account-section.tsx
@@ -82,7 +82,7 @@ const AccountSection: FunctionComponent = () => {
   }
 
   return (
-    <section className="border-t border-border px-4 py-5 xl:mt-6 xl:px-0">
+    <section className="grid gap-5 border-t border-border px-4 py-5 xl:grid-cols-2 xl:px-0 xl:pt-6">
       <div>
         <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
           바로가기
@@ -94,7 +94,7 @@ const AccountSection: FunctionComponent = () => {
         </div>
       </div>
 
-      <div className="pt-5">
+      <div>
         <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
           계정 관리
         </p>

--- a/src/app/(root)/account/sections/profile-section.tsx
+++ b/src/app/(root)/account/sections/profile-section.tsx
@@ -13,9 +13,9 @@ const ProfileSection: FunctionComponent = () => {
   const user = data?.user
 
   return (
-    <section className="border-b border-border px-4 py-6 xl:border-0 xl:px-0 xl:py-0">
+    <section className="border-b border-border px-4 py-6 xl:px-0 xl:py-5">
       <UpdateProfileModal />
-      <div className="relative flex items-center gap-4 xl:flex-col xl:items-start">
+      <div className="flex min-w-0 items-center gap-4">
         <DmUserAvatar
           name={user?.nickname}
           image={user?.image}
@@ -35,7 +35,7 @@ const ProfileSection: FunctionComponent = () => {
           onClick={() => setOpen(true)}
           aria-label="프로필 편집"
           title="프로필 편집"
-          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-accent hover:text-foreground xl:absolute xl:right-0 xl:top-0"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-accent hover:text-foreground"
         >
           <Pencil className="h-4 w-4" />
         </button>

--- a/src/modules/movie/movie-cast.test.ts
+++ b/src/modules/movie/movie-cast.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('./movie-datasource', () => ({
+  MovieDatasource: class {},
+}))
+
+import { MovieRepository } from './movie-repository'
+
+describe('movie cast mapping', () => {
+  it('maps actor portraits returned by the detail API', async () => {
+    const datasource = {
+      getMovieDetail: async () => ({
+        movieCd: 20250654,
+        audience: 0,
+        title: '오디세이',
+        createdAt: '2026-08-10',
+        updatedAt: '2026-08-10',
+        poster: '/poster.jpg',
+        rank: 0,
+        isRanked: false,
+        rankInten: '0',
+        plot: '',
+        rankOldAndNew: '',
+        openDt: '2026-01-01',
+        genre: '모험',
+        director: '크리스토퍼 놀란',
+        ratting: '',
+        vods: [],
+        actors: [
+          {
+            id: 6193,
+            name: '맷 데이먼',
+            character: '오디세우스',
+            profileUrl: 'https://image.tmdb.org/t/p/w342/matt.jpg',
+            sortOrder: 0,
+          },
+        ],
+      }),
+    }
+    const repository = new MovieRepository(undefined, datasource as any)
+
+    const movie = await repository.getMovieDetail('20250654')
+
+    expect(movie.actors).toEqual([
+      expect.objectContaining({ name: '맷 데이먼', sortOrder: 0 }),
+    ])
+  })
+})

--- a/src/modules/movie/movie-repository.ts
+++ b/src/modules/movie/movie-repository.ts
@@ -69,6 +69,15 @@ export class MovieRepository {
       commentCount: unknown.commentCount,
       scoreCount: unknown.scoreCount,
       averageScore: unknown.averageScore,
+      actors: Array.isArray(unknown.actors)
+        ? unknown.actors.map((actor: any) => ({
+            id: Number(actor.id),
+            name: String(actor.name ?? ''),
+            character: String(actor.character ?? ''),
+            profileUrl: String(actor.profileUrl ?? ''),
+            sortOrder: Number(actor.sortOrder) || 0,
+          }))
+        : [],
     } as Movie
     assertMovie(result)
     return result

--- a/src/modules/movie/movie.entity.ts
+++ b/src/modules/movie/movie.entity.ts
@@ -18,6 +18,14 @@ export interface Movie {
   commentCount?: number
   scoreCount?: number
   averageScore?: number
+  actors: MovieActor[]
+}
+export type MovieActor = {
+  id: number
+  name: string
+  character: string
+  profileUrl: string
+  sortOrder: number
 }
 export type MovieVod = {
   id: number
@@ -45,6 +53,7 @@ export function isMovie(arg: any): arg is Movie {
     typeof arg.genre === 'string' &&
     typeof arg.director === 'string' &&
     typeof arg.ratting === 'string' &&
+    Array.isArray(arg.actors) &&
     (typeof arg.commentCount === 'number' || arg.commentCount === undefined) &&
     (typeof arg.scoreCount === 'number' || arg.scoreCount === undefined) &&
     (typeof arg.averageScore === 'number' || arg.averageScore === undefined)


### PR DESCRIPTION
## Summary
계정 데스크탑 레이아웃 수정과 영화 상세 주연 배우 카드를 운영 배포합니다.

## 변경
- PR #460 — 영화 상세 배우 얼굴·이름·배역 카드
- PR #461 — 계정 화면 중첩 사이드 레일 제거

## Test plan
- [x] 계정 레이아웃 Vitest 7건
- [x] 배우 변환·UI Vitest 3건
- [x] `pnpm lint`
- [x] 환경변수 주입 후 `pnpm build`
- [ ] master 머지 후 GitHub Actions 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)