### PR TITLE
🚀 Release: 매칭 페이지네이션 URL 복원

### DIFF
--- a/src/app/(root)/(routes)/match/components/match-container.tsx
+++ b/src/app/(root)/(routes)/match/components/match-container.tsx
@@ -10,6 +10,8 @@ import { MatchHeaderSection } from '../sections/match-header-section'
 import { MatchListSection } from '../sections/match-list-section'
 import {
   buildMatchFilterHref,
+  buildMatchPageHref,
+  getMatchPage,
   getMatchPostFilter,
 } from '../match-filter-url'
 
@@ -24,6 +26,7 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
   const searchParams = useSearchParams()
   const { toast } = useToast()
   const filter = getMatchPostFilter(searchParams?.get('filter') ?? null)
+  const page = getMatchPage(searchParams?.get('page') ?? null)
   const [showApplyDialog, setShowApplyDialog] = useState(false)
   const [selectedMatch, setSelectedMatch] = useState<any>(null)
 
@@ -33,7 +36,7 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
     hasMore,
     loadMore,
     isLoading: isLoadingPosts,
-  } = useMatchPosts(10, { movieTitle, filter, userno: userId })
+  } = useMatchPosts(10, { movieTitle, filter, userno: userId }, page)
   // 매치 신청 함수
   const handleApplyToMatch = async (matchId: string, message: string) => {
     try {
@@ -101,6 +104,12 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
     router.push(buildMatchFilterHref(params, nextFilter), { scroll: false })
   }
 
+  const handleLoadMore = () => {
+    loadMore()
+    const params = new URLSearchParams(searchParams?.toString() ?? '')
+    router.replace(buildMatchPageHref(params, page + 1), { scroll: false })
+  }
+
   return (
     <>
       <MatchHeaderSection movieTitle={movieTitle} />
@@ -110,7 +119,7 @@ export const MatchContainer = ({ movieTitle }: MatchContainerProps) => {
         matchPosts={matchPosts}
         isLoading={isLoadingPosts}
         hasMore={hasMore}
-        loadMore={loadMore}
+        loadMore={handleLoadMore}
         filter={filter}
         onFilterChange={handleFilterChange}
         selectedMatch={selectedMatch}

--- a/src/app/(root)/(routes)/match/hooks/use-match-posts.ts
+++ b/src/app/(root)/(routes)/match/hooks/use-match-posts.ts
@@ -45,9 +45,11 @@ const getKey =
 export const useMatchPosts = (
   pageSize: number = 10,
   query: MatchPostQuery = {},
+  initialPage: number = 1,
 ) => {
   const { data, setSize, mutate, error, isLoading, isValidating } =
     useSWRInfinite<MatchPostResponse>(getKey(pageSize, query), fetcher, {
+      initialSize: initialPage,
       refreshInterval: 30000, // 30초마다 새로고침
       revalidateOnFocus: true,
     })

--- a/src/app/(root)/(routes)/match/match-filter-url.test.ts
+++ b/src/app/(root)/(routes)/match/match-filter-url.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildMatchFilterHref,
+  buildMatchPageHref,
+  getMatchPage,
   getMatchPostFilter,
 } from './match-filter-url'
 
@@ -27,5 +29,31 @@ describe('match filter URL', () => {
         'all',
       ),
     ).toBe('/match?movieTitle=%EA%B5%B0%EC%B2%B4')
+  })
+
+  it('restores a bounded page number and falls back to the first page', () => {
+    expect(getMatchPage('3')).toBe(3)
+    expect(getMatchPage('50')).toBe(10)
+    expect(getMatchPage('invalid')).toBe(1)
+    expect(getMatchPage('3abc')).toBe(1)
+    expect(getMatchPage('2.5')).toBe(1)
+  })
+
+  it('records later pages while keeping the current filters', () => {
+    expect(
+      buildMatchPageHref(
+        new URLSearchParams('movieTitle=%EA%B5%B0%EC%B2%B4&filter=week'),
+        3,
+      ),
+    ).toBe('/match?movieTitle=%EA%B5%B0%EC%B2%B4&filter=week&page=3')
+  })
+
+  it('resets pagination when changing filters', () => {
+    expect(
+      buildMatchFilterHref(
+        new URLSearchParams('filter=week&page=4'),
+        'available',
+      ),
+    ).toBe('/match?filter=available')
   })
 })

--- a/src/app/(root)/(routes)/match/match-filter-url.ts
+++ b/src/app/(root)/(routes)/match/match-filter-url.ts
@@ -6,6 +6,7 @@ const MATCH_POST_FILTERS: MatchPostFilter[] = [
   'week',
   'mine',
 ]
+const MAX_RESTORED_PAGE = 10
 
 export function getMatchPostFilter(value: string | null): MatchPostFilter {
   return MATCH_POST_FILTERS.includes(value as MatchPostFilter)
@@ -18,9 +19,28 @@ export function buildMatchFilterHref(
   filter: MatchPostFilter,
 ) {
   const params = new URLSearchParams(currentParams)
+  params.delete('page')
 
   if (filter === 'all') params.delete('filter')
   else params.set('filter', filter)
+
+  const query = params.toString()
+  return query ? `/match?${query}` : '/match'
+}
+
+export function getMatchPage(value: string | null) {
+  const page = Number(value)
+  if (!Number.isInteger(page) || page < 1) return 1
+  return Math.min(page, MAX_RESTORED_PAGE)
+}
+
+export function buildMatchPageHref(
+  currentParams: URLSearchParams,
+  page: number,
+) {
+  const params = new URLSearchParams(currentParams)
+  if (page <= 1) params.delete('page')
+  else params.set('page', String(Math.min(page, MAX_RESTORED_PAGE)))
 
   const query = params.toString()
   return query ? `/match?${query}` : '/match'

--- a/src/app/(root)/(routes)/match/match-pagination-ui.test.ts
+++ b/src/app/(root)/(routes)/match/match-pagination-ui.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const hookSource = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    'src/app/(root)/(routes)/match/hooks/use-match-posts.ts',
+  ),
+  'utf8',
+)
+const containerSource = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    'src/app/(root)/(routes)/match/components/match-container.tsx',
+  ),
+  'utf8',
+)
+
+describe('match pagination URL contract', () => {
+  it('restores loaded pages and records load-more progress', () => {
+    expect(hookSource).toContain('initialSize: initialPage')
+    expect(containerSource).toContain('buildMatchPageHref')
+  })
+})


### PR DESCRIPTION
## Summary
매칭 페이지네이션 URL 복원 변경을 운영에 배포합니다.

## 변경
- PR #467 — 무한 스크롤 페이지 기록·복원과 필터 전환 초기화

## Test plan
- [x] pnpm exec vitest run (101 tests)
- [x] pnpm lint (errors 0)
- [x] pnpm build
- [ ] master 머지 후 GitHub Actions 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)