### PR TITLE
🚀 Release: 매칭 필터 URL 상태 보존

### DIFF
--- a/src/app/(root)/(routes)/match/components/match-container.tsx
+++ b/src/app/(root)/(routes)/match/components/match-container.tsx
@@ -2,12 +2,16 @@
 
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
 import { useMatchPosts } from '../hooks'
 import type { MatchPostFilter } from '../hooks'
 import { MatchHeaderSection } from '../sections/match-header-section'
 import { MatchListSection } from '../sections/match-list-section'
+import {
+  buildMatchFilterHref,
+  getMatchPostFilter,
+} from '../match-filter-url'
 
 interface MatchContainerProps {
   movieTitle?: string
@@ -17,8 +21,9 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
   const { data: session, status } = useSession()
   const userId = session?.user?.id ? Number(session.user.id) : null
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { toast } = useToast()
-  const [filter, setFilter] = useState<MatchPostFilter>('all')
+  const filter = getMatchPostFilter(searchParams?.get('filter') ?? null)
   const [showApplyDialog, setShowApplyDialog] = useState(false)
   const [selectedMatch, setSelectedMatch] = useState<any>(null)
 
@@ -91,6 +96,11 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
     }
   }
 
+  const handleFilterChange = (nextFilter: MatchPostFilter) => {
+    const params = new URLSearchParams(searchParams?.toString() ?? '')
+    router.push(buildMatchFilterHref(params, nextFilter), { scroll: false })
+  }
+
   return (
     <>
       <MatchHeaderSection movieTitle={movieTitle} />
@@ -101,7 +111,7 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
         hasMore={hasMore}
         loadMore={loadMore}
         filter={filter}
-        onFilterChange={setFilter}
+        onFilterChange={handleFilterChange}
         selectedMatch={selectedMatch}
         showApplyDialog={showApplyDialog}
         onApply={handleApply}

--- a/src/app/(root)/(routes)/match/match-filter-url.test.ts
+++ b/src/app/(root)/(routes)/match/match-filter-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildMatchFilterHref,
+  getMatchPostFilter,
+} from './match-filter-url'
+
+describe('match filter URL', () => {
+  it('restores a supported filter and falls back to all', () => {
+    expect(getMatchPostFilter('week')).toBe('week')
+    expect(getMatchPostFilter('unknown')).toBe('all')
+    expect(getMatchPostFilter(null)).toBe('all')
+  })
+
+  it('keeps the movie title while adding a filter', () => {
+    expect(
+      buildMatchFilterHref(
+        new URLSearchParams('movieTitle=%EA%B5%B0%EC%B2%B4'),
+        'available',
+      ),
+    ).toBe('/match?movieTitle=%EA%B5%B0%EC%B2%B4&filter=available')
+  })
+
+  it('removes the filter query for the default all tab', () => {
+    expect(
+      buildMatchFilterHref(
+        new URLSearchParams('movieTitle=%EA%B5%B0%EC%B2%B4&filter=mine'),
+        'all',
+      ),
+    ).toBe('/match?movieTitle=%EA%B5%B0%EC%B2%B4')
+  })
+})

--- a/src/app/(root)/(routes)/match/match-filter-url.ts
+++ b/src/app/(root)/(routes)/match/match-filter-url.ts
@@ -1,0 +1,27 @@
+import type { MatchPostFilter } from './hooks'
+
+const MATCH_POST_FILTERS: MatchPostFilter[] = [
+  'all',
+  'available',
+  'week',
+  'mine',
+]
+
+export function getMatchPostFilter(value: string | null): MatchPostFilter {
+  return MATCH_POST_FILTERS.includes(value as MatchPostFilter)
+    ? (value as MatchPostFilter)
+    : 'all'
+}
+
+export function buildMatchFilterHref(
+  currentParams: URLSearchParams,
+  filter: MatchPostFilter,
+) {
+  const params = new URLSearchParams(currentParams)
+
+  if (filter === 'all') params.delete('filter')
+  else params.set('filter', filter)
+
+  const query = params.toString()
+  return query ? `/match?${query}` : '/match'
+}


### PR DESCRIPTION
## Summary
매칭 필터 URL 상태 보존 변경을 운영에 배포합니다.

## 변경
- PR #463 — 필터를 URL 쿼리로 관리해 새로고침과 뒤로가기에서 복원

## Test plan
- [x] pnpm exec vitest run (96 tests)
- [x] pnpm lint (errors 0)
- [x] pnpm build
- [ ] master 머지 후 GitHub Actions 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)