### PR TITLE
✨ 빈 매칭 결과 생성 CTA 추가

### DIFF
--- a/src/app/(root)/(routes)/match/components/match-container.tsx
+++ b/src/app/(root)/(routes)/match/components/match-container.tsx
@@ -106,6 +106,7 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
       <MatchHeaderSection movieTitle={movieTitle} />
 
       <MatchListSection
+        movieTitle={movieTitle}
         matchPosts={matchPosts}
         isLoading={isLoadingPosts}
         hasMore={hasMore}

--- a/src/app/(root)/(routes)/match/match-empty-state-ui.test.ts
+++ b/src/app/(root)/(routes)/match/match-empty-state-ui.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    'src/app/(root)/(routes)/match/sections/match-list-section.tsx',
+  ),
+  'utf8',
+)
+
+describe('match empty state UI', () => {
+  it('offers a create action that keeps the selected movie', () => {
+    expect(source).toContain('매치 만들기')
+    expect(source).toContain('buildNewMatchHref(movieTitle)')
+  })
+})

--- a/src/app/(root)/(routes)/match/match-navigation.ts
+++ b/src/app/(root)/(routes)/match/match-navigation.ts
@@ -1,0 +1,5 @@
+export function buildNewMatchHref(movieTitle?: string) {
+  return movieTitle
+    ? `/match/new?movieTitle=${encodeURIComponent(movieTitle)}`
+    : '/match/new'
+}

--- a/src/app/(root)/(routes)/match/sections/match-header-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-header-section.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from 'react'
 import Link from 'next/link'
+import { buildNewMatchHref } from '../match-navigation'
 
 interface MatchHeaderSectionProps {
   movieTitle?: string
@@ -8,17 +9,13 @@ interface MatchHeaderSectionProps {
 const MatchHeaderSection: FunctionComponent<MatchHeaderSectionProps> = ({
   movieTitle,
 }) => {
-  const newMatchHref = movieTitle
-    ? `/match/new?movieTitle=${encodeURIComponent(movieTitle)}`
-    : '/match/new'
-
   return (
     <div className="flex items-center border-b border-border px-4 py-3.5">
       <h1 className="text-[18px] font-bold tracking-tight text-foreground">
         {movieTitle ? `${movieTitle} 같이 볼 사람` : '같이 볼 사람'}
       </h1>
       <Link
-        href={newMatchHref}
+        href={buildNewMatchHref(movieTitle)}
         className="ml-auto inline-flex h-8 items-center rounded-md bg-primary px-3 text-[13px] font-medium text-primary-foreground"
       >
         ＋ 만들기

--- a/src/app/(root)/(routes)/match/sections/match-list-section.tsx
+++ b/src/app/(root)/(routes)/match/sections/match-list-section.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import { FunctionComponent, useEffect, useRef, useCallback } from 'react'
+import Link from 'next/link'
 import { DmMatchTicket } from '@/components/dm'
 import { MatchApplyDialog } from '@/components/app/match-apply-dialog'
 import { cn, getMatchScheduleStatus } from '@/lib/utils'
 import type { MatchPostFilter } from '../hooks'
+import { buildNewMatchHref } from '../match-navigation'
 
 interface MatchListSectionProps {
+  movieTitle?: string
   matchPosts: any[]
   isLoading: boolean
   hasMore: boolean
@@ -28,6 +31,7 @@ const FILTERS: { key: MatchPostFilter; label: string }[] = [
 ]
 
 const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
+  movieTitle,
   matchPosts,
   isLoading,
   hasMore,
@@ -112,6 +116,12 @@ const MatchListSection: FunctionComponent<MatchListSectionProps> = ({
         <div className="py-12 text-center text-muted-foreground">
           <p className="text-[14px]">{emptyTitle}</p>
           <p className="mt-1 text-[12px]">{emptySub}</p>
+          <Link
+            href={buildNewMatchHref(movieTitle)}
+            className="mt-5 inline-flex h-10 items-center rounded-md bg-primary px-5 text-[13px] font-medium text-primary-foreground"
+          >
+            매치 만들기
+          </Link>
         </div>
       ) : (
         <div className="flex flex-col gap-3 px-4 py-2">


### PR DESCRIPTION
## Summary
매칭 결과가 없을 때 같은 화면에서 바로 새 매치를 만들 수 있는 CTA를 제공합니다.

## 원인
빈 상태가 안내 문구만 보여 사용자가 상단까지 시선을 옮겨 만들기 버튼을 찾아야 했습니다.

## 변경
- 모든 빈 필터 상태에 매치 만들기 버튼 추가
- 영화별 매칭 화면에서는 선택 영화 제목을 생성 화면에 전달
- 상단/빈 상태 링크가 공용 URL 생성 함수를 사용
- 빈 상태 UI 계약 테스트 추가

## Test plan
- [x] pnpm exec vitest run (97 tests)
- [x] pnpm lint (errors 0)
- [x] pnpm build
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)